### PR TITLE
feat(formatters): change default version from simple to full

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -474,12 +474,12 @@ PromptScript supports multiple format versions for tools that have evolved their
 
 | Tool           | Version     | Output Path                                | When to Use                        |
 | -------------- | ----------- | ------------------------------------------ | ---------------------------------- |
-| GitHub Copilot | simple      | `.github/copilot-instructions.md`          | Single file (default)              |
+| GitHub Copilot | simple      | `.github/copilot-instructions.md`          | Single file                        |
 | GitHub Copilot | multifile   | + `.github/instructions/*.instructions.md` | Path-specific rules with `applyTo` |
-| GitHub Copilot | full        | + `.github/skills/`, `AGENTS.md`           | Skills and custom agents           |
-| Claude Code    | simple      | `CLAUDE.md`                                | Single file (default)              |
+| GitHub Copilot | full        | + `.github/skills/`, `AGENTS.md`           | Skills and custom agents (default) |
+| Claude Code    | simple      | `CLAUDE.md`                                | Single file                        |
 | Claude Code    | multifile   | + `.claude/rules/*.md`                     | Path-specific rules                |
-| Claude Code    | full        | + `.claude/skills/`, `CLAUDE.local.md`     | Skills and local config            |
+| Claude Code    | full        | + `.claude/skills/`, `CLAUDE.local.md`     | Skills and local config (default)  |
 | Cursor         | (modern)    | `.cursor/rules/project.mdc`                | Cursor 0.45+ (default)             |
 | Cursor         | legacy      | `.cursorrules`                             | Older Cursor versions              |
 | Antigravity    | simple      | `.agent/rules/project.md`                  | Plain Markdown (default)           |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -348,19 +348,19 @@ targets:
 
   # GitHub Copilot versions
   - github:
-      version: simple # Single file (default)
+      version: simple # Single file
   - github:
       version: multifile # Main + path-specific instructions + prompts
   - github:
-      version: full # Multifile + skills + AGENTS.md
+      version: full # Multifile + skills + AGENTS.md (default)
 
   # Claude Code versions
   - claude:
-      version: simple # Single CLAUDE.md (default)
+      version: simple # Single CLAUDE.md
   - claude:
       version: multifile # Main + modular rules in .claude/rules/
   - claude:
-      version: full # Multifile + skills + CLAUDE.local.md
+      version: full # Multifile + skills + CLAUDE.local.md (default)
 
   # OpenCode versions
   - opencode:
@@ -413,12 +413,12 @@ targets:
 
 **Target Options:**
 
-| Field        | Type    | Default     | Description                              |
-| ------------ | ------- | ----------- | ---------------------------------------- |
-| `enabled`    | boolean | `true`      | Whether target is enabled                |
-| `output`     | string  | (see above) | Custom output path                       |
-| `convention` | string  | `markdown`  | Output convention ('xml' or 'markdown')  |
-| `version`    | string  | (default)   | Format version ('legacy' for deprecated) |
+| Field        | Type    | Default     | Description                                  |
+| ------------ | ------- | ----------- | -------------------------------------------- |
+| `enabled`    | boolean | `true`      | Whether target is enabled                    |
+| `output`     | string  | (see above) | Custom output path                           |
+| `convention` | string  | `markdown`  | Output convention ('xml' or 'markdown')      |
+| `version`    | string  | `full`      | Format version (varies by target, see below) |
 
 !!! tip "Disabling Targets"
 Setting `enabled: false` skips the target during compilation.

--- a/packages/formatters/src/__tests__/claude.spec.ts
+++ b/packages/formatters/src/__tests__/claude.spec.ts
@@ -408,17 +408,60 @@ describe('ClaudeFormatter', () => {
       expect(ClaudeFormatter.getSupportedVersions()).toBe(CLAUDE_VERSIONS);
     });
 
-    it('should use simple mode by default', () => {
-      const ast = createMinimalProgram();
+    it('should use full mode by default', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                commit: {
+                  description: 'Create git commits',
+                  content: 'Instructions for commit skill...',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
       const result = formatter.format(ast);
-      expect(result.additionalFiles).toBeUndefined();
+      // Full mode produces skill files; simple mode would not
+      expect(result.additionalFiles).toBeDefined();
+      const skillFile = result.additionalFiles?.find((f) => f.path.includes('skills/'));
+      expect(skillFile).toBeDefined();
     });
 
-    it('should default to simple mode for unknown version', () => {
-      const ast = createMinimalProgram();
+    it('should default to full mode for unknown version', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                commit: {
+                  description: 'Create git commits',
+                  content: 'Instructions for commit skill...',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
       const result = formatter.format(ast, { version: 'unknown-version' });
-      expect(result.additionalFiles).toBeUndefined();
-      expect(result.content.startsWith('# CLAUDE.md\n')).toBe(true);
+      // Unknown versions fall back to full mode, which produces skill files
+      expect(result.additionalFiles).toBeDefined();
+      const skillFile = result.additionalFiles?.find((f) => f.path.includes('skills/'));
+      expect(skillFile).toBeDefined();
     });
 
     it('should skip markdown header with XML convention in multifile mode', () => {

--- a/packages/formatters/src/__tests__/factory.spec.ts
+++ b/packages/formatters/src/__tests__/factory.spec.ts
@@ -1342,7 +1342,7 @@ describe('FactoryFormatter', () => {
         ],
       };
 
-      const result = formatter.format(ast);
+      const result = formatter.format(ast, { version: 'simple' });
       const droids = result.additionalFiles?.filter((f) => f.path.includes('droids/'));
       expect(droids ?? []).toHaveLength(0);
     });

--- a/packages/formatters/src/__tests__/feature-coverage.spec.ts
+++ b/packages/formatters/src/__tests__/feature-coverage.spec.ts
@@ -359,7 +359,8 @@ describe('Feature Implementation Tests', () => {
       const formatter = formatters.get('github')!;
       const result = formatter.format(createTestAST());
 
-      expect(result.additionalFiles).toBeUndefined();
+      const workflows = result.additionalFiles?.filter((f) => f.path.includes('workflows'));
+      expect(workflows ?? []).toHaveLength(0);
     });
   });
 

--- a/packages/formatters/src/__tests__/gemini.spec.ts
+++ b/packages/formatters/src/__tests__/gemini.spec.ts
@@ -169,11 +169,32 @@ describe('GeminiFormatter', () => {
       expect(result.additionalFiles).toBeUndefined();
     });
 
-    it('should default to simple mode for unknown version', () => {
-      const ast = createMinimalProgram();
+    it('should default to full mode for unknown version', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                commit: {
+                  description: 'Create git commits',
+                  content: 'Instructions for commit skill...',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
       const result = formatter.format(ast, { version: 'unknown-version' });
-      expect(result.additionalFiles).toBeUndefined();
-      expect(result.content.startsWith('# GEMINI.md\n')).toBe(true);
+      // Unknown versions fall back to full mode, which produces skill files
+      expect(result.additionalFiles).toBeDefined();
+      const skillFile = result.additionalFiles?.find((f) => f.path.includes('skills/'));
+      expect(skillFile).toBeDefined();
     });
 
     it('should generate multifile output in full mode', () => {

--- a/packages/formatters/src/__tests__/github.spec.ts
+++ b/packages/formatters/src/__tests__/github.spec.ts
@@ -324,17 +324,60 @@ describe('GitHubFormatter', () => {
       expect(GitHubFormatter.getSupportedVersions()).toBe(GITHUB_VERSIONS);
     });
 
-    it('should use simple mode by default', () => {
-      const ast = createMinimalProgram();
+    it('should use full mode by default', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                commit: {
+                  description: 'Create git commits',
+                  content: 'Instructions for commit skill...',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
       const result = formatter.format(ast);
-      expect(result.additionalFiles).toBeUndefined();
+      // Full mode produces skill files; simple mode would not
+      expect(result.additionalFiles).toBeDefined();
+      const skillFile = result.additionalFiles?.find((f) => f.path.includes('skills/'));
+      expect(skillFile).toBeDefined();
     });
 
-    it('should default to simple mode for unknown version', () => {
-      const ast = createMinimalProgram();
+    it('should default to full mode for unknown version', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                commit: {
+                  description: 'Create git commits',
+                  content: 'Instructions for commit skill...',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
       const result = formatter.format(ast, { version: 'unknown-version' });
-      expect(result.additionalFiles).toBeUndefined();
-      expect(result.content).toContain('# GitHub Copilot Instructions');
+      // Unknown versions fall back to full mode, which produces skill files
+      expect(result.additionalFiles).toBeDefined();
+      const skillFile = result.additionalFiles?.find((f) => f.path.includes('skills/'));
+      expect(skillFile).toBeDefined();
     });
 
     it('should skip markdown header with XML convention in multifile mode', () => {

--- a/packages/formatters/src/__tests__/markdown-instruction-formatter.spec.ts
+++ b/packages/formatters/src/__tests__/markdown-instruction-formatter.spec.ts
@@ -63,10 +63,32 @@ describe('MarkdownInstructionFormatter', () => {
       expect(result.content).toContain('# TEST.md');
     });
 
-    it('should default to simple mode', () => {
-      const ast = createMinimalProgram();
+    it('should default to full mode', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                commit: {
+                  description: 'Create git commits',
+                  content: 'Instructions for commit skill...',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
       const result = formatter.format(ast);
-      expect(result.additionalFiles).toBeUndefined();
+      // Full mode produces skill files; simple mode would not
+      expect(result.additionalFiles).toBeDefined();
+      const skillFile = result.additionalFiles?.find((f) => f.path.includes('skills/'));
+      expect(skillFile).toBeDefined();
     });
 
     it('should support multifile mode', () => {

--- a/packages/formatters/src/__tests__/opencode.spec.ts
+++ b/packages/formatters/src/__tests__/opencode.spec.ts
@@ -216,11 +216,32 @@ describe('OpenCodeFormatter', () => {
       expect(result.additionalFiles).toBeUndefined();
     });
 
-    it('should default to simple mode for unknown version', () => {
-      const ast = createMinimalProgram();
+    it('should default to full mode for unknown version', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                commit: {
+                  description: 'Create git commits',
+                  content: 'Instructions for commit skill...',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
       const result = formatter.format(ast, { version: 'unknown-version' });
-      expect(result.additionalFiles).toBeUndefined();
-      expect(result.content.startsWith('# OPENCODE.md\n')).toBe(true);
+      // Unknown versions fall back to full mode, which produces skill files
+      expect(result.additionalFiles).toBeDefined();
+      const skillFile = result.additionalFiles?.find((f) => f.path.includes('skills/'));
+      expect(skillFile).toBeDefined();
     });
   });
 

--- a/packages/formatters/src/formatters/claude.ts
+++ b/packages/formatters/src/formatters/claude.ts
@@ -116,14 +116,14 @@ interface ClaudeAgentConfig {
  * Formatter for Claude Code instructions.
  *
  * Supports three versions:
- * - **simple** (default): Single `CLAUDE.md` file
+ * - **simple**: Single `CLAUDE.md` file
  * - **multifile**: Main + `.claude/rules/*.md` with path-specific rules
- * - **full**: Multifile + `.claude/skills/<name>/SKILL.md` + `CLAUDE.local.md`
+ * - **full** (default): Multifile + `.claude/skills/<name>/SKILL.md` + `CLAUDE.local.md`
  *
  * @example
  * ```yaml
  * targets:
- *   - claude  # uses simple mode
+ *   - claude  # uses full mode (default)
  *   - claude:
  *       version: multifile
  *   - claude:
@@ -171,9 +171,9 @@ export class ClaudeFormatter extends BaseFormatter {
    * Resolve version string to ClaudeVersion.
    */
   private resolveVersion(version?: string): ClaudeVersion {
+    if (version === 'simple') return 'simple';
     if (version === 'multifile') return 'multifile';
-    if (version === 'full') return 'full';
-    return 'simple';
+    return 'full';
   }
 
   // ============================================================

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -99,14 +99,14 @@ interface FactoryDroidConfig extends MarkdownAgentConfig {
  * .factory/skills/<name>/SKILL.md for reusable skills.
  *
  * Supports three versions:
- * - **simple** (default): Single `AGENTS.md` file
+ * - **simple**: Single `AGENTS.md` file
  * - **multifile**: AGENTS.md + `.factory/skills/<name>/SKILL.md` for each skill
- * - **full**: Multifile + additional supporting files for skills
+ * - **full** (default): Multifile + additional supporting files for skills
  *
  * @example
  * ```yaml
  * targets:
- *   - factory  # uses simple mode
+ *   - factory  # uses full mode (default)
  *   - factory:
  *       version: multifile
  *   - factory:

--- a/packages/formatters/src/formatters/gemini.ts
+++ b/packages/formatters/src/formatters/gemini.ts
@@ -41,16 +41,17 @@ export const GEMINI_VERSIONS = {
  *
  * Gemini has no agent concept.
  *
- * Supports two versions:
- * - **simple** (default): Single `GEMINI.md` file
+ * Supports three versions:
+ * - **simple**: Single `GEMINI.md` file
  * - **multifile**: GEMINI.md + commands (TOML) + skills
+ * - **full** (default): Multifile + skills
  *
  * @example
  * ```yaml
  * targets:
- *   - gemini  # uses simple mode
+ *   - gemini  # uses full mode (default)
  *   - gemini:
- *       version: multifile
+ *       version: simple
  * ```
  */
 export class GeminiFormatter extends MarkdownInstructionFormatter {
@@ -109,8 +110,8 @@ export class GeminiFormatter extends MarkdownInstructionFormatter {
    * Override version resolution: full maps to multifile for Gemini.
    */
   protected override resolveVersion(version?: string): MarkdownVersion {
+    if (version === 'simple') return 'simple';
     if (version === 'multifile') return 'multifile';
-    if (version === 'full') return 'full';
-    return 'simple';
+    return 'full';
   }
 }

--- a/packages/formatters/src/formatters/github.ts
+++ b/packages/formatters/src/formatters/github.ts
@@ -172,14 +172,14 @@ const MODEL_NAME_MAPPING: Record<string, string> = {
  * Formatter for GitHub Copilot instructions.
  *
  * Supports three versions:
- * - **simple** (default): Single `.github/copilot-instructions.md` file
+ * - **simple**: Single `.github/copilot-instructions.md` file
  * - **multifile**: Main + `.github/instructions/*.instructions.md` + `.github/prompts/*.prompt.md`
- * - **full**: Multifile + `.github/skills/<name>/SKILL.md` + `AGENTS.md`
+ * - **full** (default): Multifile + `.github/skills/<name>/SKILL.md` + `AGENTS.md`
  *
  * @example
  * ```yaml
  * targets:
- *   - github  # uses simple mode
+ *   - github  # uses full mode (default)
  *   - github:
  *       version: multifile
  *   - github:
@@ -227,9 +227,9 @@ export class GitHubFormatter extends BaseFormatter {
    * Resolve version string to GithubVersion.
    */
   private resolveVersion(version?: string): GithubVersion {
+    if (version === 'simple') return 'simple';
     if (version === 'multifile') return 'multifile';
-    if (version === 'full') return 'full';
-    return 'simple';
+    return 'full';
   }
 
   // ============================================================

--- a/packages/formatters/src/markdown-instruction-formatter.ts
+++ b/packages/formatters/src/markdown-instruction-formatter.ts
@@ -155,9 +155,9 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
   // ============================================================
 
   protected resolveVersion(version?: string): MarkdownVersion {
+    if (version === 'simple') return 'simple';
     if (version === 'multifile') return 'multifile';
-    if (version === 'full') return 'full';
-    return 'simple';
+    return 'full';
   }
 
   // ============================================================


### PR DESCRIPTION
## Summary

- Targets specified without an explicit version (e.g. `- github`, `- factory`) now default to `full` mode instead of `simple`
- Users get the richest output (skills, agents, multifile rules) out of the box
- Formatters with different version schemes are unchanged (Antigravity defaults to `simple`, Cursor defaults to `modern`)

## Changes

**Formatter logic** — `resolveVersion()` in base class + GitHub, Claude, Gemini formatters now returns `full` when no version is specified

**Documentation** — Updated `docs/getting-started.md` and `docs/reference/config.md` to reflect new default

**Tests** — Updated 7 test files; default-mode tests now use ASTs with `@skills` blocks to verify that `full` mode actually produces skill files (not just trivially passing path checks)

## Test plan

- [x] All 1098 formatter tests pass
- [x] Full verification pipeline passes (format, lint, typecheck, test, validate, schema:check, skill:check)
- [x] Code review completed — fixed stale JSDoc comments and strengthened test assertions