### PR TITLE
feat(formatters): add Factory AI droids support

### DIFF
--- a/.claude/skills/promptscript/SKILL.md
+++ b/.claude/skills/promptscript/SKILL.md
@@ -215,7 +215,8 @@ userInvocable, allowedTools, context ("fork" or "inherit"), agent.
 
 ### @agents
 
-Custom subagent definitions:
+Custom subagent definitions. Compiles to `.claude/agents/` for Claude Code,
+`.github/agents/` for GitHub Copilot, `.factory/droids/` for Factory AI, etc.
 
 ```
 @agents {
@@ -228,6 +229,10 @@ Custom subagent definitions:
   }
 }
 ```
+
+Factory AI droids support additional properties: `model` (any model ID or "inherit"),
+`reasoningEffort` ("low", "medium", "high"), and `tools` (category name like "read-only"
+or array of tool IDs).
 
 ### @knowledge
 
@@ -331,21 +336,21 @@ prs diff --target claude    # Show compilation diff
 
 38 supported targets. Key examples:
 
-| Target      | Main File                       | Skills                         |
-| ----------- | ------------------------------- | ------------------------------ |
-| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md     |
-| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md     |
-| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md         |
-| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md             |
-| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md    |
-| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md   |
-| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md     |
-| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md   |
-| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md     |
-| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md        |
-| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md     |
-| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md   |
-| + 26 more   |                                 | See full list in documentation |
+| Target      | Main File                       | Skills                                             |
+| ----------- | ------------------------------- | -------------------------------------------------- |
+| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md                         |
+| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md                         |
+| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md                             |
+| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md                                 |
+| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md, .factory/droids/\*.md |
+| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md                       |
+| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md                         |
+| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md                       |
+| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md                         |
+| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md                            |
+| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
+| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md                       |
+| + 26 more   |                                 | See full list in documentation                     |
 
 ## Project Organization
 

--- a/.promptscript/skills/promptscript/SKILL.md
+++ b/.promptscript/skills/promptscript/SKILL.md
@@ -215,7 +215,8 @@ userInvocable, allowedTools, context ("fork" or "inherit"), agent.
 
 ### @agents
 
-Custom subagent definitions:
+Custom subagent definitions. Compiles to `.claude/agents/` for Claude Code,
+`.github/agents/` for GitHub Copilot, `.factory/droids/` for Factory AI, etc.
 
 ```
 @agents {
@@ -228,6 +229,10 @@ Custom subagent definitions:
   }
 }
 ```
+
+Factory AI droids support additional properties: `model` (any model ID or "inherit"),
+`reasoningEffort` ("low", "medium", "high"), and `tools` (category name like "read-only"
+or array of tool IDs).
 
 ### @knowledge
 
@@ -331,21 +336,21 @@ prs diff --target claude    # Show compilation diff
 
 38 supported targets. Key examples:
 
-| Target      | Main File                       | Skills                         |
-| ----------- | ------------------------------- | ------------------------------ |
-| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md     |
-| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md     |
-| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md         |
-| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md             |
-| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md    |
-| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md   |
-| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md     |
-| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md   |
-| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md     |
-| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md        |
-| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md     |
-| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md   |
-| + 26 more   |                                 | See full list in documentation |
+| Target      | Main File                       | Skills                                             |
+| ----------- | ------------------------------- | -------------------------------------------------- |
+| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md                         |
+| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md                         |
+| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md                             |
+| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md                                 |
+| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md, .factory/droids/\*.md |
+| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md                       |
+| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md                         |
+| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md                       |
+| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md                         |
+| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md                            |
+| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
+| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md                       |
+| + 26 more   |                                 | See full list in documentation                     |
 
 ## Project Organization
 

--- a/packages/cli/skills/promptscript/SKILL.md
+++ b/packages/cli/skills/promptscript/SKILL.md
@@ -215,7 +215,8 @@ userInvocable, allowedTools, context ("fork" or "inherit"), agent.
 
 ### @agents
 
-Custom subagent definitions:
+Custom subagent definitions. Compiles to `.claude/agents/` for Claude Code,
+`.github/agents/` for GitHub Copilot, `.factory/droids/` for Factory AI, etc.
 
 ```
 @agents {
@@ -228,6 +229,10 @@ Custom subagent definitions:
   }
 }
 ```
+
+Factory AI droids support additional properties: `model` (any model ID or "inherit"),
+`reasoningEffort` ("low", "medium", "high"), and `tools` (category name like "read-only"
+or array of tool IDs).
 
 ### @knowledge
 
@@ -331,21 +336,21 @@ prs diff --target claude    # Show compilation diff
 
 38 supported targets. Key examples:
 
-| Target      | Main File                       | Skills                         |
-| ----------- | ------------------------------- | ------------------------------ |
-| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md     |
-| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md     |
-| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md         |
-| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md             |
-| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md    |
-| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md   |
-| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md     |
-| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md   |
-| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md     |
-| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md        |
-| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md     |
-| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md   |
-| + 26 more   |                                 | See full list in documentation |
+| Target      | Main File                       | Skills                                             |
+| ----------- | ------------------------------- | -------------------------------------------------- |
+| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md                         |
+| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md                         |
+| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md                             |
+| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md                                 |
+| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md, .factory/droids/\*.md |
+| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md                       |
+| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md                         |
+| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md                       |
+| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md                         |
+| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md                            |
+| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
+| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md                       |
+| + 26 more   |                                 | See full list in documentation                     |
 
 ## Project Organization
 

--- a/packages/formatters/src/__tests__/factory.spec.ts
+++ b/packages/formatters/src/__tests__/factory.spec.ts
@@ -48,6 +48,7 @@ describe('FactoryFormatter', () => {
       expect(versions.simple.description).toBe('Single AGENTS.md file');
       expect(versions.multifile.name).toBe('multifile');
       expect(versions.full.name).toBe('full');
+      expect(versions.full.description).toContain('droids');
     });
   });
 
@@ -1111,6 +1112,372 @@ describe('FactoryFormatter', () => {
       const result = formatter.format(ast);
       expect(result.content).toContain('No any type');
       expect(result.content).toContain('No default exports');
+    });
+  });
+
+  describe('droid file generation', () => {
+    it('should generate droid files from @agents block in full mode', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                'code-reviewer': {
+                  description: 'Focused reviewer for diffs',
+                  model: 'inherit',
+                  tools: 'read-only',
+                  content: 'You are the team senior reviewer.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+
+      expect(result.additionalFiles).toBeDefined();
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid).toBeDefined();
+      expect(droid?.path).toBe('.factory/droids/code-reviewer.md');
+      expect(droid?.content).toContain('name: code-reviewer');
+      expect(droid?.content).toContain('description: Focused reviewer for diffs');
+      expect(droid?.content).toContain('model: inherit');
+      expect(droid?.content).toContain('tools: read-only');
+      expect(droid?.content).toContain('You are the team senior reviewer.');
+    });
+
+    it('should generate droid with all supported fields', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                'deep-analyzer': {
+                  description: 'Thorough analysis with extended thinking',
+                  model: 'claude-sonnet-4-5-20250929',
+                  reasoningEffort: 'high',
+                  tools: ['Read', 'Grep', 'Glob', 'WebSearch'],
+                  content: 'Perform deep analysis of the code.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid).toBeDefined();
+      expect(droid?.path).toBe('.factory/droids/deep-analyzer.md');
+      expect(droid?.content).toContain('name: deep-analyzer');
+      expect(droid?.content).toContain('description: Thorough analysis with extended thinking');
+      expect(droid?.content).toContain('model: claude-sonnet-4-5-20250929');
+      expect(droid?.content).toContain('reasoningEffort: high');
+      expect(droid?.content).toContain('tools: ["Read", "Grep", "Glob", "WebSearch"]');
+      expect(droid?.content).toContain('Perform deep analysis of the code.');
+    });
+
+    it('should generate multiple droid files', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                reviewer: {
+                  description: 'Reviews code',
+                  content: 'Review the code.',
+                },
+                debugger: {
+                  description: 'Debugs issues',
+                  content: 'Debug the issue.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+
+      const droids = result.additionalFiles?.filter((f) => f.path.includes('droids/'));
+      expect(droids).toHaveLength(2);
+      expect(droids?.find((f) => f.path === '.factory/droids/reviewer.md')).toBeDefined();
+      expect(droids?.find((f) => f.path === '.factory/droids/debugger.md')).toBeDefined();
+    });
+
+    it('should not generate droid files in simple mode', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                reviewer: {
+                  description: 'Reviews code',
+                  content: 'Review the code.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast);
+      const droids = result.additionalFiles?.filter((f) => f.path.includes('droids/'));
+      expect(droids ?? []).toHaveLength(0);
+    });
+
+    it('should not generate droid files in multifile mode', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                reviewer: {
+                  description: 'Reviews code',
+                  content: 'Review the code.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'multifile' });
+      const droids = result.additionalFiles?.filter((f) => f.path.includes('droids/'));
+      expect(droids ?? []).toHaveLength(0);
+    });
+
+    it('should skip agents without description', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                'no-desc': {
+                  content: 'Some content.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const droids = result.additionalFiles?.filter((f) => f.path.includes('droids/'));
+      expect(droids ?? []).toHaveLength(0);
+    });
+
+    it('should convert dots to hyphens in droid names', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                'speckit.review': {
+                  description: 'Reviews specs',
+                  content: 'Review the spec.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid?.path).toBe('.factory/droids/speckit-review.md');
+      expect(droid?.content).toContain('name: speckit-review');
+    });
+
+    it('should generate minimal droid with only name and description', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                helper: {
+                  description: 'A simple helper',
+                  content: 'Help with tasks.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid?.content).toContain('name: helper');
+      expect(droid?.content).toContain('description: A simple helper');
+      expect(droid?.content).not.toContain('model:');
+      expect(droid?.content).not.toContain('reasoningEffort:');
+      expect(droid?.content).not.toContain('tools:');
+    });
+
+    it('should generate droid without content', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                empty: {
+                  description: 'Empty droid',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid).toBeDefined();
+      expect(droid?.content).toContain('name: empty');
+      expect(droid?.content).toContain('description: Empty droid');
+      // Should end with frontmatter close + newline, no body content
+      expect(droid?.content).toMatch(/---\n\n$/);
+    });
+
+    it('should handle empty tools array', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                tester: {
+                  description: 'Tester droid',
+                  tools: [],
+                  content: 'Test things.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid).toBeDefined();
+      expect(droid?.content).not.toContain('tools:');
+    });
+
+    it('should handle non-array non-string tools value', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                tester: {
+                  description: 'Tester droid',
+                  tools: true,
+                  content: 'Test things.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid).toBeDefined();
+      expect(droid?.content).toContain('tools: true');
+    });
+
+    it('should ignore invalid reasoningEffort values', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'agents',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                tester: {
+                  description: 'Tester droid',
+                  reasoningEffort: 'ultra',
+                  content: 'Test things.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const droid = result.additionalFiles?.find((f) => f.path.includes('droids/'));
+      expect(droid?.content).not.toContain('reasoningEffort:');
     });
   });
 

--- a/packages/formatters/src/feature-matrix.ts
+++ b/packages/formatters/src/feature-matrix.ts
@@ -517,11 +517,12 @@ export const FEATURE_MATRIX: FeatureSpec[] = [
       cursor: 'not-supported',
       claude: 'supported', // .claude/agents/<name>.md
       antigravity: 'not-supported',
-      factory: 'not-supported',
+      factory: 'supported', // .factory/droids/<name>.md
       opencode: 'supported', // .opencode/agents/<name>.md
       gemini: 'not-supported',
     },
-    testStrategy: 'Check for AGENTS.md, .github/agents/ or .claude/agents/ files',
+    testStrategy:
+      'Check for AGENTS.md, .github/agents/, .claude/agents/, or .factory/droids/ files',
   },
   {
     id: 'local-memory',

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -1,6 +1,7 @@
 import type { Program, Value } from '@promptscript/core';
 import {
   MarkdownInstructionFormatter,
+  type MarkdownAgentConfig,
   type MarkdownCommandConfig,
   type MarkdownSkillConfig,
 } from '../markdown-instruction-formatter.js';
@@ -27,7 +28,7 @@ export const FACTORY_VERSIONS = {
   },
   full: {
     name: 'full',
-    description: 'Multifile + additional skill supporting files',
+    description: 'Multifile + droids + additional supporting files',
     outputPath: 'AGENTS.md',
   },
 } as const;
@@ -71,6 +72,23 @@ interface FactorySkillConfig extends MarkdownSkillConfig {
 }
 
 /**
+ * Valid reasoning effort levels for Factory AI droids.
+ */
+type FactoryReasoningEffort = 'low' | 'medium' | 'high';
+
+/**
+ * Configuration for a Factory AI droid (subagent).
+ */
+interface FactoryDroidConfig extends MarkdownAgentConfig {
+  /** Model to use (e.g., 'inherit', 'claude-sonnet-4-5-20250929') */
+  model?: string;
+  /** Reasoning effort level */
+  reasoningEffort?: FactoryReasoningEffort;
+  /** Tool access: category name or array of tool IDs */
+  tools?: string | string[];
+}
+
+/**
  * Formatter for Factory AI instructions.
  *
  * Factory AI uses AGENTS.md as its main configuration file and
@@ -103,7 +121,7 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
       mainFileHeader: '# AGENTS.md',
       dotDir: '.factory',
       skillFileName: 'SKILL.md',
-      hasAgents: false,
+      hasAgents: true,
       hasCommands: true,
       hasSkills: true,
       skillsInMultifile: true,
@@ -282,6 +300,99 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
       content: lines.join('\n') + '\n',
       additionalFiles: resourceFiles.length > 0 ? resourceFiles : undefined,
     };
+  }
+
+  // ============================================================
+  // Droid File Generation (Factory-specific)
+  // ============================================================
+
+  protected override extractAgents(ast: Program): FactoryDroidConfig[] {
+    const agentsBlock = this.findBlock(ast, 'agents');
+    if (!agentsBlock) return [];
+
+    const droids: FactoryDroidConfig[] = [];
+    const props = this.getProps(agentsBlock.content);
+
+    for (const [name, value] of Object.entries(props)) {
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        const obj = value as Record<string, Value>;
+        const description = obj['description'] ? this.valueToString(obj['description']) : '';
+        if (!description) continue; // description is required
+
+        droids.push({
+          name: name.replace(/\./g, '-'),
+          description,
+          content: obj['content'] ? this.valueToString(obj['content']) : '',
+          model: obj['model'] ? this.valueToString(obj['model']) : undefined,
+          reasoningEffort: this.parseReasoningEffort(obj['reasoningEffort']),
+          tools: this.parseDroidTools(obj['tools']),
+        });
+      }
+    }
+
+    return droids;
+  }
+
+  protected override generateAgentFile(config: MarkdownAgentConfig): FormatterOutput {
+    const droidConfig = config as FactoryDroidConfig;
+    const lines: string[] = [];
+
+    // YAML frontmatter
+    lines.push('---');
+    lines.push(`name: ${droidConfig.name}`);
+
+    if (droidConfig.description) {
+      lines.push(`description: ${this.yamlString(droidConfig.description)}`);
+    }
+
+    if (droidConfig.model) {
+      lines.push(`model: ${droidConfig.model}`);
+    }
+
+    if (droidConfig.reasoningEffort) {
+      lines.push(`reasoningEffort: ${droidConfig.reasoningEffort}`);
+    }
+
+    if (droidConfig.tools) {
+      if (typeof droidConfig.tools === 'string') {
+        lines.push(`tools: ${droidConfig.tools}`);
+      } else if (Array.isArray(droidConfig.tools) && droidConfig.tools.length > 0) {
+        const toolsArray = droidConfig.tools.map((t) => `"${t}"`).join(', ');
+        lines.push(`tools: [${toolsArray}]`);
+      }
+    }
+
+    lines.push('---');
+    lines.push('');
+
+    if (droidConfig.content) {
+      const dedentedContent = this.dedent(droidConfig.content);
+      lines.push(dedentedContent);
+    }
+
+    return {
+      path: `.factory/droids/${droidConfig.name}.md`,
+      content: lines.join('\n') + '\n',
+    };
+  }
+
+  private parseReasoningEffort(value: Value | undefined): FactoryReasoningEffort | undefined {
+    if (!value) return undefined;
+    const str = this.valueToString(value);
+    const valid: FactoryReasoningEffort[] = ['low', 'medium', 'high'];
+    return valid.includes(str as FactoryReasoningEffort)
+      ? (str as FactoryReasoningEffort)
+      : undefined;
+  }
+
+  private parseDroidTools(value: Value | undefined): string | string[] | undefined {
+    if (!value) return undefined;
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) {
+      const arr = value.map((v) => this.valueToString(v)).filter((s) => s.length > 0);
+      return arr.length > 0 ? arr : undefined;
+    }
+    return this.valueToString(value);
   }
 
   // ============================================================

--- a/packages/playground/src/store.ts
+++ b/packages/playground/src/store.ts
@@ -441,7 +441,7 @@ export const selectOutputsForFormatter = (
     ],
     cursor: [/\.cursor\/rules\/.*\.mdc$/, /\.cursorrules$/],
     antigravity: [/\.agent\/rules\/.*\.md$/, /\.agent\/workflows\/.*\.md$/],
-    factory: [/^AGENTS\.md$/, /\.factory\/skills\/.*\/SKILL\.md$/],
+    factory: [/^AGENTS\.md$/, /\.factory\/skills\/.*\/SKILL\.md$/, /\.factory\/droids\/.*\.md$/],
     opencode: [
       /^OPENCODE\.md$/,
       /\.opencode\/commands\/.*\.md$/,

--- a/skills/promptscript/SKILL.md
+++ b/skills/promptscript/SKILL.md
@@ -215,7 +215,8 @@ userInvocable, allowedTools, context ("fork" or "inherit"), agent.
 
 ### @agents
 
-Custom subagent definitions:
+Custom subagent definitions. Compiles to `.claude/agents/` for Claude Code,
+`.github/agents/` for GitHub Copilot, `.factory/droids/` for Factory AI, etc.
 
 ```
 @agents {
@@ -228,6 +229,10 @@ Custom subagent definitions:
   }
 }
 ```
+
+Factory AI droids support additional properties: `model` (any model ID or "inherit"),
+`reasoningEffort` ("low", "medium", "high"), and `tools` (category name like "read-only"
+or array of tool IDs).
 
 ### @knowledge
 
@@ -331,21 +336,21 @@ prs diff --target claude    # Show compilation diff
 
 38 supported targets. Key examples:
 
-| Target      | Main File                       | Skills                         |
-| ----------- | ------------------------------- | ------------------------------ |
-| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md     |
-| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md     |
-| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md         |
-| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md             |
-| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md    |
-| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md   |
-| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md     |
-| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md   |
-| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md     |
-| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md        |
-| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md     |
-| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md   |
-| + 26 more   |                                 | See full list in documentation |
+| Target      | Main File                       | Skills                                             |
+| ----------- | ------------------------------- | -------------------------------------------------- |
+| GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md                         |
+| Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md                         |
+| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md                             |
+| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md                                 |
+| Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md, .factory/droids/\*.md |
+| OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md                       |
+| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md                         |
+| Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md                       |
+| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md                         |
+| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md                            |
+| Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
+| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md                       |
+| + 26 more   |                                 | See full list in documentation                     |
 
 ## Project Organization
 


### PR DESCRIPTION
## Summary

- Add support for Factory AI custom droids (subagents) generated from `@agents` blocks
- Droids output to `.factory/droids/<name>.md` with YAML frontmatter (`name`, `description`, `model`, `reasoningEffort`, `tools`)
- Supports both tool category strings (e.g. `"read-only"`) and tool ID arrays (e.g. `["Read", "Grep"]`)
- Available in `full` version mode only, matching Factory AI's `.factory/droids/` convention
- Updated feature matrix, playground patterns, and PromptScript SKILL.md documentation

## Test plan

- [x] 12 new tests covering all droid code paths (generation, fields, modes, edge cases)
- [x] 100% line and function coverage on new code
- [x] All 996 formatter tests pass
- [x] Full verification pipeline passes (format, lint, typecheck, test, validate, schema:check, skill:check)
- [x] Pre-commit hooks pass