### PR TITLE
fix(cli): bundle server into CLI for global install

### DIFF
--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -36,7 +36,11 @@
           "chokidar",
           "yaml",
           "simple-git",
-          "@promptscript/server"
+          "fastify",
+          "@fastify/cors",
+          "@fastify/websocket",
+          "ws",
+          "fast-glob"
         ],
         "generatePackageJson": false
       }

--- a/packages/cli/src/__tests__/bundle-smoke.spec.ts
+++ b/packages/cli/src/__tests__/bundle-smoke.spec.ts
@@ -102,5 +102,21 @@ describe('bundle smoke tests', () => {
       expect(output).toContain('init');
       expect(output).toContain('registry');
     });
+
+    it('should display serve help without missing module errors', () => {
+      if (!isBundleBuilt()) {
+        console.log('Skipping: bundle not built (run `nx build cli` first)');
+        return;
+      }
+
+      const output = execFileSync('node', [binPath, 'serve', '--help'], {
+        encoding: 'utf-8',
+        cwd: distRoot,
+        timeout: 10000,
+      });
+
+      expect(output).toContain('serve');
+      expect(output).toContain('--port');
+    });
   });
 });

--- a/packages/playground/src/components/ConnectionBar.tsx
+++ b/packages/playground/src/components/ConnectionBar.tsx
@@ -49,9 +49,12 @@ export function ConnectionBar({
         ) : (
           <span className="text-gray-400">{STATUS_LABELS[status]}</span>
         )}
+        <span className="text-gray-600 text-xs ml-auto">
+          Start with: <code className="text-gray-500">prs serve</code>
+        </span>
         <button
           onClick={() => setShowInput(true)}
-          className="ml-auto px-2 py-0.5 text-xs bg-ps-primary hover:bg-ps-secondary rounded text-white cursor-pointer"
+          className="px-2 py-0.5 text-xs bg-ps-primary hover:bg-ps-secondary rounded text-white cursor-pointer"
         >
           {error ? 'Retry' : 'Connect to local server'}
         </button>

--- a/scripts/prepare-cli-publish.mjs
+++ b/scripts/prepare-cli-publish.mjs
@@ -16,6 +16,7 @@ const distRoot = join(root, 'dist/packages/cli');
 
 const pkg = JSON.parse(readFileSync(join(cliRoot, 'package.json'), 'utf-8'));
 const resolverPkg = JSON.parse(readFileSync(join(root, 'packages/resolver/package.json'), 'utf-8'));
+const serverPkg = JSON.parse(readFileSync(join(root, 'packages/server/package.json'), 'utf-8'));
 
 // Fix version detection paths in bundled index.js
 // After bundling, all code is in index.js and package.json is in the same directory.
@@ -42,6 +43,13 @@ const dependencies = Object.fromEntries(
 // Add transitive dependencies that are marked as external in esbuild
 // (simple-git from resolver is CJS and cannot be bundled into ESM)
 dependencies['simple-git'] = resolverPkg.dependencies['simple-git'];
+
+// Server dependencies (server is bundled, but its deps are external)
+dependencies['fastify'] = serverPkg.dependencies['fastify'];
+dependencies['@fastify/cors'] = serverPkg.dependencies['@fastify/cors'];
+dependencies['@fastify/websocket'] = serverPkg.dependencies['@fastify/websocket'];
+dependencies['ws'] = serverPkg.dependencies['ws'];
+dependencies['fast-glob'] = serverPkg.dependencies['fast-glob'];
 
 const publishPkg = {
   name: pkg.name,


### PR DESCRIPTION
## Summary

- `prs serve` crashed with `ERR_MODULE_NOT_FOUND` when CLI was installed globally via npm, because `@promptscript/server` was both `external` in esbuild (not bundled) and `private: true` (not published)
- Server code is now bundled into CLI; its third-party deps (fastify, ws, etc.) are added as runtime dependencies in the published package.json
- Added smoke test for `prs serve --help` to prevent regression
- Added `prs serve` hint in playground ConnectionBar

## Test plan

- [x] `prs serve --help` works from bundled dist CLI
- [x] Published `package.json` includes fastify, ws, fast-glob dependencies
- [x] Full verification pipeline passes (format, lint, typecheck, 582 tests)
- [ ] CI passes