### PR TITLE
fix(compiler): use relative paths in generated file markers

### DIFF
--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -1682,6 +1682,89 @@ describe('addMarkerToOutput edge cases', () => {
   });
 });
 
+describe('marker uses relative source path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should convert absolute entryPath to relative in HTML marker', async () => {
+    const ast = createTestProgram();
+    const formatter = createMockFormatter('claude', 'CLAUDE.md');
+
+    mockResolve.mockResolvedValue(createResolveSuccess(ast));
+    mockValidate.mockReturnValue(createValidationSuccess());
+
+    const compiler = new Compiler({
+      resolver: { registryPath: '/registry' },
+      formatters: [formatter],
+    });
+
+    // Pass an absolute path (simulating what the CLI does)
+    const absolutePath = `${process.cwd()}/.promptscript/project.prs`;
+    const result = await compiler.compile(absolutePath);
+    expect(result.success).toBe(true);
+
+    const output = result.outputs.get('CLAUDE.md');
+    expect(output).toBeDefined();
+    // Should contain relative path, NOT absolute
+    expect(output?.content).toContain('| source: .promptscript/project.prs');
+    expect(output?.content).not.toContain(process.cwd());
+  });
+
+  it('should convert absolute entryPath to relative in YAML marker', async () => {
+    const ast = createTestProgram();
+
+    const formatterWithFrontmatter: Formatter = {
+      name: 'factory',
+      outputPath: '.factory/skills/commit/SKILL.md',
+      description: 'Formatter with frontmatter',
+      defaultConvention: 'markdown',
+      format: vi.fn(() => ({
+        path: '.factory/skills/commit/SKILL.md',
+        content: '---\nname: commit\n---\n\nContent.',
+      })),
+      getSkillBasePath: () => '.factory/skills',
+      getSkillFileName: () => 'SKILL.md',
+    };
+
+    mockResolve.mockResolvedValue(createResolveSuccess(ast));
+    mockValidate.mockReturnValue(createValidationSuccess());
+
+    const compiler = new Compiler({
+      resolver: { registryPath: '/registry' },
+      formatters: [formatterWithFrontmatter],
+    });
+
+    const absolutePath = `${process.cwd()}/.promptscript/project.prs`;
+    const result = await compiler.compile(absolutePath);
+    expect(result.success).toBe(true);
+
+    const output = result.outputs.get('.factory/skills/commit/SKILL.md');
+    expect(output).toBeDefined();
+    expect(output?.content).toContain('| source: .promptscript/project.prs');
+    expect(output?.content).not.toContain(process.cwd());
+  });
+
+  it('should keep already-relative paths unchanged', async () => {
+    const ast = createTestProgram();
+    const formatter = createMockFormatter('claude', 'CLAUDE.md');
+
+    mockResolve.mockResolvedValue(createResolveSuccess(ast));
+    mockValidate.mockReturnValue(createValidationSuccess());
+
+    const compiler = new Compiler({
+      resolver: { registryPath: '/registry' },
+      formatters: [formatter],
+    });
+
+    const result = await compiler.compile('.promptscript/project.prs');
+    expect(result.success).toBe(true);
+
+    const output = result.outputs.get('CLAUDE.md');
+    expect(output?.content).toContain('| source: .promptscript/project.prs');
+  });
+});
+
 describe('compile with non-Error thrown in resolver', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -2,6 +2,7 @@ import { noopLogger, type Logger, type PSError } from '@promptscript/core';
 import { FormatterRegistry } from '@promptscript/formatters';
 import { Resolver, type ResolvedAST } from '@promptscript/resolver';
 import { Validator, type ValidatorConfig, type ValidationMessage } from '@promptscript/validator';
+import { relative, isAbsolute } from 'path';
 import type {
   CompilerOptions,
   CompileResult,
@@ -152,6 +153,10 @@ export class Compiler {
       totalTime: 0,
     };
 
+    // Compute a relative source label for markers so absolute user paths
+    // are never leaked into generated output files.
+    const sourceLabel = isAbsolute(entryPath) ? relative(process.cwd(), entryPath) : entryPath;
+
     // Stage 1: Resolve
     this.logger.verbose('=== Stage 1: Resolve ===');
     const startResolve = Date.now();
@@ -252,7 +257,7 @@ export class Compiler {
         outputPathOwners.set(output.path, formatter.name);
 
         // Add PromptScript marker to all outputs for overwrite detection
-        outputs.set(output.path, addMarkerToOutput(output, entryPath, formatter.name));
+        outputs.set(output.path, addMarkerToOutput(output, sourceLabel, formatter.name));
 
         // Also add any additional files (e.g., .cursor/commands/, .github/prompts/)
         // Recursively collect nested additionalFiles (e.g., skill resource files)
@@ -282,7 +287,7 @@ export class Compiler {
 
             outputs.set(
               additionalFile.path,
-              addMarkerToOutput(additionalFile, entryPath, formatter.name)
+              addMarkerToOutput(additionalFile, sourceLabel, formatter.name)
             );
             if (additionalFile.additionalFiles) {
               queue.push(...additionalFile.additionalFiles);
@@ -335,7 +340,7 @@ export class Compiler {
           path: skillPath,
           content: this.options.skillContent,
         };
-        outputs.set(skillPath, addMarkerToOutput(skillOutput, entryPath, 'promptscript'));
+        outputs.set(skillPath, addMarkerToOutput(skillOutput, sourceLabel, 'promptscript'));
         this.logger.verbose(`  → ${skillPath} (auto-injected promptscript skill)`);
       }
     }


### PR DESCRIPTION
## Summary

- **Bug**: The compiler embedded absolute local file paths (e.g. `/Users/wogu/Work/...`) in generated output file markers, leaking private filesystem info into committed files
- **Impact**: 85+ generated files per project exposed user paths; multi-developer teams got unnecessary git conflicts on every compile (different paths per developer)
- **Fix**: Convert `entryPath` to a `process.cwd()`-relative path before embedding it in HTML/YAML markers

## Before
```
<!-- PromptScript 2026-03-26T20:38:32.445Z | source: /Users/wogu/Work/Comarch/ccms/.promptscript/project.prs | target: github - do not edit -->
```

## After
```
<!-- PromptScript 2026-03-26T20:38:32.445Z | source: .promptscript/project.prs | target: github - do not edit -->
```

## Test plan

- [x] Added test: absolute entryPath is relativized in HTML markers
- [x] Added test: absolute entryPath is relativized in YAML markers  
- [x] Added test: already-relative paths remain unchanged
- [x] All 64 compiler tests pass
- [x] Full verification pipeline passes (format, lint, typecheck, test, validate, schema:check, skill:check)