### PR TITLE
feat: skill folders with shared resources and skill contracts

### DIFF
--- a/docs/guides/local-skills.md
+++ b/docs/guides/local-skills.md
@@ -291,8 +291,32 @@ python3 .claude/skills/my-skill/scripts/search.py "query"
 
 For cross-target compatibility, consider parameterizing the path or documenting the convention.
 
+## Skill Dependencies
+
+Skills can declare dependencies on other skills using the `requires` field:
+
+```text
+@skills {
+  lint-check: {
+    description: "Run linting"
+  }
+
+  full-review: {
+    description: "Complete code review"
+    requires: ["lint-check"]
+  }
+}
+```
+
+The PS016 validation rule checks that:
+
+- Required skills exist in the same `@skills` block
+- No self-referencing requires
+- No circular dependencies
+
 ## See Also
 
+- [Shared Resources](shared-resources.md) — Share files across all skills
 - [Skills & Local Memory](../examples/skills-and-local.md) — Example of `@skills` with inline content
 - [Multi-File Organization](multi-file.md) — Organizing `.prs` files with `@use` imports
 - [Build Your Registry](registry.md) — Publishing and consuming registry packages

--- a/docs/guides/shared-resources.md
+++ b/docs/guides/shared-resources.md
@@ -1,0 +1,68 @@
+---
+title: Shared Resources
+description: Share files across all skills using the .promptscript/shared/ directory
+---
+
+# Shared Resources
+
+Place files in `.promptscript/shared/` to make them available to every skill during compilation. Shared resources are included in each skill's output with the `@shared/` prefix.
+
+## Directory Structure
+
+```
+my-project/
+├── .promptscript/
+│   ├── project.prs
+│   ├── skills/
+│   │   ├── review/
+│   │   │   └── SKILL.md
+│   │   └── security/
+│   │       └── SKILL.md
+│   └── shared/                  # Shared across all skills
+│       ├── templates/
+│       │   └── report.md
+│       └── data/
+│           └── config.json
+└── promptscript.yaml
+```
+
+## How It Works
+
+When PromptScript compiles skills, it:
+
+1. Discovers files in `.promptscript/shared/`
+2. Adds them to **every** skill's resources with an `@shared/` prefix
+3. Copies them to each compilation target alongside skill-specific files
+
+A skill at `.promptscript/skills/review/` with its own `checklist.md` and shared resources gets:
+
+```
+.claude/skills/review/
+├── SKILL.md
+├── checklist.md              # Skill-specific resource
+├── @shared/templates/report.md   # From shared/
+└── @shared/data/config.json      # From shared/
+```
+
+## Use Cases
+
+- **Report templates** shared across review, security, and audit skills
+- **Configuration files** (linting rules, coding standards) used by multiple skills
+- **Data files** (CSV databases, JSON schemas) referenced by several skills
+- **Scripts** (Python tools, shell scripts) invoked by different skills
+
+## Security Limits
+
+Shared resources follow the same security limits as skill resources:
+
+- Files larger than 1 MB are skipped
+- Total resources per skill cannot exceed 10 MB
+- Maximum 100 resource files per skill (including shared)
+- Symlinks are ignored
+- Binary files are excluded
+- System files (`.env`, `.gitignore`, `node_modules/`) are skipped
+
+## See Also
+
+- [Local Skills](local-skills.md) — Managing skills in your project
+- [Parameterized Skills](local-skills.md#parameterized-skills) — Making skills configurable

--- a/docs/guides/skill-contracts.md
+++ b/docs/guides/skill-contracts.md
@@ -1,0 +1,95 @@
+---
+title: Skill Contracts
+description: Define inputs and outputs for skills to create clear interfaces
+---
+
+# Skill Contracts
+
+Skills can declare their expected inputs and produced outputs, creating a clear contract for how they interact with the environment.
+
+## Defining Contracts in SKILL.md
+
+Add `inputs` and `outputs` sections to the YAML frontmatter:
+
+```text
+---
+name: security-scan
+description: Scan for vulnerabilities
+inputs:
+  files:
+    description: List of file paths to scan
+    type: string
+  severity:
+    description: Minimum severity level
+    type: enum
+    options: [low, medium, high]
+    default: medium
+outputs:
+  report:
+    description: Scan report in markdown
+    type: string
+  passed:
+    description: Whether scan passed
+    type: boolean
+---
+
+Scan the provided files for security issues.
+Report findings with at least {{severity}} severity.
+```
+
+## Field Properties
+
+Each input or output field supports:
+
+| Property      | Required  | Description                           |
+| ------------- | --------- | ------------------------------------- |
+| `description` | Yes       | What the field represents             |
+| `type`        | Yes       | `string`, `number`, `boolean`, `enum` |
+| `options`     | Enum only | Valid values for enum type            |
+| `default`     | No        | Default value if not provided         |
+
+## Combining with Parameters
+
+A skill can have `params`, `inputs`, and `outputs` together:
+
+- **params** — Template variables interpolated at compile time (`{{var}}` syntax)
+- **inputs** — Runtime data the skill expects to receive
+- **outputs** — Runtime data the skill produces
+
+```text
+---
+name: code-review
+description: Review {{language}} code
+params:
+  language:
+    type: string
+    default: typescript
+inputs:
+  files:
+    description: Files to review
+    type: string
+outputs:
+  issues:
+    description: List of issues found
+    type: string
+  score:
+    description: Quality score
+    type: number
+---
+
+Review the provided {{language}} files.
+```
+
+## Validation
+
+The PS017 validation rule checks contract definitions:
+
+- Field types must be `string`, `number`, `boolean`, or `enum`
+- Enum fields must include an `options` array
+- Name collisions between `params` and `inputs` are flagged
+
+## See Also
+
+- [Local Skills](local-skills.md) — Managing skills in your project
+- [Parameterized Skills](local-skills.md#parameterized-skills) — Making skills configurable with `{{var}}` templates
+- [Shared Resources](shared-resources.md) — Share files across all skills

--- a/packages/core/src/__tests__/skill-definition.spec.ts
+++ b/packages/core/src/__tests__/skill-definition.spec.ts
@@ -29,6 +29,37 @@ describe('SkillDefinition', () => {
     expect(skill.params).toBeUndefined();
   });
 
+  it('can represent a skill with requires', () => {
+    const skill: SkillDefinition = {
+      description: 'Full review',
+      content: 'Run all checks',
+      requires: ['lint-check', 'security-scan'],
+    };
+    expect(skill.requires).toEqual(['lint-check', 'security-scan']);
+  });
+
+  it('can represent a skill with inputs and outputs', () => {
+    const skill: SkillDefinition = {
+      description: 'Security scan',
+      content: 'Scan files',
+      inputs: {
+        files: { description: 'List of file paths', type: 'string' },
+        severity: {
+          description: 'Minimum severity',
+          type: 'enum',
+          options: ['low', 'medium', 'high'],
+          default: 'medium',
+        },
+      },
+      outputs: {
+        report: { description: 'Scan report', type: 'string' },
+        passed: { description: 'Whether scan passed', type: 'boolean' },
+      },
+    };
+    expect(Object.keys(skill.inputs!)).toEqual(['files', 'severity']);
+    expect(Object.keys(skill.outputs!)).toEqual(['report', 'passed']);
+  });
+
   it('can represent a skill with trigger and allowedTools', () => {
     const skill: SkillDefinition = {
       description: 'Security review',

--- a/packages/core/src/types/ast.ts
+++ b/packages/core/src/types/ast.ts
@@ -376,4 +376,24 @@ export interface SkillDefinition {
   context?: string;
   /** Agent to use */
   agent?: string;
+  /** Skills that must exist for this skill to work */
+  requires?: string[];
+  /** Runtime inputs the skill expects */
+  inputs?: Record<string, SkillContractField>;
+  /** Outputs the skill produces */
+  outputs?: Record<string, SkillContractField>;
+}
+
+/**
+ * A field in a skill contract (input or output).
+ */
+export interface SkillContractField {
+  /** Description of the field */
+  description: string;
+  /** Value type */
+  type: 'string' | 'number' | 'boolean' | 'enum';
+  /** Options for enum type */
+  options?: string[];
+  /** Default value */
+  default?: Value;
 }

--- a/packages/resolver/src/__tests__/shared-resources.spec.ts
+++ b/packages/resolver/src/__tests__/shared-resources.spec.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveNativeSkills } from '../skills.js';
+import { mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { Program, Block, ObjectContent, TextContent } from '@promptscript/core';
+
+describe('shared resources discovery', () => {
+  let testDir: string;
+  let registryPath: string;
+  let localPath: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `shared-res-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    registryPath = join(testDir, 'registry');
+    localPath = join(testDir, '.promptscript');
+    await mkdir(registryPath, { recursive: true });
+    await mkdir(localPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  const createProgram = (blocks: Block[]): Program => ({
+    type: 'Program',
+    loc: { file: 'test.prs', line: 1, column: 1, offset: 0 },
+    blocks,
+    uses: [],
+    extends: [],
+  });
+
+  const createSkillsBlock = (properties: Record<string, unknown>): Block => ({
+    type: 'Block',
+    name: 'skills',
+    content: {
+      type: 'ObjectContent',
+      properties,
+      loc: { file: 'test.prs', line: 1, column: 1, offset: 0 },
+    } as ObjectContent,
+    loc: { file: 'test.prs', line: 1, column: 1, offset: 0 },
+  });
+
+  it('should discover shared/ directory and include resources with @shared/ prefix', async () => {
+    // Create skill
+    const skillDir = join(localPath, 'skills', 'review');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: review\ndescription: Review code\n---\n\nReview code.'
+    );
+
+    // Create shared directory with resources
+    const sharedDir = join(localPath, 'shared');
+    await mkdir(join(sharedDir, 'templates'), { recursive: true });
+    await writeFile(join(sharedDir, 'templates', 'template.md'), '# Template content');
+    await writeFile(join(sharedDir, 'config.json'), '{"key": "value"}');
+
+    const ast = createProgram([
+      createSkillsBlock({
+        review: { description: 'Review code' },
+      }),
+    ]);
+
+    const result = await resolveNativeSkills(
+      ast,
+      registryPath,
+      join(localPath, 'test.prs'),
+      localPath
+    );
+
+    const skillsBlock = result.blocks.find((b) => b.name === 'skills');
+    const skillsContent = skillsBlock!.content as ObjectContent;
+    const skill = skillsContent.properties['review'] as Record<string, unknown>;
+    const resources = skill['resources'] as Array<{ relativePath: string; content: string }>;
+
+    const sharedResources = resources.filter((r) => r.relativePath.startsWith('@shared/'));
+    expect(sharedResources).toHaveLength(2);
+
+    const paths = sharedResources.map((r) => r.relativePath).sort();
+    expect(paths).toContain('@shared/config.json');
+    expect(paths).toContain('@shared/templates/template.md');
+  });
+
+  it('should merge shared resources with skill-specific resources', async () => {
+    // Create skill with its own resource
+    const skillDir = join(localPath, 'skills', 'review');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: review\ndescription: Review\n---\n\nContent.'
+    );
+    await writeFile(join(skillDir, 'local-data.txt'), 'skill-specific data');
+
+    // Create shared directory
+    const sharedDir = join(localPath, 'shared');
+    await mkdir(sharedDir, { recursive: true });
+    await writeFile(join(sharedDir, 'global-data.txt'), 'shared data');
+
+    const ast = createProgram([
+      createSkillsBlock({
+        review: { description: 'Review' },
+      }),
+    ]);
+
+    const result = await resolveNativeSkills(
+      ast,
+      registryPath,
+      join(localPath, 'test.prs'),
+      localPath
+    );
+
+    const skillsBlock = result.blocks.find((b) => b.name === 'skills');
+    const skillsContent = skillsBlock!.content as ObjectContent;
+    const skill = skillsContent.properties['review'] as Record<string, unknown>;
+    const resources = skill['resources'] as Array<{ relativePath: string; content: string }>;
+
+    const paths = resources.map((r) => r.relativePath);
+    expect(paths).toContain('local-data.txt');
+    expect(paths).toContain('@shared/global-data.txt');
+  });
+
+  it('should not error when shared/ directory is missing', async () => {
+    // Create skill without shared dir
+    const skillDir = join(localPath, 'skills', 'review');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: review\ndescription: Review\n---\n\nContent.'
+    );
+
+    const ast = createProgram([
+      createSkillsBlock({
+        review: { description: 'Review' },
+      }),
+    ]);
+
+    const result = await resolveNativeSkills(
+      ast,
+      registryPath,
+      join(localPath, 'test.prs'),
+      localPath
+    );
+
+    const skillsBlock = result.blocks.find((b) => b.name === 'skills');
+    const skillsContent = skillsBlock!.content as ObjectContent;
+    const skill = skillsContent.properties['review'] as Record<string, unknown>;
+
+    // Should still have content from SKILL.md
+    const content = skill['content'] as TextContent;
+    expect(content.value).toContain('Content.');
+  });
+
+  it('should include shared resources in every skill', async () => {
+    // Create two skills
+    const skillDir1 = join(localPath, 'skills', 'skill-a');
+    const skillDir2 = join(localPath, 'skills', 'skill-b');
+    await mkdir(skillDir1, { recursive: true });
+    await mkdir(skillDir2, { recursive: true });
+    await writeFile(join(skillDir1, 'SKILL.md'), '---\nname: skill-a\n---\n\nSkill A.');
+    await writeFile(join(skillDir2, 'SKILL.md'), '---\nname: skill-b\n---\n\nSkill B.');
+
+    // Create shared directory
+    const sharedDir = join(localPath, 'shared');
+    await mkdir(sharedDir, { recursive: true });
+    await writeFile(join(sharedDir, 'common.txt'), 'common resource');
+
+    const ast = createProgram([
+      createSkillsBlock({
+        'skill-a': { description: 'A' },
+        'skill-b': { description: 'B' },
+      }),
+    ]);
+
+    const result = await resolveNativeSkills(
+      ast,
+      registryPath,
+      join(localPath, 'test.prs'),
+      localPath
+    );
+
+    const skillsBlock = result.blocks.find((b) => b.name === 'skills');
+    const skillsContent = skillsBlock!.content as ObjectContent;
+
+    for (const name of ['skill-a', 'skill-b']) {
+      const skill = skillsContent.properties[name] as Record<string, unknown>;
+      const resources = skill['resources'] as Array<{ relativePath: string; content: string }>;
+      const sharedPaths = resources.filter((r) => r.relativePath.startsWith('@shared/'));
+      expect(sharedPaths).toHaveLength(1);
+      expect(sharedPaths[0]!.relativePath).toBe('@shared/common.txt');
+    }
+  });
+
+  it('should apply size limits to shared resources', async () => {
+    // Create skill
+    const skillDir = join(localPath, 'skills', 'review');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: review\ndescription: Review\n---\n\nContent.'
+    );
+
+    // Create shared directory with empty file (should be discovered)
+    const sharedDir = join(localPath, 'shared');
+    await mkdir(sharedDir, { recursive: true });
+    await writeFile(join(sharedDir, 'small.txt'), 'small');
+
+    const ast = createProgram([
+      createSkillsBlock({
+        review: { description: 'Review' },
+      }),
+    ]);
+
+    const result = await resolveNativeSkills(
+      ast,
+      registryPath,
+      join(localPath, 'test.prs'),
+      localPath
+    );
+
+    const skillsBlock = result.blocks.find((b) => b.name === 'skills');
+    const skillsContent = skillsBlock!.content as ObjectContent;
+    const skill = skillsContent.properties['review'] as Record<string, unknown>;
+    const resources = skill['resources'] as Array<{ relativePath: string; content: string }>;
+
+    const sharedPaths = resources.filter((r) => r.relativePath.startsWith('@shared/'));
+    expect(sharedPaths).toHaveLength(1);
+    expect(sharedPaths[0]!.content).toBe('small');
+  });
+});

--- a/packages/resolver/src/__tests__/skill-contracts.spec.ts
+++ b/packages/resolver/src/__tests__/skill-contracts.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { parseSkillMd } from '../skills.js';
+
+describe('parseSkillMd with inputs/outputs', () => {
+  it('parses inputs from SKILL.md frontmatter', () => {
+    const content = `---
+name: security-scan
+description: Scan for vulnerabilities
+inputs:
+  files:
+    description: List of file paths
+    type: string
+  severity:
+    description: Minimum severity level
+    type: enum
+    options: [low, medium, high]
+    default: medium
+---
+
+Scan the provided files.`;
+
+    const result = parseSkillMd(content);
+    expect(result.inputs).toBeDefined();
+    expect(Object.keys(result.inputs!)).toEqual(['files', 'severity']);
+    expect(result.inputs!['files']!.description).toBe('List of file paths');
+    expect(result.inputs!['files']!.type).toBe('string');
+    expect(result.inputs!['severity']!.type).toBe('enum');
+    expect(result.inputs!['severity']!.options).toEqual(['low', 'medium', 'high']);
+    expect(result.inputs!['severity']!.default).toBe('medium');
+  });
+
+  it('parses outputs from SKILL.md frontmatter', () => {
+    const content = `---
+name: security-scan
+description: Scan
+outputs:
+  report:
+    description: Scan report
+    type: string
+  passed:
+    description: Whether scan passed
+    type: boolean
+    default: true
+---
+
+Scan content.`;
+
+    const result = parseSkillMd(content);
+    expect(result.outputs).toBeDefined();
+    expect(Object.keys(result.outputs!)).toEqual(['report', 'passed']);
+    expect(result.outputs!['report']!.description).toBe('Scan report');
+    expect(result.outputs!['report']!.type).toBe('string');
+    expect(result.outputs!['passed']!.type).toBe('boolean');
+    expect(result.outputs!['passed']!.default).toBe(true);
+  });
+
+  it('parses skill with both inputs, outputs, and params', () => {
+    const content = `---
+name: full-skill
+description: A {{mode}} skill
+params:
+  mode:
+    type: string
+    default: standard
+inputs:
+  files:
+    description: Files to process
+    type: string
+outputs:
+  result:
+    description: Processing result
+    type: string
+---
+
+Process files in {{mode}} mode.`;
+
+    const result = parseSkillMd(content);
+    expect(result.params).toHaveLength(1);
+    expect(result.params![0]!.name).toBe('mode');
+    expect(result.inputs).toBeDefined();
+    expect(result.inputs!['files']!.description).toBe('Files to process');
+    expect(result.outputs).toBeDefined();
+    expect(result.outputs!['result']!.description).toBe('Processing result');
+  });
+
+  it('works without inputs/outputs (backward compat)', () => {
+    const content = `---
+name: simple
+description: Simple skill
+---
+
+Content.`;
+
+    const result = parseSkillMd(content);
+    expect(result.inputs).toBeUndefined();
+    expect(result.outputs).toBeUndefined();
+  });
+
+  it('parses number default values in contract fields', () => {
+    const content = `---
+name: test
+inputs:
+  count:
+    description: Number of items
+    type: number
+    default: 42
+---
+
+Content.`;
+
+    const result = parseSkillMd(content);
+    expect(result.inputs!['count']!.default).toBe(42);
+  });
+});

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -9,6 +9,7 @@ import type {
   TextContent,
   ParamDefinition,
   ParamType,
+  SkillContractField,
 } from '@promptscript/core';
 
 /**
@@ -29,6 +30,8 @@ export interface ParsedSkillMd {
   description?: string;
   content: string;
   params?: ParamDefinition[];
+  inputs?: Record<string, SkillContractField>;
+  outputs?: Record<string, SkillContractField>;
 }
 
 /**
@@ -59,6 +62,8 @@ export function parseSkillMd(content: string): ParsedSkillMd {
   let name: string | undefined;
   let description: string | undefined;
   let params: ParamDefinition[] | undefined;
+  let inputs: Record<string, SkillContractField> | undefined;
+  let outputs: Record<string, SkillContractField> | undefined;
   let bodyContent: string;
 
   if (frontmatterStart >= 0 && frontmatterEnd > frontmatterStart) {
@@ -67,6 +72,8 @@ export function parseSkillMd(content: string): ParsedSkillMd {
     name = parsed.name;
     description = parsed.description;
     params = parsed.params;
+    inputs = parsed.inputs;
+    outputs = parsed.outputs;
 
     bodyContent = lines
       .slice(frontmatterEnd + 1)
@@ -76,7 +83,7 @@ export function parseSkillMd(content: string): ParsedSkillMd {
     bodyContent = content.trim();
   }
 
-  return { name, description, content: bodyContent, params };
+  return { name, description, content: bodyContent, params, inputs, outputs };
 }
 
 /**
@@ -86,10 +93,14 @@ function parseFrontmatterFields(lines: string[]): {
   name?: string;
   description?: string;
   params?: ParamDefinition[];
+  inputs?: Record<string, SkillContractField>;
+  outputs?: Record<string, SkillContractField>;
 } {
   let name: string | undefined;
   let description: string | undefined;
   let params: ParamDefinition[] | undefined;
+  let inputs: Record<string, SkillContractField> | undefined;
+  let outputs: Record<string, SkillContractField> | undefined;
 
   let i = 0;
   while (i < lines.length) {
@@ -117,10 +128,26 @@ function parseFrontmatterFields(lines: string[]): {
       continue;
     }
 
+    if (line.match(/^inputs:\s*$/)) {
+      i++;
+      const result = parseContractFieldsBlock(lines, i);
+      inputs = result.fields;
+      i = result.nextIndex;
+      continue;
+    }
+
+    if (line.match(/^outputs:\s*$/)) {
+      i++;
+      const result = parseContractFieldsBlock(lines, i);
+      outputs = result.fields;
+      i = result.nextIndex;
+      continue;
+    }
+
     i++;
   }
 
-  return { name, description, params };
+  return { name, description, params, inputs, outputs };
 }
 
 /**
@@ -217,6 +244,81 @@ function parseDefaultValue(valueStr: string, paramType: ParamType): Value {
     default:
       return valueStr;
   }
+}
+
+/**
+ * Parse a contract fields block (inputs or outputs) from YAML frontmatter.
+ */
+function parseContractFieldsBlock(
+  lines: string[],
+  startIndex: number
+): { fields: Record<string, SkillContractField>; nextIndex: number } {
+  const fields: Record<string, SkillContractField> = {};
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const line = lines[i] ?? '';
+
+    // A field name line is indented with 2 spaces and ends with ':'
+    const fieldNameMatch = line.match(/^ {2}(\w+):\s*$/);
+    if (!fieldNameMatch) break;
+
+    const fieldName = fieldNameMatch[1]!;
+    i++;
+
+    let description = '';
+    let type: 'string' | 'number' | 'boolean' | 'enum' = 'string';
+    let options: string[] | undefined;
+    let defaultValue: Value | undefined;
+
+    // Read field properties (indented with 4+ spaces)
+    while (i < lines.length) {
+      const propLine = lines[i] ?? '';
+      if (!propLine.match(/^ {4}/)) break;
+      const trimmed = propLine.trim();
+
+      const descMatch = trimmed.match(/^description:\s*(?:"([^"]+)"|'([^']+)'|(.+))$/);
+      if (descMatch) {
+        description = (descMatch[1] ?? descMatch[2] ?? descMatch[3] ?? '').trim();
+        i++;
+        continue;
+      }
+
+      const typeMatch = trimmed.match(/^type:\s*(.+)$/);
+      if (typeMatch) {
+        const typeStr = typeMatch[1]!.trim();
+        if (['string', 'number', 'boolean', 'enum'].includes(typeStr)) {
+          type = typeStr as 'string' | 'number' | 'boolean' | 'enum';
+        }
+        i++;
+        continue;
+      }
+
+      const optionsMatch = trimmed.match(/^options:\s*\[(.+)\]$/);
+      if (optionsMatch) {
+        options = optionsMatch[1]!.split(',').map((o) => o.trim());
+        i++;
+        continue;
+      }
+
+      const defaultMatch = trimmed.match(/^default:\s*(.+)$/);
+      if (defaultMatch) {
+        const pt = parseParamType(type);
+        defaultValue = parseDefaultValue(defaultMatch[1]!.trim(), pt);
+        i++;
+        continue;
+      }
+
+      i++;
+    }
+
+    const field: SkillContractField = { description, type };
+    if (options) field.options = options;
+    if (defaultValue !== undefined) field.default = defaultValue;
+    fields[fieldName] = field;
+  }
+
+  return { fields, nextIndex: i };
 }
 
 /**
@@ -795,6 +897,22 @@ export async function resolveNativeSkills(
     return ast;
   }
 
+  // Discover shared resources from .promptscript/shared/ directory
+  let sharedResources: SkillResource[] = [];
+  if (localPath) {
+    const sharedDir = resolve(localPath, 'shared');
+    if (await fileExists(sharedDir)) {
+      try {
+        sharedResources = await discoverSkillResources(sharedDir, logger);
+        if (sharedResources.length > 0) {
+          logger.verbose(`Discovered ${sharedResources.length} shared resources from ${sharedDir}`);
+        }
+      } catch {
+        logger.verbose(`Failed to discover shared resources from ${sharedDir}`);
+      }
+    }
+  }
+
   // Resolve each skill's SKILL.md content and resources
   for (const [skillName, skillValue] of Object.entries(updatedProperties)) {
     if (typeof skillValue !== 'object' || skillValue === null || Array.isArray(skillValue)) {
@@ -869,9 +987,18 @@ export async function resolveNativeSkills(
         // Discover resource files alongside SKILL.md
         const skillDir = dirname(skillMdPath);
         const resources = await discoverSkillResources(skillDir, logger);
-        if (resources.length > 0) {
-          // Each resource is { relativePath: string, content: string } which satisfies { [key: string]: Value }
-          const resourceValues: Value[] = resources.map((r) => ({
+
+        // Merge skill-specific resources with shared resources
+        const allResources: SkillResource[] = [...resources];
+        for (const shared of sharedResources) {
+          allResources.push({
+            relativePath: `@shared/${shared.relativePath}`,
+            content: shared.content,
+          });
+        }
+
+        if (allResources.length > 0) {
+          const resourceValues: Value[] = allResources.map((r) => ({
             relativePath: r.relativePath,
             content: r.content,
           }));

--- a/packages/validator/src/__tests__/rules-coverage.spec.ts
+++ b/packages/validator/src/__tests__/rules-coverage.spec.ts
@@ -73,7 +73,7 @@ function createTextBlock(name: string, text: string, loc?: SourceLocation): Bloc
 describe('rules/index.ts coverage', () => {
   describe('allRules', () => {
     it('should contain all validation rules', () => {
-      expect(allRules).toHaveLength(15);
+      expect(allRules).toHaveLength(17);
       expect(allRules.map((r) => r.id)).toEqual([
         'PS001',
         'PS002',
@@ -85,6 +85,8 @@ describe('rules/index.ts coverage', () => {
         'PS008',
         'PS009',
         'PS015',
+        'PS016',
+        'PS017',
         'PS010',
         'PS011',
         'PS012',

--- a/packages/validator/src/__tests__/skill-contracts.spec.ts
+++ b/packages/validator/src/__tests__/skill-contracts.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { skillContracts } from '../rules/skill-contracts.js';
+import type { RuleContext, ValidatorConfig, ValidationMessage } from '../types.js';
+import type { Program, Block, ObjectContent, SourceLocation } from '@promptscript/core';
+
+const loc: SourceLocation = { file: 'test.prs', line: 1, column: 1, offset: 0 };
+
+function makeSkillsBlock(properties: Record<string, unknown>): Block {
+  return {
+    type: 'Block',
+    name: 'skills',
+    content: {
+      type: 'ObjectContent',
+      properties: properties as Record<string, import('@promptscript/core').Value>,
+      loc,
+    } as ObjectContent,
+    loc,
+  };
+}
+
+function makeAST(blocks: Block[]): Program {
+  return {
+    type: 'Program',
+    uses: [],
+    blocks,
+    extends: [],
+    loc,
+  };
+}
+
+function runRule(ast: Program): ValidationMessage[] {
+  const messages: ValidationMessage[] = [];
+  const config: ValidatorConfig = {};
+  const ctx: RuleContext = {
+    ast,
+    config,
+    report: (msg) => {
+      messages.push({
+        ...msg,
+        ruleId: skillContracts.id,
+        ruleName: skillContracts.name,
+        severity: skillContracts.defaultSeverity,
+      });
+    },
+  };
+  skillContracts.validate(ctx);
+  return messages;
+}
+
+describe('skill-contracts rule', () => {
+  it('passes for valid contract', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        scan: {
+          description: 'Scan',
+          inputs: {
+            files: { description: 'Files', type: 'string' },
+          },
+          outputs: {
+            report: { description: 'Report', type: 'string' },
+          },
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('warns on params/inputs name collision', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        scan: {
+          description: 'Scan',
+          params: {
+            files: { type: 'string' },
+          },
+          inputs: {
+            files: { description: 'Files', type: 'string' },
+          },
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toContain('files');
+    expect(msgs[0]!.message).toContain('both params and inputs');
+  });
+
+  it('warns on input with invalid type', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        scan: {
+          description: 'Scan',
+          inputs: {
+            files: { description: 'Files', type: 'foobar' },
+          },
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toContain('unknown type');
+    expect(msgs[0]!.message).toContain('foobar');
+  });
+
+  it('warns on output with invalid type', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        scan: {
+          description: 'Scan',
+          outputs: {
+            result: { description: 'Result', type: 'badtype' },
+          },
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toContain('unknown type');
+  });
+
+  it('warns on enum input without options', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        scan: {
+          description: 'Scan',
+          inputs: {
+            level: { description: 'Level', type: 'enum' },
+          },
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toContain('no options');
+  });
+
+  it('passes when no contract defined (backward compat)', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        simple: { description: 'Simple' },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('passes when no skills block exists', () => {
+    const ast = makeAST([]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(0);
+  });
+});

--- a/packages/validator/src/__tests__/skill-dependencies.spec.ts
+++ b/packages/validator/src/__tests__/skill-dependencies.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { skillDependencies } from '../rules/skill-dependencies.js';
+import type { RuleContext, ValidatorConfig, ValidationMessage } from '../types.js';
+import type { Program, Block, ObjectContent, SourceLocation } from '@promptscript/core';
+
+const loc: SourceLocation = { file: 'test.prs', line: 1, column: 1, offset: 0 };
+
+function makeSkillsBlock(properties: Record<string, unknown>): Block {
+  return {
+    type: 'Block',
+    name: 'skills',
+    content: {
+      type: 'ObjectContent',
+      properties: properties as Record<string, import('@promptscript/core').Value>,
+      loc,
+    } as ObjectContent,
+    loc,
+  };
+}
+
+function makeAST(blocks: Block[]): Program {
+  return {
+    type: 'Program',
+    uses: [],
+    blocks,
+    extends: [],
+    loc,
+  };
+}
+
+function runRule(ast: Program): ValidationMessage[] {
+  const messages: ValidationMessage[] = [];
+  const config: ValidatorConfig = {};
+  const ctx: RuleContext = {
+    ast,
+    config,
+    report: (msg) => {
+      messages.push({
+        ...msg,
+        ruleId: skillDependencies.id,
+        ruleName: skillDependencies.name,
+        severity: skillDependencies.defaultSeverity,
+      });
+    },
+  };
+  skillDependencies.validate(ctx);
+  return messages;
+}
+
+describe('skill-dependencies rule', () => {
+  it('passes for valid requires', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        'lint-check': { description: 'Lint code' },
+        'full-review': {
+          description: 'Full review',
+          requires: ['lint-check'],
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('errors on requires nonexistent skill', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        'full-review': {
+          description: 'Full review',
+          requires: ['missing-skill'],
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toContain('missing-skill');
+    expect(msgs[0]!.message).toContain('does not exist');
+  });
+
+  it('errors on self-referencing requires', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        'self-ref': {
+          description: 'Self-referencing',
+          requires: ['self-ref'],
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toContain('self-ref');
+    expect(msgs[0]!.message).toContain('itself');
+  });
+
+  it('errors on circular dependency', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        'skill-a': {
+          description: 'A',
+          requires: ['skill-b'],
+        },
+        'skill-b': {
+          description: 'B',
+          requires: ['skill-a'],
+        },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs.length).toBeGreaterThanOrEqual(1);
+    const hasCircular = msgs.some((m) => m.message.toLowerCase().includes('circular'));
+    expect(hasCircular).toBe(true);
+  });
+
+  it('passes when no requires defined (backward compat)', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        'simple-skill': { description: 'Simple' },
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('passes when no skills block exists', () => {
+    const ast = makeAST([]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('passes for skills with simple string values', () => {
+    const ast = makeAST([
+      makeSkillsBlock({
+        'code-review': 'Review code',
+      }),
+    ]);
+    const msgs = runRule(ast);
+    expect(msgs).toHaveLength(0);
+  });
+});

--- a/packages/validator/src/rules/index.ts
+++ b/packages/validator/src/rules/index.ts
@@ -15,6 +15,8 @@ import { obfuscatedContent } from './obfuscated-content.js';
 import { pathTraversal } from './path-traversal.js';
 import { unicodeSecurity } from './unicode-security.js';
 import { skillParams } from './skill-params.js';
+import { skillDependencies } from './skill-dependencies.js';
+import { skillContracts } from './skill-contracts.js';
 
 // Re-export all rules
 export { requiredMetaId, requiredMetaSyntax } from './required-meta.js';
@@ -61,6 +63,8 @@ export { obfuscatedContent } from './obfuscated-content.js';
 export { pathTraversal, hasPathTraversal } from './path-traversal.js';
 export { unicodeSecurity } from './unicode-security.js';
 export { skillParams } from './skill-params.js';
+export { skillDependencies } from './skill-dependencies.js';
+export { skillContracts } from './skill-contracts.js';
 
 /**
  * All validation rules in the order they should be executed.
@@ -85,6 +89,10 @@ export const allRules: ValidationRule[] = [
   validParams,
   // Skill params (PS015)
   skillParams,
+  // Skill dependencies (PS016)
+  skillDependencies,
+  // Skill contracts (PS017)
+  skillContracts,
   // Security rules (PS010, PS011, PS012, PS013, PS014)
   suspiciousUrls,
   authorityInjection,

--- a/packages/validator/src/rules/skill-contracts.ts
+++ b/packages/validator/src/rules/skill-contracts.ts
@@ -1,0 +1,143 @@
+import type { ValidationRule } from '../types.js';
+import type { Value } from '@promptscript/core';
+
+const AST_NODE_TYPES = new Set([
+  'TextContent',
+  'ObjectContent',
+  'TemplateExpression',
+  'TypeExpression',
+  'Block',
+]);
+
+const VALID_CONTRACT_TYPES = new Set(['string', 'number', 'boolean', 'enum']);
+
+function isAstNode(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const typed = value as Record<string, unknown>;
+  return typeof typed['type'] === 'string' && AST_NODE_TYPES.has(typed['type'] as string);
+}
+
+function validateContractFields(
+  fields: Record<string, unknown>,
+  fieldKind: 'input' | 'output',
+  skillName: string,
+  report: (msg: { message: string; location: unknown; suggestion?: string }) => void,
+  location: unknown
+): void {
+  for (const [fieldName, fieldDef] of Object.entries(fields)) {
+    if (!fieldDef || typeof fieldDef !== 'object' || Array.isArray(fieldDef) || isAstNode(fieldDef))
+      continue;
+
+    const defObj = fieldDef as Record<string, Value>;
+    const typeVal = defObj['type'];
+
+    if (typeof typeVal === 'string' && !VALID_CONTRACT_TYPES.has(typeVal)) {
+      report({
+        message: `Skill "${skillName}": ${fieldKind} "${fieldName}" has unknown type "${typeVal}"`,
+        location,
+        suggestion: `Use one of: ${[...VALID_CONTRACT_TYPES].join(', ')}`,
+      });
+    }
+
+    if (typeVal === 'enum') {
+      const options = defObj['options'];
+      if (!options || !Array.isArray(options) || options.length === 0) {
+        report({
+          message: `Skill "${skillName}": enum ${fieldKind} "${fieldName}" has no options defined`,
+          location,
+          suggestion: 'Add options array for enum field',
+        });
+      }
+    }
+  }
+}
+
+/**
+ * PS017: Skill contract validation
+ *
+ * Validates inputs and outputs definitions in @skills block:
+ * - Field types are valid (string, number, boolean, enum)
+ * - Enum fields have options defined
+ * - No name collisions between params and inputs
+ */
+export const skillContracts: ValidationRule = {
+  id: 'PS017',
+  name: 'skill-contracts',
+  description: 'Validate skill contract definitions (inputs/outputs)',
+  defaultSeverity: 'warning',
+  validate: (ctx) => {
+    const skillsBlock = ctx.ast.blocks.find((b) => b.name === 'skills');
+    if (!skillsBlock || skillsBlock.content.type !== 'ObjectContent') {
+      return;
+    }
+
+    for (const [skillName, skillValue] of Object.entries(skillsBlock.content.properties)) {
+      if (!skillValue || typeof skillValue !== 'object' || Array.isArray(skillValue)) continue;
+      if (isAstNode(skillValue)) continue;
+
+      const skillObj = skillValue as Record<string, Value>;
+
+      // Validate inputs
+      const inputsVal = skillObj['inputs'];
+      if (
+        inputsVal &&
+        typeof inputsVal === 'object' &&
+        !Array.isArray(inputsVal) &&
+        !isAstNode(inputsVal)
+      ) {
+        validateContractFields(
+          inputsVal as Record<string, unknown>,
+          'input',
+          skillName,
+          (msg) =>
+            ctx.report({
+              ...msg,
+              location: skillsBlock.loc,
+            }),
+          skillsBlock.loc
+        );
+
+        // Check name collision between params and inputs
+        const paramsVal = skillObj['params'];
+        if (
+          paramsVal &&
+          typeof paramsVal === 'object' &&
+          !Array.isArray(paramsVal) &&
+          !isAstNode(paramsVal)
+        ) {
+          const paramNames = new Set(Object.keys(paramsVal as Record<string, Value>));
+          for (const inputName of Object.keys(inputsVal as Record<string, Value>)) {
+            if (paramNames.has(inputName)) {
+              ctx.report({
+                message: `Skill "${skillName}": "${inputName}" defined in both params and inputs`,
+                location: skillsBlock.loc,
+                suggestion: 'Use either params or inputs for each field, not both',
+              });
+            }
+          }
+        }
+      }
+
+      // Validate outputs
+      const outputsVal = skillObj['outputs'];
+      if (
+        outputsVal &&
+        typeof outputsVal === 'object' &&
+        !Array.isArray(outputsVal) &&
+        !isAstNode(outputsVal)
+      ) {
+        validateContractFields(
+          outputsVal as Record<string, unknown>,
+          'output',
+          skillName,
+          (msg) =>
+            ctx.report({
+              ...msg,
+              location: skillsBlock.loc,
+            }),
+          skillsBlock.loc
+        );
+      }
+    }
+  },
+};

--- a/packages/validator/src/rules/skill-dependencies.ts
+++ b/packages/validator/src/rules/skill-dependencies.ts
@@ -1,0 +1,110 @@
+import type { ValidationRule } from '../types.js';
+import type { Value } from '@promptscript/core';
+
+const AST_NODE_TYPES = new Set([
+  'TextContent',
+  'ObjectContent',
+  'TemplateExpression',
+  'TypeExpression',
+  'Block',
+]);
+
+function isAstNode(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const typed = value as Record<string, unknown>;
+  return typeof typed['type'] === 'string' && AST_NODE_TYPES.has(typed['type'] as string);
+}
+
+/**
+ * PS016: Skill dependency validation
+ *
+ * Validates the `requires` field in @skills block entries:
+ * - Required skills must exist in the same @skills block
+ * - No self-referencing requires
+ * - No circular dependencies
+ */
+export const skillDependencies: ValidationRule = {
+  id: 'PS016',
+  name: 'skill-dependencies',
+  description: 'Validate skill dependency declarations (requires)',
+  defaultSeverity: 'error',
+  validate: (ctx) => {
+    const skillsBlock = ctx.ast.blocks.find((b) => b.name === 'skills');
+    if (!skillsBlock || skillsBlock.content.type !== 'ObjectContent') {
+      return;
+    }
+
+    const allSkillNames = new Set(Object.keys(skillsBlock.content.properties));
+
+    // Build dependency graph
+    const deps = new Map<string, string[]>();
+
+    for (const [skillName, skillValue] of Object.entries(skillsBlock.content.properties)) {
+      if (!skillValue || typeof skillValue !== 'object' || Array.isArray(skillValue)) continue;
+      if (isAstNode(skillValue)) continue;
+
+      const skillObj = skillValue as Record<string, Value>;
+      const requiresVal = skillObj['requires'];
+      if (!requiresVal || !Array.isArray(requiresVal)) continue;
+
+      const requires = requiresVal.filter((r): r is string => typeof r === 'string');
+
+      // Check self-reference
+      if (requires.includes(skillName)) {
+        ctx.report({
+          message: `Skill "${skillName}" requires itself`,
+          location: skillsBlock.loc,
+          suggestion: 'Remove self-reference from requires array',
+        });
+        continue;
+      }
+
+      deps.set(skillName, requires);
+
+      // Check that required skills exist
+      for (const reqName of requires) {
+        if (!allSkillNames.has(reqName)) {
+          ctx.report({
+            message: `Skill "${skillName}" requires "${reqName}" which does not exist in @skills`,
+            location: skillsBlock.loc,
+            suggestion: `Add "${reqName}" to the @skills block or remove it from requires`,
+          });
+        }
+      }
+    }
+
+    // Detect circular dependencies
+    const visited = new Set<string>();
+    const inStack = new Set<string>();
+
+    function hasCycle(node: string): boolean {
+      if (inStack.has(node)) return true;
+      if (visited.has(node)) return false;
+
+      visited.add(node);
+      inStack.add(node);
+
+      const nodeDeps = deps.get(node) ?? [];
+      for (const dep of nodeDeps) {
+        if (deps.has(dep) && hasCycle(dep)) {
+          return true;
+        }
+      }
+
+      inStack.delete(node);
+      return false;
+    }
+
+    for (const skillName of deps.keys()) {
+      visited.clear();
+      inStack.clear();
+      if (hasCycle(skillName)) {
+        ctx.report({
+          message: `Circular dependency detected involving skill "${skillName}"`,
+          location: skillsBlock.loc,
+          suggestion: 'Break the circular dependency chain in requires',
+        });
+      }
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- **Skill Folders & Shared Resources**: Skills can now share resources via `.promptscript/shared/` directory, discovered automatically with `@shared/` prefix. Skills can declare dependencies via `requires` field.
- **Skill Contracts**: Skills can define `inputs` and `outputs` with typed fields (`string`, `number`, `boolean`, `enum`) parsed from SKILL.md frontmatter.
- **Validation Rules**: PS016 validates skill dependencies (existence, self-reference, circular deps). PS017 validates skill contracts (field types, enum options, param/input collisions).
- **Documentation**: Guides for shared resources and skill contracts, updated local-skills guide.

Consolidates work from PRs #115 (closed) and #116 (merged to wrong base) onto main.

## Changes

| Package | Changes |
|---------|---------|
| `core` | `SkillDefinition` + `SkillContractField` types |
| `resolver` | Shared resources discovery, contract parsing from frontmatter |
| `validator` | PS016 (skill-dependencies), PS017 (skill-contracts) rules |
| `docs` | shared-resources.md, skill-contracts.md, local-skills.md |

## Test plan

- [x] 560 tests passing across all packages
- [x] Full verification pipeline (format, lint, typecheck, test, validate, schema:check, skill:check)
- [ ] CI checks pass