### PR TITLE
fix(cli): respect --force flag for unchanged files during compilation

### DIFF
--- a/packages/cli/src/__tests__/compile-overwrite.spec.ts
+++ b/packages/cli/src/__tests__/compile-overwrite.spec.ts
@@ -827,6 +827,71 @@ describe('compile command - overwrite protection', () => {
     });
   });
 
+  describe('--force with unchanged files', () => {
+    it('should rewrite PromptScript-generated files even when content is unchanged', async () => {
+      const newContent = `${PROMPTSCRIPT_HTML_MARKER}\n\n# Title\n\nSame content`;
+      const outputs = new Map([['CLAUDE.md', createMockOutput('CLAUDE.md', newContent)]]);
+
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path.includes('project.prs')) return true;
+        if (path.includes('CLAUDE.md')) return true;
+        return false;
+      });
+
+      // Existing file has different timestamp but same body content
+      const existingContent = `<!-- PromptScript 2023-06-15T12:00:00.000Z - do not edit -->\n\n# Title\n\nSame content`;
+      mockReadFile.mockResolvedValue(existingContent);
+
+      await compileCommand({ force: true }, mockServices);
+
+      // --force should rewrite the file even though body content is unchanged
+      expect(mockWriteFile).toHaveBeenCalledWith(resolve('CLAUDE.md'), newContent, 'utf-8');
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('✓'));
+    });
+
+    it('should rewrite non-marker files even when content matches', async () => {
+      const resourceContent = 'import os\nprint("hello")\n';
+      const outputs = new Map([
+        ['skills/myskill/helper.py', createMockOutput('skills/myskill/helper.py', resourceContent)],
+      ]);
+
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path.includes('project.prs')) return true;
+        if (path.includes('helper.py')) return true;
+        return false;
+      });
+
+      // Identical content on disk
+      mockReadFile.mockResolvedValue(resourceContent);
+
+      await compileCommand({ force: true }, mockServices);
+
+      // --force should rewrite the file even though content is identical
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        resolve('skills/myskill/helper.py'),
+        resourceContent,
+        'utf-8'
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('✓'));
+    });
+  });
+
   describe('dry-run with unchanged detection', () => {
     it('should show unchanged status in dry-run mode', async () => {
       const content = `${PROMPTSCRIPT_HTML_MARKER}\n\nSame content`;

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -295,7 +295,7 @@ async function writeOutputs(
       const existingWithoutMarker = stripMarkers(existingContent);
       const newWithoutMarker = stripMarkers(output.content);
 
-      if (existingWithoutMarker === newWithoutMarker) {
+      if (!options.force && existingWithoutMarker === newWithoutMarker) {
         // Content unchanged - skip writing to preserve original timestamp
         ConsoleOutput.unchanged(outputPath);
         result.unchanged.push(outputPath);
@@ -321,7 +321,7 @@ async function writeOutputs(
       // Can't read file — fall through to overwrite protection
     }
 
-    if (contentMatches) {
+    if (!options.force && contentMatches) {
       ConsoleOutput.unchanged(outputPath);
       result.unchanged.push(outputPath);
       continue;


### PR DESCRIPTION
## Summary

- `compile --force` now rewrites all output files regardless of whether body content has changed
- Previously, `--force` was only checked for non-generated files with differing content — PromptScript-generated files with unchanged bodies and non-marker resource files with identical content were always skipped
- This prevented refreshing output files after CLI upgrades that changed header format (e.g., absolute→relative paths in v1.8.3)

Fixes the reported bug where `promptscript compile --force` reported all files as "Unchanged" after upgrading from v1.8.2 to v1.8.3.

## Test plan

- [x] Added test: `--force` rewrites PromptScript-generated files even when body content is unchanged
- [x] Added test: `--force` rewrites non-marker resource files even when content is identical
- [x] All existing tests pass (no regressions)
- [x] Full verification pipeline passes (format, lint, typecheck, test, validate, schema:check, skill:check)