### PR TITLE
fix(compiler): suppress spurious PS4001 warning for same-formatter skill collision

### DIFF
--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -969,7 +969,7 @@ describe('Compiler', () => {
       expect(result.outputs.has('.gemini/skills/promptscript/SKILL.md')).toBe(false);
     });
 
-    it('should warn and skip when collision with user-defined skill at same path', async () => {
+    it('should silently skip auto-injection when same formatter already output the skill', async () => {
       const ast = createTestProgram();
       const formatter: Formatter = {
         ...createMockFormatter('claude', 'CLAUDE.md', '.claude/skills', 'SKILL.md'),
@@ -993,6 +993,36 @@ describe('Compiler', () => {
       expect(result.success).toBe(true);
       const skillOutput = result.outputs.get('.claude/skills/promptscript/SKILL.md');
       expect(skillOutput?.content).toContain('User-defined promptscript skill');
+      // Same formatter → no warning (auto-discovered skill takes precedence silently)
+      expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(false);
+    });
+
+    it('should warn when different formatter already output the skill at same path', async () => {
+      const ast = createTestProgram();
+      // First formatter outputs a skill at the path that the second formatter's
+      // auto-injection would use
+      const formatter1: Formatter = {
+        ...createMockFormatter('custom', 'CUSTOM.md'),
+        format: vi.fn(() => ({
+          path: 'CUSTOM.md',
+          content: '# Custom',
+          additionalFiles: [
+            {
+              path: '.claude/skills/promptscript/SKILL.md',
+              content: '# Custom promptscript skill',
+            },
+          ],
+        })),
+      };
+      const formatter2 = createMockFormatter('claude', 'CLAUDE.md', '.claude/skills', 'SKILL.md');
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = createTestCompiler({ formatters: [formatter1, formatter2], skillContent });
+      const result = await compiler.compile('test.prs');
+      expect(result.success).toBe(true);
+      // Different formatter → should warn
       expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(true);
     });
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -304,13 +304,22 @@ export class Compiler {
         const skillPath = `${skillBasePath}/promptscript/${skillFileName}`;
         const existingOwner = outputPathOwners.get(skillPath);
         if (existingOwner) {
-          formatWarnings.push({
-            ruleId: 'PS4001',
-            ruleName: 'output-path-collision',
-            severity: 'warning',
-            message: `Output path '${skillPath}' is already written by '${existingOwner}'. Skipping auto-injected PromptScript skill for '${formatter.name}'.`,
-            suggestion: `The user-defined skill takes precedence. To use the bundled skill, remove the custom one or rename it.`,
-          });
+          // If the same formatter already output the promptscript skill (e.g. via
+          // auto-discovered @skills block), silently skip — the content is identical.
+          // Only warn when a *different* formatter caused the collision.
+          if (existingOwner !== formatter.name) {
+            formatWarnings.push({
+              ruleId: 'PS4001',
+              ruleName: 'output-path-collision',
+              severity: 'warning',
+              message: `Output path '${skillPath}' is already written by '${existingOwner}'. Skipping auto-injected PromptScript skill for '${formatter.name}'.`,
+              suggestion: `The user-defined skill takes precedence. To use the bundled skill, remove the custom one or rename it.`,
+            });
+          } else {
+            this.logger.debug(
+              `  Skill path '${skillPath}' already output by '${formatter.name}' (auto-discovered). Skipping auto-injection.`
+            );
+          }
           continue;
         }
         outputPathOwners.set(skillPath, `${formatter.name}:promptscript-skill`);


### PR DESCRIPTION
## Summary

- After `prs init` (any target) + `prs compile`, a misleading PS4001 warning appeared:
  `⚠ PS4001: Output path '.factory/skills/promptscript/SKILL.md' is already written by 'factory'. Skipping auto-injected PromptScript skill for 'factory'.`
- Root cause: two mechanisms deliver the same skill to the same path — auto-discovery from `.promptscript/skills/` and the compiler's auto-injection
- Fix: when the collision is with the **same formatter** (it already output the skill from the AST), silently skip. Warnings still fire for cross-formatter collisions.

## Test plan

- [x] Updated existing test to expect no warning for same-formatter collision
- [x] Added new test for cross-formatter collision (still warns)
- [x] Manual verification: `prs init --targets factory` + `prs compile` — no PS4001 warning
- [x] Full verification pipeline passes (format, lint, typecheck, test, validate, schema:check, skill:check)