### PR TITLE
fix(resolver): skip SKILL.md in command auto-discovery

### DIFF
--- a/packages/resolver/src/__tests__/auto-discovery.spec.ts
+++ b/packages/resolver/src/__tests__/auto-discovery.spec.ts
@@ -498,6 +498,35 @@ describe('discoverNativeContent', () => {
     }
   });
 
+  it('should not treat root SKILL.md as a command (no phantom /SKILL shortcut)', async () => {
+    // Regression: discoverCommands picked up SKILL.md files because they have
+    // description: in frontmatter and no tools:/model:, creating a phantom
+    // /SKILL command alongside the correct skill entry.
+    const { mkdtemp, writeFile, rm } = await import('fs/promises');
+    const { tmpdir } = await import('os');
+    const tmpDir = await mkdtemp(resolve(tmpdir(), 'prs-autodiscovery-no-phantom-'));
+
+    try {
+      await writeFile(
+        resolve(tmpDir, 'SKILL.md'),
+        '---\nname: my-skill\ndescription: A real skill\n---\n\n# My Skill\n\nDoes things.'
+      );
+
+      const result = await discoverNativeContent(tmpDir);
+      expect(result).not.toBeNull();
+
+      // Should have a skills block
+      const skillsBlock = result!.blocks.find((b) => b.name === 'skills');
+      expect(skillsBlock).toBeDefined();
+
+      // Should NOT have a shortcuts block (no phantom /SKILL command)
+      const shortcutsBlock = result!.blocks.find((b) => b.name === 'shortcuts');
+      expect(shortcutsBlock).toBeUndefined();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('should discover both root-level SKILL.md and subdirectory skills together', async () => {
     // Arrange
     const { mkdtemp, mkdir, writeFile, rm } = await import('fs/promises');

--- a/packages/resolver/src/auto-discovery.ts
+++ b/packages/resolver/src/auto-discovery.ts
@@ -193,6 +193,11 @@ async function discoverCommands(dir: string): Promise<Record<string, Value> | nu
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
 
+    // Skip SKILL.md — these are skill files, not commands.
+    // Without this guard, discoverRootSkill and discoverCommands both
+    // claim the same file, producing a phantom /SKILL command.
+    if (entry.name === 'SKILL.md') continue;
+
     const fullPath = resolve(dir, entry.name);
     try {
       const stat = await lstat(fullPath);


### PR DESCRIPTION
## Summary
- `discoverCommands()` in auto-discovery incorrectly classified `SKILL.md` files as commands because they have `description:` in frontmatter without `tools:` or `model:`
- This produced a phantom `/SKILL` command in `## Commands` section and a ghost `.factory/commands/SKILL.md` file with unrelated skill content
- Fix: skip `SKILL.md` files in `discoverCommands()` — they are already handled by `discoverRootSkill()`

## Root cause
When `@use` resolves external skills (e.g. `github.com/figma/.../figma-implement-design`), `discoverNativeContent()` calls both `discoverRootSkill()` and `discoverCommands()` on the same directory. The `SKILL.md` file was double-classified — once as skill (correct), once as command named `/SKILL` (incorrect).

## Test plan
- [x] Regression test: "should not treat root SKILL.md as a command (no phantom /SKILL shortcut)"
- [x] All existing auto-discovery tests pass (647 tests)