### PR TITLE
refactor(formatters): enforce getSupportedVersions() via FormatterClass interface

### DIFF
--- a/packages/formatters/src/__tests__/registry.spec.ts
+++ b/packages/formatters/src/__tests__/registry.spec.ts
@@ -1,11 +1,25 @@
+import type { Program } from '@promptscript/core';
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { FormatterRegistry } from '../registry.js';
-import type { Formatter, FormatterOutput } from '../types.js';
+import { BaseFormatter } from '../base-formatter.js';
+import type { Formatter, FormatterOutput, FormatterVersionMap, FormatOptions } from '../types.js';
 
 // Import the main module to trigger auto-registration of built-in formatters
 import '../index.js';
 
-// Mock formatter for testing
+// ============================================================
+// Test Helpers
+// ============================================================
+
+const MOCK_VERSIONS = {
+  simple: {
+    name: 'simple',
+    description: 'Single file',
+    outputPath: 'mock.txt',
+  },
+} as const;
+
+// Mock formatter for testing (legacy factory pattern)
 class MockFormatter implements Formatter {
   readonly name = 'mock';
   readonly outputPath = 'mock.txt';
@@ -25,6 +39,54 @@ class MockFormatter implements Formatter {
   }
 }
 
+// Valid formatter class with static getSupportedVersions()
+class ValidClassFormatter extends BaseFormatter {
+  readonly name = 'valid-class';
+  readonly outputPath = 'VALID.md';
+  readonly description = 'A valid class-based formatter';
+  readonly defaultConvention = 'markdown';
+
+  format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+    return { path: this.outputPath, content: '' };
+  }
+
+  static getSupportedVersions(): typeof MOCK_VERSIONS {
+    return MOCK_VERSIONS;
+  }
+}
+
+const MULTI_VERSIONS = {
+  simple: {
+    name: 'simple',
+    description: 'Simple mode',
+    outputPath: 'MULTI.md',
+  },
+  full: {
+    name: 'full',
+    description: 'Full mode with extras',
+    outputPath: 'MULTI.md',
+  },
+} as const;
+
+class MultiVersionFormatter extends BaseFormatter {
+  readonly name = 'multi-version';
+  readonly outputPath = 'MULTI.md';
+  readonly description = 'Multi-version formatter';
+  readonly defaultConvention = 'markdown';
+
+  format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+    return { path: this.outputPath, content: '' };
+  }
+
+  static getSupportedVersions(): typeof MULTI_VERSIONS {
+    return MULTI_VERSIONS;
+  }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
 describe('FormatterRegistry', () => {
   // Store original state
   let originalFormatters: string[];
@@ -43,14 +105,283 @@ describe('FormatterRegistry', () => {
     }
   });
 
-  describe('register', () => {
-    it('should register a new formatter', () => {
-      FormatterRegistry.register('test-formatter', () => new MockFormatter());
-      expect(FormatterRegistry.has('test-formatter')).toBe(true);
+  describe('register (class-based)', () => {
+    it('should register a valid formatter class', () => {
+      // Arrange & Act
+      FormatterRegistry.register('class-test', ValidClassFormatter);
+
+      // Assert
+      expect(FormatterRegistry.has('class-test')).toBe(true);
+    });
+
+    it('should create instances from registered formatter class', () => {
+      // Arrange
+      FormatterRegistry.register('class-instance', ValidClassFormatter);
+
+      // Act
+      const formatter = FormatterRegistry.get('class-instance');
+
+      // Assert
+      expect(formatter).toBeDefined();
+      expect(formatter?.name).toBe('valid-class');
+      expect(formatter?.outputPath).toBe('VALID.md');
+    });
+
+    it('should register a formatter with multiple versions', () => {
+      // Arrange & Act
+      FormatterRegistry.register('multi-ver', MultiVersionFormatter);
+
+      // Assert
+      const formatter = FormatterRegistry.get('multi-ver');
+      expect(formatter).toBeDefined();
+      expect(formatter?.name).toBe('multi-version');
     });
 
     it('should throw when registering duplicate name', () => {
+      // Arrange
+      FormatterRegistry.register('dup-class', ValidClassFormatter);
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('dup-class', ValidClassFormatter)).toThrow(
+        "Formatter 'dup-class' is already registered"
+      );
+    });
+  });
+
+  describe('register (enforcement)', () => {
+    it('should reject a class missing getSupportedVersions', () => {
+      // Arrange
+      class MissingVersions extends BaseFormatter {
+        readonly name = 'missing';
+        readonly outputPath = 'MISSING.md';
+        readonly description = 'Missing versions';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+      }
+
+      // Force TypeScript to accept this to test runtime validation
+      const BadClass = MissingVersions as unknown as {
+        new (): InstanceType<typeof MissingVersions>;
+        getSupportedVersions(): FormatterVersionMap;
+      };
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('missing', BadClass)).toThrow(
+        /must implement a static getSupportedVersions\(\) method/
+      );
+    });
+
+    it('should reject a class where getSupportedVersions returns null', () => {
+      // Arrange
+      class NullVersions extends BaseFormatter {
+        readonly name = 'null-versions';
+        readonly outputPath = 'NULL.md';
+        readonly description = 'Null versions';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return null as unknown as FormatterVersionMap;
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('null-versions', NullVersions)).toThrow(
+        /must return a non-null version map/
+      );
+    });
+
+    it('should reject a class where getSupportedVersions returns a non-object', () => {
+      // Arrange
+      class StringVersions extends BaseFormatter {
+        readonly name = 'string-versions';
+        readonly outputPath = 'STRING.md';
+        readonly description = 'String versions';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return 'not-an-object' as unknown as FormatterVersionMap;
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('string-versions', StringVersions)).toThrow(
+        /must return a non-null version map/
+      );
+    });
+
+    it('should reject a class where getSupportedVersions returns empty object', () => {
+      // Arrange
+      class EmptyVersions extends BaseFormatter {
+        readonly name = 'empty';
+        readonly outputPath = 'EMPTY.md';
+        readonly description = 'Empty versions';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return {};
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('empty', EmptyVersions)).toThrow(
+        /returned an empty version map/
+      );
+    });
+
+    it('should reject a version entry missing name field', () => {
+      // Arrange
+      class BadName extends BaseFormatter {
+        readonly name = 'bad-name';
+        readonly outputPath = 'BAD.md';
+        readonly description = 'Bad name';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return {
+            simple: { description: 'Missing name', outputPath: 'BAD.md' },
+          } as unknown as FormatterVersionMap;
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('bad-name', BadName)).toThrow(
+        /version 'simple' is missing required 'name' field/
+      );
+    });
+
+    it('should reject a version entry missing description field', () => {
+      // Arrange
+      class BadDesc extends BaseFormatter {
+        readonly name = 'bad-desc';
+        readonly outputPath = 'BAD.md';
+        readonly description = 'Bad desc';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return {
+            simple: { name: 'simple', outputPath: 'BAD.md' },
+          } as unknown as FormatterVersionMap;
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('bad-desc', BadDesc)).toThrow(
+        /version 'simple' is missing required 'description' field/
+      );
+    });
+
+    it('should reject a version entry missing outputPath field', () => {
+      // Arrange
+      class BadPath extends BaseFormatter {
+        readonly name = 'bad-path';
+        readonly outputPath = 'BAD.md';
+        readonly description = 'Bad path';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return {
+            simple: { name: 'simple', description: 'Missing path' },
+          } as unknown as FormatterVersionMap;
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('bad-path', BadPath)).toThrow(
+        /version 'simple' is missing required 'outputPath' field/
+      );
+    });
+
+    it('should validate all version entries, not just the first', () => {
+      // Arrange
+      class BadSecondVersion extends BaseFormatter {
+        readonly name = 'bad-second';
+        readonly outputPath = 'BAD.md';
+        readonly description = 'Bad second version';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return {
+            simple: { name: 'simple', description: 'OK', outputPath: 'BAD.md' },
+            full: { name: 'full', outputPath: 'BAD.md' },
+          } as unknown as FormatterVersionMap;
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('bad-second', BadSecondVersion)).toThrow(
+        /version 'full' is missing required 'description' field/
+      );
+    });
+
+    it('should include formatter name in error messages', () => {
+      // Arrange
+      class MyBadFormatter extends BaseFormatter {
+        readonly name = 'my-bad';
+        readonly outputPath = 'BAD.md';
+        readonly description = 'Bad';
+        readonly defaultConvention = 'markdown';
+
+        format(_ast: Program, _options?: FormatOptions): FormatterOutput {
+          return { path: this.outputPath, content: '' };
+        }
+
+        static getSupportedVersions(): FormatterVersionMap {
+          return {};
+        }
+      }
+
+      // Act & Assert
+      expect(() => FormatterRegistry.register('my-bad', MyBadFormatter)).toThrow(
+        /Formatter 'my-bad'/
+      );
+    });
+  });
+
+  describe('register (factory-based, legacy)', () => {
+    it('should register a new formatter via factory function', () => {
+      // Arrange & Act
+      FormatterRegistry.register('test-formatter', () => new MockFormatter());
+
+      // Assert
+      expect(FormatterRegistry.has('test-formatter')).toBe(true);
+    });
+
+    it('should throw when registering duplicate name via factory', () => {
+      // Arrange
       FormatterRegistry.register('duplicate-test', () => new MockFormatter());
+
+      // Act & Assert
       expect(() => {
         FormatterRegistry.register('duplicate-test', () => new MockFormatter());
       }).toThrow("Formatter 'duplicate-test' is already registered");
@@ -59,33 +390,49 @@ describe('FormatterRegistry', () => {
 
   describe('get', () => {
     it('should return formatter instance by name', () => {
+      // Arrange
       FormatterRegistry.register('get-test', () => new MockFormatter());
+
+      // Act
       const formatter = FormatterRegistry.get('get-test');
+
+      // Assert
       expect(formatter).toBeDefined();
       expect(formatter?.name).toBe('mock');
     });
 
     it('should return undefined for unknown formatter', () => {
-      const formatter = FormatterRegistry.get('unknown-formatter');
-      expect(formatter).toBeUndefined();
+      // Act & Assert
+      expect(FormatterRegistry.get('unknown-formatter')).toBeUndefined();
     });
 
     it('should create new instance on each call', () => {
-      FormatterRegistry.register('instance-test', () => new MockFormatter());
+      // Arrange
+      FormatterRegistry.register('instance-test', ValidClassFormatter);
+
+      // Act
       const instance1 = FormatterRegistry.get('instance-test');
       const instance2 = FormatterRegistry.get('instance-test');
+
+      // Assert
       expect(instance1).not.toBe(instance2);
     });
   });
 
   describe('getAll', () => {
     it('should return all registered formatters', () => {
+      // Act
       const formatters = FormatterRegistry.getAll();
+
+      // Assert
       expect(formatters.length).toBeGreaterThan(0);
     });
 
     it('should return formatter instances', () => {
+      // Act
       const formatters = FormatterRegistry.getAll();
+
+      // Assert
       for (const formatter of formatters) {
         expect(formatter.name).toBeDefined();
         expect(formatter.outputPath).toBeDefined();
@@ -96,7 +443,10 @@ describe('FormatterRegistry', () => {
 
   describe('list', () => {
     it('should return list of formatter names', () => {
+      // Act
       const names = FormatterRegistry.list();
+
+      // Assert
       expect(Array.isArray(names)).toBe(true);
       // Should include built-in formatters
       expect(names).toContain('github');
@@ -107,50 +457,114 @@ describe('FormatterRegistry', () => {
 
   describe('has', () => {
     it('should return true for registered formatter', () => {
+      // Act & Assert
       expect(FormatterRegistry.has('github')).toBe(true);
     });
 
     it('should return false for unknown formatter', () => {
+      // Act & Assert
       expect(FormatterRegistry.has('unknown')).toBe(false);
     });
   });
 
   describe('unregister', () => {
     it('should unregister a formatter', () => {
-      FormatterRegistry.register('unregister-test', () => new MockFormatter());
+      // Arrange
+      FormatterRegistry.register('unregister-test', ValidClassFormatter);
       expect(FormatterRegistry.has('unregister-test')).toBe(true);
 
+      // Act
       const result = FormatterRegistry.unregister('unregister-test');
+
+      // Assert
       expect(result).toBe(true);
       expect(FormatterRegistry.has('unregister-test')).toBe(false);
     });
 
     it('should return false for unknown formatter', () => {
-      const result = FormatterRegistry.unregister('unknown');
-      expect(result).toBe(false);
+      // Act & Assert
+      expect(FormatterRegistry.unregister('unknown')).toBe(false);
     });
   });
 
   describe('built-in formatters', () => {
     it('should have github formatter registered', () => {
+      // Act
       const formatter = FormatterRegistry.get('github');
+
+      // Assert
       expect(formatter).toBeDefined();
       expect(formatter?.name).toBe('github');
       expect(formatter?.outputPath).toBe('.github/copilot-instructions.md');
     });
 
     it('should have claude formatter registered', () => {
+      // Act
       const formatter = FormatterRegistry.get('claude');
+
+      // Assert
       expect(formatter).toBeDefined();
       expect(formatter?.name).toBe('claude');
       expect(formatter?.outputPath).toBe('CLAUDE.md');
     });
 
     it('should have cursor formatter registered', () => {
+      // Act
       const formatter = FormatterRegistry.get('cursor');
+
+      // Assert
       expect(formatter).toBeDefined();
       expect(formatter?.name).toBe('cursor');
       expect(formatter?.outputPath).toBe('.cursor/rules/project.mdc');
+    });
+
+    it('should have all built-in formatters registered with valid getSupportedVersions', () => {
+      // This test verifies that all built-in formatters passed the registration
+      // validation, meaning they all have valid getSupportedVersions() methods.
+      const expectedFormatters = [
+        'github',
+        'claude',
+        'cursor',
+        'antigravity',
+        'factory',
+        'opencode',
+        'gemini',
+        'windsurf',
+        'cline',
+        'roo',
+        'codex',
+        'continue',
+        'augment',
+        'goose',
+        'kilo',
+        'amp',
+        'trae',
+        'junie',
+        'kiro',
+        'cortex',
+        'crush',
+        'command-code',
+        'kode',
+        'mcpjam',
+        'mistral-vibe',
+        'mux',
+        'openhands',
+        'pi',
+        'qoder',
+        'qwen-code',
+        'zencoder',
+        'neovate',
+        'pochi',
+        'adal',
+        'iflow',
+        'openclaw',
+        'codebuddy',
+      ];
+
+      // Assert
+      for (const name of expectedFormatters) {
+        expect(FormatterRegistry.has(name)).toBe(true);
+      }
     });
   });
 });

--- a/packages/formatters/src/index.ts
+++ b/packages/formatters/src/index.ts
@@ -8,7 +8,15 @@
  */
 
 // Types
-export type { Formatter, FormatterFactory, FormatterOutput, FormatOptions } from './types.js';
+export type {
+  Formatter,
+  FormatterClass,
+  FormatterFactory,
+  FormatterOutput,
+  FormatterVersionInfo,
+  FormatterVersionMap,
+  FormatOptions,
+} from './types.js';
 
 // Base classes
 export { BaseFormatter } from './base-formatter.js';
@@ -142,43 +150,43 @@ import { OpenClawFormatter } from './formatters/openclaw.js';
 import { CodeBuddyFormatter } from './formatters/codebuddy.js';
 
 // Original 7
-FormatterRegistry.register('github', () => new GitHubFormatter());
-FormatterRegistry.register('claude', () => new ClaudeFormatter());
-FormatterRegistry.register('cursor', () => new CursorFormatter());
-FormatterRegistry.register('antigravity', () => new AntigravityFormatter());
-FormatterRegistry.register('factory', () => new FactoryFormatter());
-FormatterRegistry.register('opencode', () => new OpenCodeFormatter());
-FormatterRegistry.register('gemini', () => new GeminiFormatter());
+FormatterRegistry.register('github', GitHubFormatter);
+FormatterRegistry.register('claude', ClaudeFormatter);
+FormatterRegistry.register('cursor', CursorFormatter);
+FormatterRegistry.register('antigravity', AntigravityFormatter);
+FormatterRegistry.register('factory', FactoryFormatter);
+FormatterRegistry.register('opencode', OpenCodeFormatter);
+FormatterRegistry.register('gemini', GeminiFormatter);
 // Tier 1
-FormatterRegistry.register('windsurf', () => new WindsurfFormatter());
-FormatterRegistry.register('cline', () => new ClineFormatter());
-FormatterRegistry.register('roo', () => new RooFormatter());
-FormatterRegistry.register('codex', () => new CodexFormatter());
-FormatterRegistry.register('continue', () => new ContinueFormatter());
+FormatterRegistry.register('windsurf', WindsurfFormatter);
+FormatterRegistry.register('cline', ClineFormatter);
+FormatterRegistry.register('roo', RooFormatter);
+FormatterRegistry.register('codex', CodexFormatter);
+FormatterRegistry.register('continue', ContinueFormatter);
 // Tier 2
-FormatterRegistry.register('augment', () => new AugmentFormatter());
-FormatterRegistry.register('goose', () => new GooseFormatter());
-FormatterRegistry.register('kilo', () => new KiloFormatter());
-FormatterRegistry.register('amp', () => new AmpFormatter());
-FormatterRegistry.register('trae', () => new TraeFormatter());
-FormatterRegistry.register('junie', () => new JunieFormatter());
-FormatterRegistry.register('kiro', () => new KiroFormatter());
+FormatterRegistry.register('augment', AugmentFormatter);
+FormatterRegistry.register('goose', GooseFormatter);
+FormatterRegistry.register('kilo', KiloFormatter);
+FormatterRegistry.register('amp', AmpFormatter);
+FormatterRegistry.register('trae', TraeFormatter);
+FormatterRegistry.register('junie', JunieFormatter);
+FormatterRegistry.register('kiro', KiroFormatter);
 // Tier 3
-FormatterRegistry.register('cortex', () => new CortexFormatter());
-FormatterRegistry.register('crush', () => new CrushFormatter());
-FormatterRegistry.register('command-code', () => new CommandCodeFormatter());
-FormatterRegistry.register('kode', () => new KodeFormatter());
-FormatterRegistry.register('mcpjam', () => new McpjamFormatter());
-FormatterRegistry.register('mistral-vibe', () => new MistralVibeFormatter());
-FormatterRegistry.register('mux', () => new MuxFormatter());
-FormatterRegistry.register('openhands', () => new OpenHandsFormatter());
-FormatterRegistry.register('pi', () => new PiFormatter());
-FormatterRegistry.register('qoder', () => new QoderFormatter());
-FormatterRegistry.register('qwen-code', () => new QwenCodeFormatter());
-FormatterRegistry.register('zencoder', () => new ZencoderFormatter());
-FormatterRegistry.register('neovate', () => new NeovateFormatter());
-FormatterRegistry.register('pochi', () => new PochiFormatter());
-FormatterRegistry.register('adal', () => new AdalFormatter());
-FormatterRegistry.register('iflow', () => new IflowFormatter());
-FormatterRegistry.register('openclaw', () => new OpenClawFormatter());
-FormatterRegistry.register('codebuddy', () => new CodeBuddyFormatter());
+FormatterRegistry.register('cortex', CortexFormatter);
+FormatterRegistry.register('crush', CrushFormatter);
+FormatterRegistry.register('command-code', CommandCodeFormatter);
+FormatterRegistry.register('kode', KodeFormatter);
+FormatterRegistry.register('mcpjam', McpjamFormatter);
+FormatterRegistry.register('mistral-vibe', MistralVibeFormatter);
+FormatterRegistry.register('mux', MuxFormatter);
+FormatterRegistry.register('openhands', OpenHandsFormatter);
+FormatterRegistry.register('pi', PiFormatter);
+FormatterRegistry.register('qoder', QoderFormatter);
+FormatterRegistry.register('qwen-code', QwenCodeFormatter);
+FormatterRegistry.register('zencoder', ZencoderFormatter);
+FormatterRegistry.register('neovate', NeovateFormatter);
+FormatterRegistry.register('pochi', PochiFormatter);
+FormatterRegistry.register('adal', AdalFormatter);
+FormatterRegistry.register('iflow', IflowFormatter);
+FormatterRegistry.register('openclaw', OpenClawFormatter);
+FormatterRegistry.register('codebuddy', CodeBuddyFormatter);

--- a/packages/formatters/src/registry.ts
+++ b/packages/formatters/src/registry.ts
@@ -1,22 +1,51 @@
-import type { Formatter, FormatterFactory } from './types.js';
+import type { Formatter, FormatterClass, FormatterFactory } from './types.js';
 
 /**
  * Registry for formatter implementations.
  * Allows dynamic registration and discovery of formatters.
+ *
+ * Formatters can be registered via class constructor (preferred) or factory function.
+ * When registered via class constructor, the static `getSupportedVersions()` method
+ * is enforced at both compile time (via the `FormatterClass` type) and runtime.
  */
 export class FormatterRegistry {
   private static factories = new Map<string, FormatterFactory>();
 
   /**
-   * Register a formatter factory.
+   * Register a formatter class.
+   *
+   * Enforces that the class implements a static `getSupportedVersions()` method
+   * at compile time via the `FormatterClass` type and at runtime via validation.
+   *
+   * @param name - Unique formatter identifier
+   * @param FormatterCtor - Formatter class with static getSupportedVersions()
+   * @throws Error if the formatter is already registered
+   * @throws Error if the class lacks a static getSupportedVersions() method
+   */
+  static register(name: string, FormatterCtor: FormatterClass): void;
+
+  /**
+   * Register a formatter factory function.
+   *
    * @param name - Unique formatter identifier
    * @param factory - Factory function that creates formatter instances
+   * @throws Error if the formatter is already registered
+   * @deprecated Use the class-based overload to enforce getSupportedVersions()
    */
-  static register(name: string, factory: FormatterFactory): void {
+  static register(name: string, factory: FormatterFactory): void;
+
+  static register(name: string, ctorOrFactory: FormatterClass | FormatterFactory): void {
     if (this.factories.has(name)) {
       throw new Error(`Formatter '${name}' is already registered`);
     }
-    this.factories.set(name, factory);
+
+    if (isFormatterClass(ctorOrFactory)) {
+      // Runtime validation: ensure getSupportedVersions exists and returns a valid map
+      validateFormatterClass(name, ctorOrFactory);
+      this.factories.set(name, () => new ctorOrFactory());
+    } else {
+      this.factories.set(name, ctorOrFactory);
+    }
   }
 
   /**
@@ -66,5 +95,71 @@ export class FormatterRegistry {
    */
   static clear(): void {
     this.factories.clear();
+  }
+}
+
+/**
+ * Type guard to distinguish a FormatterClass (constructor) from a FormatterFactory (function).
+ *
+ * A FormatterClass is a constructor function with a `prototype` property,
+ * while a FormatterFactory is a plain function returning a Formatter instance.
+ */
+function isFormatterClass(value: FormatterClass | FormatterFactory): value is FormatterClass {
+  return value.prototype !== undefined && value.prototype.constructor === value;
+}
+
+/**
+ * Validate that a formatter class has a proper static getSupportedVersions() method.
+ *
+ * @param name - Formatter name (used in error messages)
+ * @param ctor - The formatter class constructor to validate
+ * @throws Error if getSupportedVersions is missing or returns an invalid value
+ */
+function validateFormatterClass(name: string, ctor: FormatterClass): void {
+  // The FormatterClass type already enforces this at compile time,
+  // but we add a runtime check for safety (e.g., JavaScript consumers).
+  const asRecord = ctor as unknown as Record<string, unknown>;
+  if (typeof asRecord['getSupportedVersions'] !== 'function') {
+    throw new Error(
+      `Formatter '${name}' must implement a static getSupportedVersions() method. ` +
+        `Add 'static getSupportedVersions()' to the ${ctor.name ?? name} class.`
+    );
+  }
+
+  const versions = ctor.getSupportedVersions();
+  if (!versions || typeof versions !== 'object') {
+    throw new Error(
+      `Formatter '${name}': getSupportedVersions() must return a non-null version map. ` +
+        `Got ${String(versions)}.`
+    );
+  }
+
+  // Validate that at least one version entry exists
+  const entries = Object.entries(versions);
+  if (entries.length === 0) {
+    throw new Error(
+      `Formatter '${name}': getSupportedVersions() returned an empty version map. ` +
+        `At least one version must be defined.`
+    );
+  }
+
+  // Validate each version entry has required fields
+  for (const [versionName, info] of entries) {
+    const versionInfo = info as unknown as Record<string, unknown>;
+    if (typeof versionInfo['name'] !== 'string') {
+      throw new Error(
+        `Formatter '${name}': version '${versionName}' is missing required 'name' field.`
+      );
+    }
+    if (typeof versionInfo['description'] !== 'string') {
+      throw new Error(
+        `Formatter '${name}': version '${versionName}' is missing required 'description' field.`
+      );
+    }
+    if (typeof versionInfo['outputPath'] !== 'string') {
+      throw new Error(
+        `Formatter '${name}': version '${versionName}' is missing required 'outputPath' field.`
+      );
+    }
   }
 }

--- a/packages/formatters/src/standalone.ts
+++ b/packages/formatters/src/standalone.ts
@@ -1,6 +1,12 @@
 import type { Program } from '@promptscript/core';
 import { FormatterRegistry } from './registry.js';
-import type { Formatter, FormatterFactory, FormatterOutput, FormatOptions } from './types.js';
+import type {
+  Formatter,
+  FormatterClass,
+  FormatterFactory,
+  FormatterOutput,
+  FormatOptions,
+} from './types.js';
 
 /**
  * Options for the standalone format function.
@@ -105,7 +111,7 @@ export function getFormatter(name: string): Formatter {
  * Use this to add custom formatters that can be referenced by name.
  *
  * @param name - Unique identifier for the formatter
- * @param factory - Factory function that creates formatter instances
+ * @param ctorOrFactory - Formatter class (preferred) or factory function
  * @throws Error if a formatter with the same name is already registered
  *
  * @example
@@ -117,16 +123,32 @@ export function getFormatter(name: string): Formatter {
  *   outputPath = '.my-tool/config.md';
  *   description = 'My custom formatter';
  *   defaultConvention = 'markdown';
+ *   static getSupportedVersions() { return { simple: { name: 'simple', description: '...', outputPath: '...' } }; }
  * }
  *
- * registerFormatter('my-tool', () => new MyFormatter());
+ * registerFormatter('my-tool', MyFormatter);
  *
  * // Now it can be used by name
  * const formatter = getFormatter('my-tool');
  * ```
  */
-export function registerFormatter(name: string, factory: FormatterFactory): void {
-  FormatterRegistry.register(name, factory);
+export function registerFormatter(
+  name: string,
+  ctorOrFactory: FormatterClass | FormatterFactory
+): void {
+  // Disambiguate for the overloaded register() method
+  if (isFormatterClassArg(ctorOrFactory)) {
+    FormatterRegistry.register(name, ctorOrFactory);
+  } else {
+    FormatterRegistry.register(name, ctorOrFactory);
+  }
+}
+
+/**
+ * Check if a value is a FormatterClass (constructor) vs a FormatterFactory (plain function).
+ */
+function isFormatterClassArg(value: FormatterClass | FormatterFactory): value is FormatterClass {
+  return value.prototype !== undefined && value.prototype.constructor === value;
 }
 
 /**

--- a/packages/formatters/src/types.ts
+++ b/packages/formatters/src/types.ts
@@ -64,3 +64,45 @@ export interface Formatter {
  * Factory function type for creating formatter instances.
  */
 export type FormatterFactory = () => Formatter;
+
+/**
+ * Version information for a single formatter version.
+ */
+export interface FormatterVersionInfo {
+  /** Version identifier (e.g. 'simple', 'multifile', 'full') */
+  readonly name: string;
+  /** Human-readable description */
+  readonly description: string;
+  /** Default output file path for this version */
+  readonly outputPath: string;
+}
+
+/**
+ * Version configuration map returned by getSupportedVersions().
+ * Maps version name to its configuration.
+ */
+export type FormatterVersionMap = Readonly<Record<string, FormatterVersionInfo>>;
+
+/**
+ * Static interface for formatter classes.
+ *
+ * Enforces that every formatter class provides a static `getSupportedVersions()`
+ * method returning its version configuration. TypeScript cannot enforce static
+ * methods via `implements`, so this type is used at registration time to
+ * provide compile-time safety.
+ *
+ * @example
+ * ```ts
+ * // This will type-check:
+ * FormatterRegistry.register('claude', ClaudeFormatter);
+ *
+ * // This will fail at compile time if MissingFormatter lacks getSupportedVersions():
+ * FormatterRegistry.register('missing', MissingFormatter);
+ * ```
+ */
+export interface FormatterClass {
+  /** Create a new formatter instance */
+  new (): Formatter;
+  /** Return version configuration for this formatter */
+  getSupportedVersions(): FormatterVersionMap;
+}


### PR DESCRIPTION
## Summary

Closes #88

- Added `FormatterClass` interface with `FormatterVersionInfo` and `FormatterVersionMap` types
- Added runtime validation in `FormatterRegistry.register()` that checks for `getSupportedVersions()` and validates returned version map structure
- Converted all 37 formatter registrations from factory functions to class constructors
- Updated `registerFormatter()` standalone API to accept both `FormatterClass` and legacy factory
- Expanded registry tests from 10 to 27, covering missing methods, null returns, empty maps, field validation

## Test plan

- [x] 27 registry tests covering enforcement, validation, and backward compatibility
- [x] All 1070 formatter tests pass
- [x] Full verification pipeline passes (format, lint, typecheck, test, validate, schema:check, skill:check)