### PR TITLE
fix(validator): accept domain-based registry paths in PS006

### DIFF
--- a/packages/validator/src/__tests__/rules-advanced.spec.ts
+++ b/packages/validator/src/__tests__/rules-advanced.spec.ts
@@ -314,6 +314,16 @@ describe('valid-path rule (PS006)', () => {
       expect(isValidPath('./file')).toBe(true);
     });
 
+    it('should accept valid registry (domain-based) paths', () => {
+      expect(isValidPath('github.com/owner/repo')).toBe(true);
+      expect(isValidPath('github.com/owner/repo/path/to/file')).toBe(true);
+      expect(isValidPath('gitlab.com/my-org/my-repo')).toBe(true);
+      expect(isValidPath('github.com/owner/repo@1.0.0')).toBe(true);
+      expect(isValidPath('github.com/owner/repo@^1.0.0')).toBe(true);
+      expect(isValidPath('github.com/owner/repo/sub/path@~2.3.0')).toBe(true);
+      expect(isValidPath('my-registry.example.com/org/pkg')).toBe(true);
+    });
+
     it('should reject invalid paths', () => {
       expect(isValidPath('no-prefix')).toBe(false);
       expect(isValidPath('@')).toBe(false);

--- a/packages/validator/src/rules/valid-path.ts
+++ b/packages/validator/src/rules/valid-path.ts
@@ -7,13 +7,19 @@ const VALID_PATH_PATTERNS = {
   namespace: /^@[a-z][a-z0-9-]*\/[a-z0-9-/]+(@\d+\.\d+\.\d+)?$/i,
   // Relative path: ./path/to/file or ../path/to/file
   relative: /^\.\.?\/[a-z0-9-/.]+$/i,
+  // Registry path: github.com/owner/repo or host.tld/owner/repo/path@version
+  registry: /^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+\/[a-z0-9_./-]+(@[a-z0-9^~./-]+)?$/i,
 };
 
 /**
  * Check if a path reference is valid.
  */
 export function isValidPath(path: string): boolean {
-  return VALID_PATH_PATTERNS.namespace.test(path) || VALID_PATH_PATTERNS.relative.test(path);
+  return (
+    VALID_PATH_PATTERNS.namespace.test(path) ||
+    VALID_PATH_PATTERNS.relative.test(path) ||
+    VALID_PATH_PATTERNS.registry.test(path)
+  );
 }
 
 /**
@@ -32,8 +38,7 @@ export const validPath: ValidationRule = {
         ctx.report({
           message: `Invalid path reference: "${path.raw}"`,
           location: ctx.ast.inherit.loc ?? ctx.ast.loc,
-          suggestion:
-            'Use @namespace/path format for absolute paths or ./relative/path for relative paths',
+          suggestion: 'Use @namespace/path, github.com/owner/repo/path, or ./relative/path',
         });
       }
     }
@@ -44,8 +49,7 @@ export const validPath: ValidationRule = {
         ctx.report({
           message: `Invalid path reference: "${use.path.raw}"`,
           location: use.loc,
-          suggestion:
-            'Use @namespace/path format for absolute paths or ./relative/path for relative paths',
+          suggestion: 'Use @namespace/path, github.com/owner/repo/path, or ./relative/path',
         });
       }
     });


### PR DESCRIPTION
## Summary
- Validator PS006 `isValidPath` rejected Go-module style paths (`github.com/owner/repo/...`) because `VALID_PATH_PATTERNS` only matched `@namespace/path` and `./relative/path`
- The resolver correctly handled these as `__registry__` imports, but the validator blocked them before resolution
- Added `registry` regex pattern accepting domain-based paths with optional semver versions (`@^1.0.0`, `@~2.3.0`)

## Test plan
- [x] 7 new assertions covering domain hosts, subpaths, versions with `^`/`~`, multi-segment hostnames
- [x] 100% line/statement/function coverage on modified file
- [x] Full verification pipeline passes (format, lint, typecheck, test, validate, schema:check, skill:check)