### PR TITLE
fix(cli): use portable prs path in hooks and detect missing stdin

### DIFF
--- a/packages/cli/src/__tests__/update-check-smoke.spec.ts
+++ b/packages/cli/src/__tests__/update-check-smoke.spec.ts
@@ -29,7 +29,7 @@ describe('update-check smoke tests', () => {
       expect(output).toContain('Update check disabled');
     });
 
-    it('should be listed in help', () => {
+    it('should be listed in help', { timeout: 15000 }, () => {
       const output = runCli(['--help']);
 
       expect(output).toContain('update-check');
@@ -38,17 +38,21 @@ describe('update-check smoke tests', () => {
   });
 
   describe('automatic update check', () => {
-    it('should skip update check when PROMPTSCRIPT_NO_UPDATE_CHECK is set', () => {
-      // Run help command with update check disabled
-      // If this doesn't throw and completes quickly, the env var works
-      const output = runCli(['--help'], {
-        PROMPTSCRIPT_NO_UPDATE_CHECK: '1',
-      });
+    it(
+      'should skip update check when PROMPTSCRIPT_NO_UPDATE_CHECK is set',
+      { timeout: 15000 },
+      () => {
+        // Run help command with update check disabled
+        // If this doesn't throw and completes quickly, the env var works
+        const output = runCli(['--help'], {
+          PROMPTSCRIPT_NO_UPDATE_CHECK: '1',
+        });
 
-      expect(output).toContain('prs');
-    });
+        expect(output).toContain('prs');
+      }
+    );
 
-    it('should skip update check in quiet mode', () => {
+    it('should skip update check in quiet mode', { timeout: 15000 }, () => {
       const output = runCli(['--quiet', '--help']);
 
       // In quiet mode, only essential output should appear

--- a/packages/cli/src/commands/__tests__/hook.spec.ts
+++ b/packages/cli/src/commands/__tests__/hook.spec.ts
@@ -187,4 +187,25 @@ describe('hookCommand', () => {
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unknown action'));
     });
   });
+
+  describe('TTY detection', () => {
+    it('exits 1 with usage message when stdin is a TTY and no internal stdin provided', async () => {
+      const originalIsTTY = process.stdin.isTTY;
+      try {
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+
+        await hookCommand('pre-edit');
+
+        expect(process.exitCode).toBe(1);
+        expect(stderrSpy).toHaveBeenCalledWith(
+          expect.stringContaining('no input received on stdin')
+        );
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', {
+          value: originalIsTTY,
+          configurable: true,
+        });
+      }
+    });
+  });
 });

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -95,6 +95,15 @@ export async function hookCommand(
   action: string,
   internalOpts?: HookInternalOptions
 ): Promise<void> {
+  if (internalOpts?.stdin === undefined && process.stdin.isTTY) {
+    process.exitCode = 1;
+    process.stderr.write(
+      `prs hook: no input received on stdin. This command is intended to be invoked by AI tools, not directly.\n` +
+        `Usage: echo '{"file_path":"..."}' | prs hook ${action}\n`
+    );
+    return;
+  }
+
   const raw = internalOpts?.stdin !== undefined ? internalOpts.stdin : await readStdin();
   const payload = parseInput(raw);
   if (!payload) return;

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -15,20 +15,11 @@ export interface HooksOptions {
 
 /**
  * Resolve the path to the `prs` CLI binary.
- * Prefers the actual script path from process.argv[1] but falls back
- * to the bare command `prs` when the resolved path looks ephemeral
- * (e.g. inside node_modules/.bin or a pnpm store).
+ * Always returns the bare command `prs` so that generated hook
+ * configurations are portable across machines (different Node
+ * version managers, install locations, etc.).
  */
 function resolvePrsPath(): string {
-  const scriptPath = process.argv[1];
-  if (scriptPath && !scriptPath.includes('node_modules/.bin') && !scriptPath.includes('pnpm')) {
-    return scriptPath;
-  }
-  if (scriptPath) {
-    ConsoleOutput.warning(
-      `Detected ephemeral script path (${scriptPath}), using bare "prs" instead`
-    );
-  }
   return 'prs';
 }
 


### PR DESCRIPTION
## Summary
- Always use bare `prs` command in hook configurations instead of absolute paths from `process.argv[1]`, making settings portable across machines
- Detect TTY stdin in `prs hook` commands and show usage message instead of hanging forever when invoked manually without piped input
- Fix flaky `update-check-smoke` test by increasing timeout from 5s to 15s for all smoke tests

## Test plan
- [x] New test: TTY detection exits with error and usage message
- [x] Existing hook tests pass (30/30)
- [x] Full CLI test suite passes (875/875)
- [x] Lint, typecheck, validate, schema:check all pass