### PR TITLE
fix/skills init compile issues

### DIFF
--- a/apps/vscode/syntaxes/promptscript.tmLanguage.json
+++ b/apps/vscode/syntaxes/promptscript.tmLanguage.json
@@ -20,6 +20,7 @@
     { "include": "#boolean" },
     { "include": "#null" },
     { "include": "#keyword-as" },
+    { "include": "#keyword-into" },
     { "include": "#keyword-type" },
     { "include": "#type-keywords" },
     { "include": "#punctuation" }
@@ -154,6 +155,10 @@
     "keyword-as": {
       "match": "\\bas\\b",
       "name": "keyword.control.as.prs"
+    },
+    "keyword-into": {
+      "match": "\\binto\\b",
+      "name": "keyword.control.into.prs"
     },
     "keyword-type": {
       "match": "\\b(?:range|enum)\\b",

--- a/docs_extensions/promptscript_lexer.py
+++ b/docs_extensions/promptscript_lexer.py
@@ -91,6 +91,8 @@ class PromptScriptLexer(RegexLexer):
             ),
             # 'as' keyword for inline @use aliases
             (r"\b(as)\b", Keyword.Namespace),
+            # 'into' keyword for inline @use output directories
+            (r"\b(into)\b", Keyword.Namespace),
             # Nested blocks
             (r"\{", Punctuation, "#push"),
             (r"\}", Punctuation, "#pop"),

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -90,6 +90,7 @@ program
   .option('-m, --migrate', 'Install migration skill for AI-assisted migration')
   .option('--auto-import', 'Automatically import existing instruction files (static)')
   .option('--backup', 'Create .prs-backup/ before migration')
+  .option('--no-hooks', 'Skip auto-compile hook installation for AI tools')
   .action((opts) => {
     if (opts.migrate) {
       ConsoleOutput.warn('--migrate is deprecated. The migration flow is now built into prs init.');

--- a/packages/cli/src/commands/__tests__/init.spec.ts
+++ b/packages/cli/src/commands/__tests__/init.spec.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { initCommand, formatTargetName } from '../init.js';
 import { type CliServices, type FileSystem, type PromptSystem } from '../../services.js';
 import type { InitOptions } from '../../types.js';
+
+const { hooksCommandMock } = vi.hoisted(() => ({
+  hooksCommandMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../hooks.js', () => ({
+  hooksCommand: hooksCommandMock,
+}));
+
+const { initCommand, formatTargetName } = await import('../init.js');
 
 describe('initCommand', () => {
   let mockFs: FileSystem;
@@ -30,6 +39,9 @@ describe('initCommand', () => {
       prompts: mockPrompts,
       cwd: '/mock/cwd',
     };
+
+    hooksCommandMock.mockClear();
+    hooksCommandMock.mockResolvedValue(undefined);
   });
 
   const defaultOptions: InitOptions = {
@@ -121,6 +133,66 @@ describe('initCommand', () => {
       expect(mockFs.mkdir).toHaveBeenCalledWith('.promptscript/skills/promptscript', {
         recursive: true,
       });
+    });
+  });
+
+  describe('hook installation', () => {
+    it('should install hooks for supported targets by default', async () => {
+      vi.mocked(mockFs.existsSync).mockReturnValue(false);
+      const options: InitOptions = {
+        ...defaultOptions,
+        yes: true,
+        name: 'test-project',
+        targets: ['claude', 'cursor'],
+      };
+
+      await initCommand(options, mockServices);
+
+      expect(hooksCommandMock).toHaveBeenCalledWith('install', 'claude');
+      expect(hooksCommandMock).toHaveBeenCalledWith('install', 'cursor');
+    });
+
+    it('should map github target to copilot hook config', async () => {
+      vi.mocked(mockFs.existsSync).mockReturnValue(false);
+      const options: InitOptions = {
+        ...defaultOptions,
+        yes: true,
+        name: 'test-project',
+        targets: ['github'],
+      };
+
+      await initCommand(options, mockServices);
+
+      expect(hooksCommandMock).toHaveBeenCalledWith('install', 'copilot');
+    });
+
+    it('should skip targets without hook configs silently', async () => {
+      vi.mocked(mockFs.existsSync).mockReturnValue(false);
+      const options: InitOptions = {
+        ...defaultOptions,
+        yes: true,
+        name: 'test-project',
+        targets: ['antigravity'],
+      };
+
+      await initCommand(options, mockServices);
+
+      expect(hooksCommandMock).not.toHaveBeenCalled();
+    });
+
+    it('should not install hooks when --no-hooks flag is set', async () => {
+      vi.mocked(mockFs.existsSync).mockReturnValue(false);
+      const options: InitOptions = {
+        ...defaultOptions,
+        yes: true,
+        name: 'test-project',
+        targets: ['claude'],
+        hooks: false,
+      };
+
+      await initCommand(options, mockServices);
+
+      expect(hooksCommandMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -454,6 +454,27 @@ describe('skillsAddCommand', () => {
     expect(writtenContent).not.toContain('https://');
   });
 
+  it('should reject GitHub URLs that include tree/<ref>', async () => {
+    await skillsAddCommand(
+      'https://github.com/coreyhaines31/marketingskills/tree/main/skills/seo-audit',
+      {}
+    );
+
+    expect(mockFail).toHaveBeenCalledWith(expect.stringContaining('Drop the "tree/main" segment'));
+    expect(mockFail).toHaveBeenCalledWith(
+      expect.stringContaining('github.com/coreyhaines31/marketingskills/skills/seo-audit')
+    );
+    expect(process.exitCode).toBe(1);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('should reject GitHub URLs that include blob/<ref>', async () => {
+    await skillsAddCommand('github.com/foo/bar/blob/main/SKILL.md', {});
+
+    expect(mockFail).toHaveBeenCalledWith(expect.stringContaining('Drop the "blob/main" segment'));
+    expect(process.exitCode).toBe(1);
+  });
+
   it('should accept SSH-style git URLs by normalizing them', async () => {
     mockExistsSync.mockImplementation((p: string) => {
       if (p.includes('entry.prs')) return true;

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -12,6 +12,7 @@ const {
   mockReadFile,
   mockReaddir,
   mockValidateRemoteAccess,
+  mockConsoleWarn,
 } = vi.hoisted(() => {
   const mockStart = vi.fn().mockReturnThis();
   const mockSucceed = vi.fn().mockReturnThis();
@@ -34,6 +35,7 @@ const {
     accessible: true,
     headCommit: 'abc1234567890123456789012345678901234567890'.slice(0, 40),
   });
+  const mockConsoleWarn = vi.fn();
   return {
     mockSucceed,
     mockFail,
@@ -46,6 +48,7 @@ const {
     mockReadFile,
     mockReaddir,
     mockValidateRemoteAccess,
+    mockConsoleWarn,
   };
 });
 
@@ -58,6 +61,8 @@ vi.mock('../../output/console.js', () => ({
     newline: vi.fn(),
     info: vi.fn(),
     dryRun: vi.fn(),
+    warn: mockConsoleWarn,
+    warning: mockConsoleWarn,
   },
 }));
 
@@ -1008,6 +1013,10 @@ describe('skillsUpdateCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.exitCode = undefined;
+    mockValidateRemoteAccess.mockResolvedValue({
+      accessible: true,
+      headCommit: 'abc1234567890123456789012345678901234567890'.slice(0, 40),
+    });
   });
 
   it('should update all md-sourced skills', async () => {
@@ -1033,11 +1042,49 @@ describe('skillsUpdateCommand', () => {
       return false;
     });
     mockReadFile.mockResolvedValue(lockContent);
+    mockValidateRemoteAccess.mockResolvedValue({
+      accessible: true,
+      headCommit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    });
 
     await skillsUpdateCommand(undefined, {});
 
     expect(mockSucceed).toHaveBeenCalledWith('Updated 1 skill(s)');
     expect(mockWriteFile).toHaveBeenCalled();
+    const writeCall = mockWriteFile.mock.calls[0]!;
+    const written = JSON.parse(writeCall[1] as string);
+    const entry = written.dependencies['github.com/org/repo/SKILL.md'];
+    expect(entry.commit).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(entry.integrity).toBe('sha256-xyz');
+    expect(typeof entry.fetchedAt).toBe('string');
+  });
+
+  it('should skip md-sourced skills when the remote is unreachable', async () => {
+    const lockContent = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'github.com/org/repo/SKILL.md': {
+          version: 'v1.0.0',
+          commit: 'abc123',
+          integrity: 'sha256-xyz',
+          source: 'md',
+        },
+      },
+    });
+
+    mockExistsSync.mockImplementation((p: string) => p === 'promptscript.lock');
+    mockReadFile.mockResolvedValue(lockContent);
+    mockValidateRemoteAccess.mockResolvedValueOnce({
+      accessible: false,
+      error: 'remote unreachable',
+    });
+
+    await skillsUpdateCommand(undefined, {});
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockConsoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped github.com/org/repo/SKILL.md')
+    );
   });
 
   it('should warn when no md-sourced skills in lockfile', async () => {

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -1245,4 +1245,29 @@ describe('skillsUpdateCommand', () => {
     expect(mockSucceed).toHaveBeenCalledWith('Updated 1 skill(s)');
     expect(mockWriteFile).toHaveBeenCalled();
   });
+
+  it('should skip a skill when validateRemoteAccess throws an exception', async () => {
+    const lockContent = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'github.com/org/repo/SKILL.md': {
+          version: 'v1.0.0',
+          commit: 'abc123',
+          integrity: 'sha256-xyz',
+          source: 'md',
+        },
+      },
+    });
+
+    mockExistsSync.mockImplementation((p: string) => p === 'promptscript.lock');
+    mockReadFile.mockResolvedValue(lockContent);
+    mockValidateRemoteAccess.mockRejectedValue(new Error('network failure'));
+
+    await skillsUpdateCommand(undefined, {});
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockConsoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped github.com/org/repo/SKILL.md')
+    );
+  });
 });

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -90,7 +90,40 @@ import {
   skillsRemoveCommand,
   skillsListCommand,
   skillsUpdateCommand,
+  normalizeSkillSource,
 } from '../skills.js';
+
+describe('normalizeSkillSource', () => {
+  it('strips https:// prefix', () => {
+    expect(normalizeSkillSource('https://github.com/foo/bar')).toBe('github.com/foo/bar');
+  });
+
+  it('strips http:// prefix', () => {
+    expect(normalizeSkillSource('http://github.com/foo/bar')).toBe('github.com/foo/bar');
+  });
+
+  it('rewrites SSH form to canonical host/owner/repo', () => {
+    expect(normalizeSkillSource('git@github.com:foo/bar.git')).toBe('github.com/foo/bar');
+  });
+
+  it('strips trailing .git suffix', () => {
+    expect(normalizeSkillSource('https://github.com/foo/bar.git')).toBe('github.com/foo/bar');
+  });
+
+  it('preserves sub-path after .git', () => {
+    expect(normalizeSkillSource('https://github.com/foo/bar.git/skills/seo')).toBe(
+      'github.com/foo/bar/skills/seo'
+    );
+  });
+
+  it('strips trailing slashes', () => {
+    expect(normalizeSkillSource('github.com/foo/bar/')).toBe('github.com/foo/bar');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(normalizeSkillSource('   ')).toBe('');
+  });
+});
 
 /** Sample .prs file content with @meta block and @use directives. */
 const SAMPLE_PRS = `@meta {
@@ -395,6 +428,52 @@ describe('skillsAddCommand', () => {
 
     expect(mockFail).toHaveBeenCalledWith(expect.stringContaining('Local paths are not supported'));
     expect(process.exitCode).toBe(1);
+  });
+
+  it('should accept https:// URLs by normalizing them', async () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.includes('entry.prs')) return true;
+      if (p === 'promptscript.lock') return false;
+      return false;
+    });
+    mockReadFile.mockResolvedValue(SAMPLE_PRS);
+
+    await skillsAddCommand('https://github.com/org/repo/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+
+    const writeCalls = mockWriteFile.mock.calls as unknown[][];
+    const prsWriteCall = writeCalls.find(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('entry.prs')
+    );
+    const writtenContent = prsWriteCall![1] as string;
+    // The directive uses the normalized form (no scheme)
+    expect(writtenContent).toContain('@use github.com/org/repo/SKILL.md');
+    expect(writtenContent).not.toContain('https://');
+  });
+
+  it('should accept SSH-style git URLs by normalizing them', async () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.includes('entry.prs')) return true;
+      if (p === 'promptscript.lock') return false;
+      return false;
+    });
+    mockReadFile.mockResolvedValue(SAMPLE_PRS);
+
+    await skillsAddCommand('git@github.com:org/repo.git', {
+      file: 'entry.prs',
+    });
+
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+
+    const writeCalls = mockWriteFile.mock.calls as unknown[][];
+    const lockWriteCall = writeCalls.find((call) => call[0] === 'promptscript.lock');
+    const lockContent = JSON.parse(lockWriteCall![1] as string) as {
+      dependencies: Record<string, unknown>;
+    };
+    expect(Object.keys(lockContent.dependencies)).toContain('github.com/org/repo');
   });
 
   it('should reject local paths starting with ../', async () => {

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -514,6 +514,7 @@ export async function compileCommand(
         skills: resolveUniversalDir(config.universalDir),
         registries: config.registries,
         lockfile,
+        skillTargets: config.skillTargets,
       },
       validator: config.validation,
       formatters: targets,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -40,6 +40,17 @@ import { isGitRepo, createBackup } from '../utils/backup.js';
 import { generateMigrationPrompt } from '../utils/migration-prompt.js';
 import { FormatterRegistry } from '@promptscript/formatters';
 import { findPrettierConfig } from '../prettier/loader.js';
+import { hooksCommand } from './hooks.js';
+import { getToolConfig } from '../hooks/tool-configs/index.js';
+
+/**
+ * Map AI tool target identifiers to hook tool-config names.
+ * Most names match directly; this only lists targets whose hook
+ * config name differs from the formatter target name.
+ */
+const TARGET_TO_HOOK_NAME: Record<string, string> = {
+  github: 'copilot',
+};
 import {
   loadManifest,
   loadManifestFromUrl,
@@ -184,6 +195,34 @@ export async function initCommand(
     // the skill without running `prs compile` first.
     const installedSkillPaths = await installSkillToTargets(config.targets, services);
 
+    // Install auto-compile hooks for the selected targets unless --no-hooks.
+    // commander maps `--no-hooks` to options.hooks === false, so any other value
+    // (undefined, true) keeps the default behaviour of installing hooks.
+    const installedHookTargets: AIToolTarget[] = [];
+    if (options.hooks !== false) {
+      const previousExitCode = process.exitCode;
+      for (const target of config.targets) {
+        const hookName = TARGET_TO_HOOK_NAME[target] ?? target;
+        if (!getToolConfig(hookName)) {
+          // No hook config registered for this target — silently skip
+          continue;
+        }
+        try {
+          await hooksCommand('install', hookName);
+          installedHookTargets.push(target);
+        } catch (error) {
+          ConsoleOutput.warn(
+            `Failed to install ${target} hooks: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+      // hooksCommand sets process.exitCode on its own validation errors,
+      // but we guarded against unknown tools above, so restore the prior code.
+      process.exitCode = previousExitCode;
+    }
+
     spinner.succeed('PromptScript initialized');
 
     // Show summary
@@ -266,9 +305,18 @@ export async function initCommand(
       }
     }
 
-    ConsoleOutput.muted(
-      '\n  Tip: Run prs hooks install to set up auto-compilation hooks for your AI tools.\n'
-    );
+    ConsoleOutput.newline();
+    if (installedHookTargets.length > 0) {
+      ConsoleOutput.info(`Auto-compile hooks installed for: ${installedHookTargets.join(', ')}`);
+    } else if (options.hooks === false) {
+      ConsoleOutput.muted(
+        'Hooks skipped (--no-hooks). Run "prs hooks install" later to enable auto-compilation.'
+      );
+    } else {
+      ConsoleOutput.muted(
+        'Tip: Run prs hooks install to set up auto-compilation hooks for your AI tools.'
+      );
+    }
   } catch (error) {
     if (error instanceof Error && error.name === 'ExitPromptError') {
       // User cancelled with Ctrl+C

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -18,6 +18,36 @@ import { validateRemoteAccess } from '@promptscript/resolver';
 const REMOTE_SOURCE_PATTERN = /^[a-zA-Z0-9][\w.-]*\.[a-zA-Z]{2,}\/.+/;
 
 /**
+ * Normalize a user-provided skill source so the internal representation is
+ * canonical (no scheme, no `.git` suffix, no SSH form, no trailing slash).
+ *
+ * Accepts:
+ *   - `https://github.com/owner/repo/path`
+ *   - `http://github.com/owner/repo/path`
+ *   - `git@github.com:owner/repo.git`
+ *   - `github.com/owner/repo/path`
+ *
+ * Returns the trimmed value when nothing matches, so downstream validation
+ * still produces a deterministic error.
+ */
+export function normalizeSkillSource(input: string): string {
+  let source = input.trim();
+  if (source.length === 0) return source;
+
+  // SSH form: git@host:owner/repo[.git]
+  const sshMatch = source.match(/^git@([^:]+):(.+)$/);
+  if (sshMatch) {
+    source = `${sshMatch[1]}/${sshMatch[2]}`;
+  } else {
+    source = source.replace(/^https?:\/\//i, '');
+  }
+
+  source = source.replace(/\.git(?=\/|$)/i, '');
+  source = source.replace(/\/+$/, '');
+  return source;
+}
+
+/**
  * Directives that appear in the header section of a `.prs` file.
  * The `@use` insertion point is calculated as the line after the last
  * occurrence of any of these directives.
@@ -201,10 +231,18 @@ async function saveLockfile(lockfile: Lockfile): Promise<void> {
  * 3. Inserts `@use <source>` directive
  * 4. Updates promptscript.lock with `source: 'md'` entry
  */
-export async function skillsAddCommand(source: string, options: SkillsAddOptions): Promise<void> {
+export async function skillsAddCommand(
+  rawSource: string,
+  options: SkillsAddOptions
+): Promise<void> {
   const spinner = createSpinner('Adding skill...').start();
 
   try {
+    // Normalize the user-provided source before validating so we treat
+    // `https://github.com/foo/bar`, `git@github.com:foo/bar.git`, and
+    // `github.com/foo/bar` as the same logical identifier.
+    const source = normalizeSkillSource(rawSource);
+
     // Validate source
     const sourceError = validateRemoteSource(source);
     if (sourceError) {

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -81,6 +81,19 @@ function validateRemoteSource(source: string): string | undefined {
   if (!REMOTE_SOURCE_PATTERN.test(source)) {
     return `Invalid source: "${source}". Expected a remote path (e.g., github.com/owner/repo/path/SKILL.md)`;
   }
+
+  // Reject GitHub-style web URLs that include a tree/<ref> or blob/<ref>
+  // segment immediately after host/owner/repo. These come from copying
+  // a URL out of a browser and they are not valid repository paths.
+  const parts = source.split('/');
+  if (parts.length > 4 && (parts[3] === 'tree' || parts[3] === 'blob')) {
+    const kind = parts[3];
+    const ref = parts[4] ?? '<ref>';
+    const stripped = [...parts.slice(0, 3), ...parts.slice(5)].join('/').replace(/\/$/, '');
+    const example = stripped.length > 0 ? stripped : parts.slice(0, 3).join('/');
+    return `Invalid source: "${source}". Drop the "${kind}/${ref}" segment copied from the GitHub web UI (use "${example}" instead).`;
+  }
+
   return undefined;
 }
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -479,31 +479,68 @@ export async function skillsUpdateCommand(
       return;
     }
 
-    // Reset pins to trigger re-resolution
-    for (const [key] of toUpdate) {
-      lockfile.dependencies[key] = {
-        version: 'latest',
-        commit: '0000000000000000000000000000000000000000',
-        integrity: 'sha256-pending',
-        source: 'md',
-      };
+    // Fetch the latest HEAD commit for each entry by reaching out to the
+    // remote with validateRemoteAccess. The integrity field is preserved from
+    // the previous pin (full re-hash happens during the next compile).
+    const fetchedAt = new Date().toISOString();
+    const updated: string[] = [];
+    const skipped: Array<{ key: string; reason: string }> = [];
+
+    for (const [key, dep] of toUpdate) {
+      const repoUrl = extractRepoUrl(key);
+      try {
+        const validation = await validateRemoteAccess(repoUrl);
+        if (!validation.accessible || !validation.headCommit) {
+          skipped.push({
+            key,
+            reason: validation.error ?? 'remote unreachable',
+          });
+          continue;
+        }
+        lockfile.dependencies[key] = {
+          version: dep.version ?? 'latest',
+          commit: validation.headCommit,
+          integrity: dep.integrity ?? 'sha256-pending',
+          source: 'md',
+          fetchedAt,
+        };
+        updated.push(key);
+      } catch (err) {
+        skipped.push({
+          key,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     if (options.dryRun) {
       spinner.succeed('Dry run — lockfile not written');
       ConsoleOutput.newline();
-      for (const [key] of toUpdate) {
+      for (const key of updated) {
         ConsoleOutput.dryRun(`Would update: ${key}`);
+      }
+      for (const { key, reason } of skipped) {
+        ConsoleOutput.warn(`Would skip ${key}: ${reason}`);
       }
       return;
     }
 
-    await saveLockfile(lockfile);
+    if (updated.length > 0) {
+      await saveLockfile(lockfile);
+    }
 
-    spinner.succeed(`Updated ${toUpdate.length} skill(s)`);
-    ConsoleOutput.newline();
-    for (const [key] of toUpdate) {
-      ConsoleOutput.success(key);
+    if (updated.length > 0) {
+      spinner.succeed(`Updated ${updated.length} skill(s)`);
+      ConsoleOutput.newline();
+      for (const key of updated) {
+        ConsoleOutput.success(key);
+      }
+    } else {
+      spinner.warn('No skills were updated');
+    }
+
+    for (const { key, reason } of skipped) {
+      ConsoleOutput.warn(`Skipped ${key}: ${reason}`);
     }
   } catch (error) {
     spinner.fail('Failed to update skills');

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -43,7 +43,9 @@ export function normalizeSkillSource(input: string): string {
   }
 
   source = source.replace(/\.git(?=\/|$)/i, '');
-  source = source.replace(/\/+$/, '');
+  while (source.endsWith('/')) {
+    source = source.slice(0, -1);
+  }
   return source;
 }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -24,6 +24,11 @@ export interface InitOptions {
   autoImport?: boolean;
   /** Create backup before migration */
   backup?: boolean;
+  /**
+   * Install auto-compile hooks for selected targets.
+   * Defaults to `true`; pass `--no-hooks` on the CLI to opt out.
+   */
+  hooks?: boolean;
   /** Internal: force migrate flow (used by prs migrate) */
   _forceMigrate?: boolean;
   /** Internal: force LLM flow (used by prs migrate --llm) */

--- a/packages/core/src/types/ast.ts
+++ b/packages/core/src/types/ast.ts
@@ -169,6 +169,12 @@ export interface UseDeclaration extends BaseNode {
   alias?: string;
   /** Template parameters (for parameterized imports) */
   params?: ParamArgument[];
+  /**
+   * Optional inline output directory (e.g. `@use foo into skills/seo`).
+   * Stored as a forward-slash relative path. When present this overrides
+   * the global `skillTargets` configuration for this import only.
+   */
+  outputDir?: string;
 }
 
 /**
@@ -183,6 +189,8 @@ export interface InlineUseDeclaration {
   params?: ParamArgument[];
   /** Alias for the phase */
   alias?: string;
+  /** Optional inline output directory (forward-slash relative). */
+  outputDir?: string;
   /** Source location */
   loc: SourceLocation;
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -229,6 +229,20 @@ export interface PromptScriptConfig {
   };
 
   /**
+   * Per-source output directories for `@use` imports.
+   *
+   * Maps a `@use` source string (matching the path's `raw` value) to a
+   * relative directory underneath each target's skill output location.
+   * An inline `into "<path>"` on the same `@use` declaration overrides
+   * the configured value.
+   *
+   * @example
+   * skillTargets:
+   *   "github.com/coreyhaines31/marketingskills/skills/seo-audit": "skills/seo-audit"
+   */
+  skillTargets?: Record<string, string>;
+
+  /**
    * Formatting configuration.
    * Controls how generated markdown files are formatted.
    * @example

--- a/packages/formatters/src/__tests__/claude.spec.ts
+++ b/packages/formatters/src/__tests__/claude.spec.ts
@@ -1813,4 +1813,34 @@ describe('ClaudeFormatter', () => {
       expect(formatter.getSkillFileName()).toBe('SKILL.md');
     });
   });
+
+  describe('outputDir override for skills', () => {
+    it('writes skill file to custom outputDir path', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                deploy: {
+                  description: 'Deploy skill',
+                  content: 'Deploy instructions',
+                  __outputDir: 'skills/custom/deploy',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      expect(skillFile?.path).toBe('.claude/skills/custom/deploy/SKILL.md');
+    });
+  });
 });

--- a/packages/formatters/src/__tests__/factory.spec.ts
+++ b/packages/formatters/src/__tests__/factory.spec.ts
@@ -2178,4 +2178,62 @@ describe('FactoryFormatter', () => {
       expect(droidFile?.content).toContain('specReasoningEffort: high');
     });
   });
+
+  describe('outputDir override for @use ... into', () => {
+    it('honors __outputDir when generating the skill file', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                'seo-audit': {
+                  description: 'SEO audit skill',
+                  content: 'Audit content',
+                  __outputDir: 'skills/marketing/seo-audit',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'multifile' });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      expect(skillFile?.path).toBe('.factory/skills/marketing/seo-audit/SKILL.md');
+    });
+
+    it('strips traversal segments from __outputDir', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                s: {
+                  description: 'd',
+                  content: 'c',
+                  __outputDir: '../../etc',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'multifile' });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      expect(skillFile?.path).toBe('.factory/etc/SKILL.md');
+    });
+  });
 });

--- a/packages/formatters/src/__tests__/github.spec.ts
+++ b/packages/formatters/src/__tests__/github.spec.ts
@@ -2302,4 +2302,34 @@ describe('GitHubFormatter', () => {
       expect(formatter.getSkillFileName()).toBe('SKILL.md');
     });
   });
+
+  describe('outputDir override for skills', () => {
+    it('writes skill file to custom outputDir path', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                deploy: {
+                  description: 'Deploy skill',
+                  content: 'Deploy instructions',
+                  __outputDir: 'skills/custom/deploy',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      expect(skillFile?.path).toBe('.github/skills/custom/deploy/SKILL.md');
+    });
+  });
 });

--- a/packages/formatters/src/__tests__/opencode.spec.ts
+++ b/packages/formatters/src/__tests__/opencode.spec.ts
@@ -926,4 +926,34 @@ describe('OpenCodeFormatter', () => {
       expect(result.content).toContain('</project>');
     });
   });
+
+  describe('outputDir override for skills', () => {
+    it('writes skill file to custom outputDir path', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                deploy: {
+                  description: 'Deploy skill',
+                  content: 'Deploy instructions',
+                  __outputDir: 'skills/custom/deploy',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { version: 'full' });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      expect(skillFile?.path).toBe('.opencode/skills/custom/deploy/SKILL.md');
+    });
+  });
 });

--- a/packages/formatters/src/base-formatter.ts
+++ b/packages/formatters/src/base-formatter.ts
@@ -477,6 +477,22 @@ export abstract class BaseFormatter implements Formatter {
   }
 
   /**
+   * Normalize a user-provided output directory (from `@use ... into "<path>"`
+   * or `skillTargets` config) to a safe forward-slash relative path. Rejects
+   * `..`, `.` and leading slashes so the result can be appended to a target's
+   * dot-directory without escaping it.
+   */
+  protected normalizeOutputDir(dir: string): string {
+    return dir
+      .replace(/\\/g, '/')
+      .replace(/^\/+/, '')
+      .replace(/\/+$/g, '')
+      .split('/')
+      .filter((segment) => segment.length > 0 && segment !== '.' && segment !== '..')
+      .join('/');
+  }
+
+  /**
    * Filter resource files to only include safe paths.
    * Rejects paths with traversal, absolute paths, and unsafe names.
    */

--- a/packages/formatters/src/formatters/claude.ts
+++ b/packages/formatters/src/formatters/claude.ts
@@ -69,6 +69,8 @@ interface ClaudeSkillConfig {
   resources?: Array<{ relativePath: string; content: string }>;
   /** Raw frontmatter from source SKILL.md for pass-through */
   rawFrontmatter?: string;
+  /** Optional relative output directory underneath .claude/ */
+  outputDir?: string;
 }
 
 /**
@@ -537,6 +539,7 @@ export class ClaudeFormatter extends BaseFormatter {
               : undefined,
           rawFrontmatter:
             typeof obj['__rawFrontmatter'] === 'string' ? obj['__rawFrontmatter'] : undefined,
+          outputDir: typeof obj['__outputDir'] === 'string' ? obj['__outputDir'] : undefined,
         });
       }
     }
@@ -594,7 +597,9 @@ export class ClaudeFormatter extends BaseFormatter {
       lines.push(normalizedContent);
     }
 
-    const skillDirPath = `.claude/skills/${config.name}`;
+    const skillDirPath = config.outputDir
+      ? `.claude/${this.normalizeOutputDir(config.outputDir)}`
+      : `.claude/skills/${config.name}`;
     const resourceFiles = this.sanitizeResourceFiles(config.resources, skillDirPath);
 
     const resourcesWithProvenance = resourceFiles.map((f) => {

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -276,6 +276,7 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
               : undefined,
           rawFrontmatter:
             typeof obj['__rawFrontmatter'] === 'string' ? obj['__rawFrontmatter'] : undefined,
+          outputDir: typeof obj['__outputDir'] === 'string' ? obj['__outputDir'] : undefined,
         });
       }
     }
@@ -326,7 +327,9 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
       lines.push(dedentedContent);
     }
 
-    const skillDirPath = `.factory/skills/${factoryConfig.name}`;
+    const skillDirPath = factoryConfig.outputDir
+      ? `.factory/${this.normalizeOutputDir(factoryConfig.outputDir)}`
+      : `.factory/skills/${factoryConfig.name}`;
     const resourceFiles = this.sanitizeResourceFiles(factoryConfig.resources, skillDirPath);
 
     const resourcesWithProvenance = resourceFiles.map((f) => {

--- a/packages/formatters/src/formatters/github.ts
+++ b/packages/formatters/src/formatters/github.ts
@@ -79,6 +79,8 @@ interface SkillConfig {
   resources?: Array<{ relativePath: string; content: string }>;
   /** Raw frontmatter from source SKILL.md for pass-through */
   rawFrontmatter?: string;
+  /** Optional relative output directory underneath .github/ */
+  outputDir?: string;
 }
 
 /**
@@ -590,6 +592,7 @@ export class GitHubFormatter extends BaseFormatter {
               : undefined,
           rawFrontmatter:
             typeof obj['__rawFrontmatter'] === 'string' ? obj['__rawFrontmatter'] : undefined,
+          outputDir: typeof obj['__outputDir'] === 'string' ? obj['__outputDir'] : undefined,
         });
       }
     }
@@ -632,7 +635,9 @@ export class GitHubFormatter extends BaseFormatter {
 
     // Strip leading slashes from name for clean file paths
     const cleanName = config.name.replace(/^\/+/, '');
-    const skillDirPath = `.github/skills/${cleanName}`;
+    const skillDirPath = config.outputDir
+      ? `.github/${this.normalizeOutputDir(config.outputDir)}`
+      : `.github/skills/${cleanName}`;
     const resourceFiles = this.sanitizeResourceFiles(config.resources, skillDirPath);
 
     const resourcesWithProvenance = resourceFiles.map((f) => {

--- a/packages/formatters/src/markdown-instruction-formatter.ts
+++ b/packages/formatters/src/markdown-instruction-formatter.ts
@@ -35,6 +35,11 @@ export interface MarkdownSkillConfig {
   rawFrontmatter?: string;
   /** Pre-extracted examples from the skill's nested examples property */
   examples?: Array<{ name: string; input: string; output: string; description?: string }>;
+  /**
+   * Relative output directory underneath the target's skill folder.
+   * Overrides the default `<dotDir>/skills/<name>` layout when provided.
+   */
+  outputDir?: string;
 }
 
 /**
@@ -377,6 +382,7 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
           rawFrontmatter:
             typeof obj['__rawFrontmatter'] === 'string' ? obj['__rawFrontmatter'] : undefined,
           examples: this.extractSkillExamples(obj),
+          outputDir: typeof obj['__outputDir'] === 'string' ? obj['__outputDir'] : undefined,
         });
       }
     }
@@ -429,7 +435,9 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
       }
     }
 
-    const skillDirPath = `${this.config.dotDir}/skills/${config.name}`;
+    const skillDirPath = config.outputDir
+      ? `${this.config.dotDir}/${this.normalizeOutputDir(config.outputDir)}`
+      : `${this.config.dotDir}/skills/${config.name}`;
     const resourceFiles = this.sanitizeResourceFiles(config.resources, skillDirPath);
 
     return {

--- a/packages/parser/src/__tests__/inline-use.spec.ts
+++ b/packages/parser/src/__tests__/inline-use.spec.ts
@@ -353,4 +353,39 @@ describe('inline @use in block content', () => {
       }
     });
   });
+
+  describe('@use ... into <path> output directory', () => {
+    it('parses outputDir on a top-level @use', () => {
+      const source = `@use github.com/foo/bar as seo into "skills/seo-audit"`;
+      const result = parse(source);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.ast?.uses).toHaveLength(1);
+      const use = result.ast!.uses[0]!;
+      expect(use.alias).toBe('seo');
+      expect(use.outputDir).toBe('skills/seo-audit');
+    });
+
+    it('parses outputDir on an inline @use', () => {
+      const source = `
+        @skills {
+          @use ./shared/ops into "skills/ops"
+        }
+      `;
+      const result = parse(source);
+
+      expect(result.errors).toHaveLength(0);
+      const skills = result.ast?.blocks.find((b) => b.name === 'skills');
+      if (skills?.content.type === 'ObjectContent') {
+        expect(skills.content.inlineUses).toHaveLength(1);
+        expect(skills.content.inlineUses![0]!.outputDir).toBe('skills/ops');
+      }
+    });
+
+    it('leaves outputDir undefined when not provided', () => {
+      const source = `@use ./foo`;
+      const result = parse(source);
+      expect(result.ast?.uses[0]!.outputDir).toBeUndefined();
+    });
+  });
 });

--- a/packages/parser/src/grammar/parser.ts
+++ b/packages/parser/src/grammar/parser.ts
@@ -6,6 +6,7 @@ import {
   Inherit,
   Use,
   As,
+  Into,
   Extend,
   True,
   False,
@@ -96,7 +97,7 @@ export class PromptScriptParser extends CstParser {
 
   /**
    * useDecl
-   *   : '@' 'use' pathRef paramCallList? ('as' Identifier)?
+   *   : '@' 'use' pathRef paramCallList? ('as' Identifier)? ('into' StringLiteral)?
    */
   private useDecl = this.RULE('useDecl', () => {
     this.CONSUME(At);
@@ -106,6 +107,10 @@ export class PromptScriptParser extends CstParser {
     this.OPTION2(() => {
       this.CONSUME(As);
       this.CONSUME(Identifier);
+    });
+    this.OPTION3(() => {
+      this.CONSUME(Into);
+      this.CONSUME(StringLiteral);
     });
   });
 
@@ -151,7 +156,7 @@ export class PromptScriptParser extends CstParser {
 
   /**
    * inlineUse
-   *   : '@' 'use' pathRef paramCallList? ('as' Identifier)?
+   *   : '@' 'use' pathRef paramCallList? ('as' Identifier)? ('into' StringLiteral)?
    *
    * Same syntax as top-level useDecl but allowed within block content.
    */
@@ -163,6 +168,10 @@ export class PromptScriptParser extends CstParser {
     this.OPTION2(() => {
       this.CONSUME(As);
       this.CONSUME(Identifier);
+    });
+    this.OPTION3(() => {
+      this.CONSUME(Into);
+      this.CONSUME(StringLiteral);
     });
   });
 

--- a/packages/parser/src/grammar/visitor.ts
+++ b/packages/parser/src/grammar/visitor.ts
@@ -54,6 +54,7 @@ interface UseDeclCstCtx {
   pathRef: CstNode[];
   paramCallList?: CstNode[];
   Identifier?: IToken[];
+  StringLiteral?: IToken[];
 }
 
 interface InlineUseCstCtx {
@@ -61,6 +62,7 @@ interface InlineUseCstCtx {
   pathRef: CstNode[];
   paramCallList?: CstNode[];
   Identifier?: IToken[];
+  StringLiteral?: IToken[];
 }
 
 interface BlockCstCtx {
@@ -349,6 +351,10 @@ class PromptScriptVisitor extends BaseVisitor {
       use.alias = ctx.Identifier[0]!.image;
     }
 
+    if (ctx.StringLiteral) {
+      use.outputDir = this.parseStringLiteral(ctx.StringLiteral[0]!.image);
+    }
+
     return use;
   }
 
@@ -368,6 +374,10 @@ class PromptScriptVisitor extends BaseVisitor {
 
     if (ctx.Identifier) {
       decl.alias = ctx.Identifier[0]!.image;
+    }
+
+    if (ctx.StringLiteral) {
+      decl.outputDir = this.parseStringLiteral(ctx.StringLiteral[0]!.image);
     }
 
     return decl;

--- a/packages/parser/src/lexer/tokens.ts
+++ b/packages/parser/src/lexer/tokens.ts
@@ -89,6 +89,12 @@ export const As = createToken({
   longer_alt: Identifier,
 });
 
+export const Into = createToken({
+  name: 'Into',
+  pattern: /into/,
+  longer_alt: Identifier,
+});
+
 export const Extend = createToken({
   name: 'Extend',
   pattern: /extend/,
@@ -276,6 +282,7 @@ export const allTokens: TokenType[] = [
   Inherit,
   Use,
   As,
+  Into,
   Extend,
   True,
   False,

--- a/packages/playground/src/utils/prs-language.ts
+++ b/packages/playground/src/utils/prs-language.ts
@@ -13,7 +13,7 @@ export const prsLanguageDefinition: Monaco.languages.IMonarchLanguage = {
   defaultToken: '',
   tokenPostfix: '.prs',
 
-  keywords: ['true', 'false', 'null', 'string', 'number', 'boolean', 'enum'],
+  keywords: ['true', 'false', 'null', 'string', 'number', 'boolean', 'enum', 'as', 'into'],
 
   // Directive names
   directives: [

--- a/packages/resolver/src/__tests__/auto-discovery.spec.ts
+++ b/packages/resolver/src/__tests__/auto-discovery.spec.ts
@@ -573,4 +573,65 @@ describe('discoverNativeContent', () => {
       await rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('discovers agents inside an agents/ wrapper directory', async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import('fs/promises');
+    const { tmpdir } = await import('os');
+    const tmpDir = await mkdtemp(resolve(tmpdir(), 'prs-agents-wrapper-'));
+
+    try {
+      const agentsDir = resolve(tmpDir, 'agents');
+      await mkdir(agentsDir, { recursive: true });
+      await writeFile(
+        resolve(agentsDir, 'deploy.md'),
+        '---\nmodel: opus\ndescription: Deploy agent\n---\nDeploy body.'
+      );
+
+      const result = await discoverNativeContent(tmpDir);
+      expect(result).not.toBeNull();
+      const agentsBlock = result!.blocks.find((b) => b.name === 'agents');
+      expect(agentsBlock).toBeDefined();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('discovers commands inside a commands/ wrapper directory', async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import('fs/promises');
+    const { tmpdir } = await import('os');
+    const tmpDir = await mkdtemp(resolve(tmpdir(), 'prs-commands-wrapper-'));
+
+    try {
+      const commandsDir = resolve(tmpDir, 'commands');
+      await mkdir(commandsDir, { recursive: true });
+      await writeFile(
+        resolve(commandsDir, 'review.md'),
+        '---\ndescription: Review command\n---\nReview body.'
+      );
+
+      const result = await discoverNativeContent(tmpDir);
+      expect(result).not.toBeNull();
+      const shortcutsBlock = result!.blocks.find((b) => b.name === 'shortcuts');
+      expect(shortcutsBlock).toBeDefined();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null from safeIsDirectory for a non-existent path', async () => {
+    const { mkdtemp, writeFile, rm } = await import('fs/promises');
+    const { tmpdir } = await import('os');
+    const tmpDir = await mkdtemp(resolve(tmpdir(), 'prs-safedir-'));
+
+    try {
+      // Create a file named "skills" (not a directory) in the root
+      await writeFile(resolve(tmpDir, 'skills'), 'not a directory');
+
+      // No actual skill content — result should be null
+      const result = await discoverNativeContent(tmpDir);
+      expect(result).toBeNull();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/resolver/src/__tests__/imports.spec.ts
+++ b/packages/resolver/src/__tests__/imports.spec.ts
@@ -491,6 +491,31 @@ describe('imports', () => {
 
       expect(source).toEqual(sourceSnapshot);
     });
+
+    it('handles non-object skill values by replacing them with __outputDir wrapper', () => {
+      // If a skill property is a primitive (unlikely but defensive),
+      // the else branch wraps it with { __outputDir: outputDir }.
+      const target = createProgram();
+      const source = createProgram({
+        blocks: [
+          createBlock(
+            'skills',
+            createObjectContent({
+              // Skill value is a string primitive, not an object
+              'my-skill': 'just a string' as unknown as Record<string, Value>,
+            })
+          ),
+        ],
+      });
+      const use = createUseDeclaration('github.com/foo/m', undefined, 'skills/m');
+
+      const result = resolveUses(target, use, source);
+
+      const skills = result.blocks.find((b) => b.name === 'skills');
+      const props = (skills?.content as ObjectContent).properties;
+      const wrapper = props['my-skill'] as Record<string, Value>;
+      expect(wrapper['__outputDir']).toBe('skills/m');
+    });
   });
 
   describe('isImportMarker', () => {

--- a/packages/resolver/src/__tests__/imports.spec.ts
+++ b/packages/resolver/src/__tests__/imports.spec.ts
@@ -66,7 +66,7 @@ const createMixedContent = (
   loc: createLoc(),
 });
 
-const createUseDeclaration = (path: string, alias?: string) => ({
+const createUseDeclaration = (path: string, alias?: string, outputDir?: string) => ({
   type: 'UseDeclaration' as const,
   path: {
     type: 'PathReference' as const,
@@ -76,6 +76,7 @@ const createUseDeclaration = (path: string, alias?: string) => ({
     loc: createLoc(),
   },
   alias,
+  outputDir,
   loc: createLoc(),
 });
 
@@ -444,6 +445,51 @@ describe('imports', () => {
 
       expect(content.properties['__source']).toBe('@company/guards');
       expect(content.properties['__blocks']).toEqual(['rules']);
+    });
+
+    it('attaches __outputDir to every skill brought in by @use ... into', () => {
+      const target = createProgram();
+      const source = createProgram({
+        blocks: [
+          createBlock(
+            'skills',
+            createObjectContent({
+              seo: { description: 'SEO audit' },
+              social: { description: 'Social skills' },
+            })
+          ),
+        ],
+      });
+      const use = createUseDeclaration('github.com/foo/marketing', undefined, 'skills/marketing');
+
+      const result = resolveUses(target, use, source);
+
+      const skills = result.blocks.find((b) => b.name === 'skills');
+      const props = (skills?.content as ObjectContent).properties;
+      const seo = props['seo'] as Record<string, Value>;
+      const social = props['social'] as Record<string, Value>;
+
+      expect(seo['__outputDir']).toBe('skills/marketing');
+      expect(social['__outputDir']).toBe('skills/marketing');
+    });
+
+    it('leaves source AST unchanged when outputDir is applied', () => {
+      const source = createProgram({
+        blocks: [
+          createBlock(
+            'skills',
+            createObjectContent({
+              seo: { description: 'SEO audit' },
+            })
+          ),
+        ],
+      });
+      const sourceSnapshot = JSON.parse(JSON.stringify(source));
+      const use = createUseDeclaration('github.com/foo/m', undefined, 'skills/m');
+
+      resolveUses(createProgram(), use, source);
+
+      expect(source).toEqual(sourceSnapshot);
     });
   });
 

--- a/packages/resolver/src/__tests__/imports.spec.ts
+++ b/packages/resolver/src/__tests__/imports.spec.ts
@@ -503,19 +503,52 @@ describe('imports', () => {
             createObjectContent({
               // Skill value is a string primitive, not an object
               'my-skill': 'just a string' as unknown as Record<string, Value>,
+              // Also test with null value
+              'null-skill': null as unknown as Record<string, Value>,
             })
           ),
         ],
       });
       const use = createUseDeclaration('github.com/foo/m', undefined, 'skills/m');
 
+      // Verify the source values are actually primitives before resolveUses
+      const srcSkillsBlock = source.blocks.find((b) => b.name === 'skills');
+      const srcProps = (srcSkillsBlock?.content as ObjectContent).properties;
+      expect(typeof srcProps['my-skill']).toBe('string');
+      expect(srcProps['null-skill']).toBeNull();
+
       const result = resolveUses(target, use, source);
 
       const skills = result.blocks.find((b) => b.name === 'skills');
+      expect(skills).toBeDefined();
       const props = (skills?.content as ObjectContent).properties;
-      const wrapper = props['my-skill'] as Record<string, Value>;
-      expect(wrapper['__outputDir']).toBe('skills/m');
+
+      // Debug: inspect what we got
+      const mySkillEntry = props['my-skill'];
+      const nullSkillEntry = props['null-skill'];
+      // Both should be __outputDir wrappers (the else branch fires for non-objects)
+      expect(typeof mySkillEntry).toBe('object');
+      expect(mySkillEntry).not.toBeNull();
+      expect((mySkillEntry as Record<string, Value>)['__outputDir']).toBe('skills/m');
+      expect(typeof nullSkillEntry).toBe('object');
+      expect((nullSkillEntry as Record<string, Value>)['__outputDir']).toBe('skills/m');
     });
+  });
+
+  it('skips outputDir attachment when source has no skills block', () => {
+    const target = createProgram();
+    // Source program has no skills block
+    const source = createProgram({
+      blocks: [createBlock('identity', createTextContent('imported'))],
+    });
+    const use = createUseDeclaration('github.com/foo/m', undefined, 'skills/m');
+
+    // Should not throw, just skip the outputDir attachment
+    const result = resolveUses(target, use, source);
+    expect(result).toBeDefined();
+    // No skills block should be added since source has none
+    const skills = result.blocks.find((b) => b.name === 'skills');
+    expect(skills).toBeUndefined();
   });
 
   describe('isImportMarker', () => {

--- a/packages/resolver/src/__tests__/md-imports.spec.ts
+++ b/packages/resolver/src/__tests__/md-imports.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { mkdtemp, mkdir, writeFile, symlink, rm, chmod } from 'fs/promises';
@@ -761,25 +761,31 @@ describe('loadAndParseMd resource/reference branches', () => {
   it('logs a verbose message when discoverSkillResources throws', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-res-err-'));
     try {
+      // Create a separate directory for the skill.md that is readable but
+      // has a subdirectory that will cause discoverSkillResources to fail.
+      // We use chmod 0o000 on a subdirectory so readdir(recursive) throws
+      // when trying to enter it.
+      const skillDir = join(tmpDir, 'skill');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        ['---', 'name: res-err-skill', 'description: d', '---', '', 'body'].join('\n')
+      );
+      // Create a subdirectory and make it unreadable
+      const secretDir = join(skillDir, 'secret');
+      await mkdir(secretDir, { recursive: true });
+      await writeFile(join(secretDir, 'data.txt'), 'secret');
+      await chmod(secretDir, 0o000);
+
       const prsContent = [
         '@meta { id: "test-res-err" syntax: "1.0.0" }',
         '',
-        '@use ./skill.md',
+        '@use ./skill',
         '',
         '@identity { """test""" }',
       ].join('\n');
       const prsFile = join(tmpDir, 'test.prs');
       await writeFile(prsFile, prsContent);
-
-      // Create a .md file at the expected relative path
-      await writeFile(
-        join(tmpDir, 'skill.md'),
-        ['---', 'name: res-err-skill', 'description: d', '---', '', 'body'].join('\n')
-      );
-
-      // Create a file named "references" (not a directory) so
-      // discoverSkillResources' readdir call throws.
-      await writeFile(join(tmpDir, 'references'), 'not a directory');
 
       const logger = createTestLogger();
       const resolver = new Resolver({
@@ -790,11 +796,26 @@ describe('loadAndParseMd resource/reference branches', () => {
       });
 
       const result = await resolver.resolve(prsFile);
+      // The skill should still be resolved; discoverSkillResources
+      // errors are caught and logged, not fatal
       expect(result.ast).not.toBeNull();
-      // Should still succeed — errors from discoverSkillResources are logged, not fatal
-      const skillsBlock = result.ast?.blocks.find((b) => b.name === 'skills');
-      expect(skillsBlock).toBeDefined();
+      // Verify the catch was actually exercised (at least on systems where
+      // chmod restricts readdir). On some systems the verbose log may not
+      // appear, so we only assert when it does.
+      const verboseLogs = logger.messages.filter((m) =>
+        m.includes('Failed to discover skill resources')
+      );
+      if (verboseLogs.length > 0) {
+        expect(verboseLogs[0]).toContain(skillDir);
+      }
     } finally {
+      // Restore permissions before cleanup
+      const secretDir = join(tmpDir, 'skill', 'secret');
+      try {
+        await chmod(secretDir, 0o755);
+      } catch {
+        /* ignore */
+      }
       await rm(tmpDir, { recursive: true, force: true });
     }
   });
@@ -920,6 +941,232 @@ describe('skillTargets config and into warning', () => {
       expect(warnMessages.length).toBeGreaterThan(0);
       expect(warnMessages[0]).toContain('overrides skillTargets');
     } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadAndParseMd error branches (mocked)', () => {
+  it('catches discoverSkillResources rejection and logs verbose', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-mock-'));
+    try {
+      const prsContent = [
+        '@meta { id: "mock-test" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      await writeFile(join(tmpDir, 'test.prs'), prsContent);
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        ['---', 'name: mock-skill', 'description: d', '---', '', 'body'].join('\n')
+      );
+
+      // Temporarily patch discoverSkillResources to throw
+      vi.spyOn(await import('../skills.js'), 'discoverSkillResources').mockRejectedValue(
+        new Error('EACCES: permission denied')
+      );
+
+      const logger = createTestLogger();
+      const { Resolver: MockResolver } = await import('../resolver.js');
+      const resolver = new MockResolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+        logger,
+      });
+
+      const result = await resolver.resolve(join(tmpDir, 'test.prs'));
+      expect(result.ast).not.toBeNull();
+      const verboseLogs = logger.messages.filter((m) =>
+        m.includes('Failed to discover skill resources')
+      );
+      expect(verboseLogs.length).toBeGreaterThan(0);
+    } finally {
+      vi.restoreAllMocks();
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('catches ResolveError from resolveSkillReferences and pushes it', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-ref-resolve-err-'));
+    try {
+      const prsContent = [
+        '@meta { id: "mock-ref-test" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      await writeFile(join(tmpDir, 'test.prs'), prsContent);
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        [
+          '---',
+          'name: ref-skill',
+          'description: d',
+          'references:',
+          '  - missing.txt',
+          '---',
+          '',
+          'body',
+        ].join('\n')
+      );
+
+      const { Resolver: RefResolver } = await import('../resolver.js');
+      const resolver = new RefResolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+      });
+
+      const result = await resolver.resolve(join(tmpDir, 'test.prs'));
+      // The missing reference should produce a ResolveError
+      expect(result.errors.some((e) => e.message.includes('missing.txt'))).toBe(true);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('catches non-ResolveError from resolveSkillReferences and wraps it', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-ref-non-resolve-'));
+    try {
+      const prsContent = [
+        '@meta { id: "mock-non-resolve" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      await writeFile(join(tmpDir, 'test.prs'), prsContent);
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        [
+          '---',
+          'name: non-resolve-skill',
+          'description: d',
+          'references:',
+          '  - ref.txt',
+          '---',
+          '',
+          'body',
+        ].join('\n')
+      );
+      // Create the referenced file so resolveSkillReferences doesn't fail with
+      // ResolveError; instead, mock it to throw a non-ResolveError
+      await writeFile(join(tmpDir, 'ref.txt'), 'data');
+
+      vi.spyOn(await import('../skills.js'), 'resolveSkillReferences').mockRejectedValue(
+        'string error'
+      );
+
+      const { Resolver: NonResolveResolver } = await import('../resolver.js');
+      const resolver = new NonResolveResolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+      });
+
+      const result = await resolver.resolve(join(tmpDir, 'test.prs'));
+      // The non-ResolveError string should be wrapped in a ResolveError
+      expect(result.errors.some((e) => e.message.includes('string error'))).toBe(true);
+    } finally {
+      vi.restoreAllMocks();
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('catches non-Error thrown by discoverSkillResources and logs String(err)', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-nonerr-'));
+    try {
+      const prsContent = [
+        '@meta { id: "mock-non-err" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      await writeFile(join(tmpDir, 'test.prs'), prsContent);
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        ['---', 'name: non-err-skill', 'description: d', '---', '', 'body'].join('\n')
+      );
+
+      // Throw a non-Error (string) to exercise String(err) branch
+      vi.spyOn(await import('../skills.js'), 'discoverSkillResources').mockRejectedValue(
+        'EACCES: string error'
+      );
+
+      const logger = createTestLogger();
+      const { Resolver: NonErrResolver } = await import('../resolver.js');
+      const resolver = new NonErrResolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+        logger,
+      });
+
+      const result = await resolver.resolve(join(tmpDir, 'test.prs'));
+      expect(result.ast).not.toBeNull();
+      // The verbose log should include String(err) representation
+      const verboseLogs = logger.messages.filter((m) =>
+        m.includes('Failed to discover skill resources')
+      );
+      expect(verboseLogs.length).toBeGreaterThan(0);
+      expect(verboseLogs[0]).toContain('EACCES: string error');
+    } finally {
+      vi.restoreAllMocks();
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('catches plain Error (non-ResolveError) from resolveSkillReferences', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-plain-err-'));
+    try {
+      const prsContent = [
+        '@meta { id: "mock-plain-err" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      await writeFile(join(tmpDir, 'test.prs'), prsContent);
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        [
+          '---',
+          'name: plain-err-skill',
+          'description: d',
+          'references:',
+          '  - ref.txt',
+          '---',
+          '',
+          'body',
+        ].join('\n')
+      );
+      await writeFile(join(tmpDir, 'ref.txt'), 'data');
+
+      // Throw a plain Error (not a ResolveError) to exercise the
+      // `err instanceof Error ? err.message : String(err)` branch
+      vi.spyOn(await import('../skills.js'), 'resolveSkillReferences').mockRejectedValue(
+        new Error('plain error from references')
+      );
+
+      const { Resolver: PlainErrResolver } = await import('../resolver.js');
+      const resolver = new PlainErrResolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+      });
+
+      const result = await resolver.resolve(join(tmpDir, 'test.prs'));
+      // The plain Error message should be wrapped in a ResolveError
+      expect(result.errors.some((e) => e.message.includes('plain error from references'))).toBe(
+        true
+      );
+    } finally {
+      vi.restoreAllMocks();
       await rm(tmpDir, { recursive: true, force: true });
     }
   });

--- a/packages/resolver/src/__tests__/md-imports.spec.ts
+++ b/packages/resolver/src/__tests__/md-imports.spec.ts
@@ -756,3 +756,171 @@ describe('E2E roundtrip: .md skill import', () => {
     }
   });
 });
+
+describe('loadAndParseMd resource/reference branches', () => {
+  it('logs a verbose message when discoverSkillResources throws', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-res-err-'));
+    try {
+      const prsContent = [
+        '@meta { id: "test-res-err" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      const prsFile = join(tmpDir, 'test.prs');
+      await writeFile(prsFile, prsContent);
+
+      // Create a .md file at the expected relative path
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        ['---', 'name: res-err-skill', 'description: d', '---', '', 'body'].join('\n')
+      );
+
+      // Create a file named "references" (not a directory) so
+      // discoverSkillResources' readdir call throws.
+      await writeFile(join(tmpDir, 'references'), 'not a directory');
+
+      const logger = createTestLogger();
+      const resolver = new Resolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+        logger,
+      });
+
+      const result = await resolver.resolve(prsFile);
+      expect(result.ast).not.toBeNull();
+      // Should still succeed — errors from discoverSkillResources are logged, not fatal
+      const skillsBlock = result.ast?.blocks.find((b) => b.name === 'skills');
+      expect(skillsBlock).toBeDefined();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('pushes a ResolveError when resolveSkillReferences fails', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-md-ref-err-'));
+    try {
+      const prsContent = [
+        '@meta { id: "test-ref-err" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      const prsFile = join(tmpDir, 'test.prs');
+      await writeFile(prsFile, prsContent);
+
+      const skillDir = join(tmpDir, 'skill');
+      await mkdir(skillDir, { recursive: true });
+      // .md with a references entry pointing to a non-existent file
+      await writeFile(
+        join(skillDir, 'skill.md'),
+        [
+          '---',
+          'name: ref-err-skill',
+          'description: d',
+          'references:',
+          '  - references/missing.md',
+          '---',
+          '',
+          'body',
+        ].join('\n')
+      );
+
+      const resolver = new Resolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+      });
+
+      const result = await resolver.resolve(prsFile);
+      // resolveSkillReferences should throw ResolveError for the missing file
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('skillTargets config and into warning', () => {
+  it('applies skillTargets from config when no inline into is present', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-skill-targets-'));
+    try {
+      const prsContent = [
+        '@meta { id: "test-skill-targets" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      const prsFile = join(tmpDir, 'test.prs');
+      await writeFile(prsFile, prsContent);
+
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        ['---', 'name: cfg-skill', 'description: d', '---', '', 'body'].join('\n')
+      );
+
+      const resolver = new Resolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+        skillTargets: { './skill.md': 'skills/marketing' },
+      });
+
+      const result = await resolver.resolve(prsFile);
+      // Accept that there may be errors from the test environment, but verify
+      // the skillTargets were applied if the AST resolved.
+      if (result.ast) {
+        const skillsBlock = result.ast.blocks.find((b) => b.name === 'skills');
+        if (skillsBlock?.content.type === 'ObjectContent') {
+          const skillObj = skillsBlock.content.properties['cfg-skill'] as Record<string, unknown>;
+          expect(skillObj['__outputDir']).toBe('skills/marketing');
+        }
+      }
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when inline into conflicts with skillTargets', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'prs-skill-targets-warn-'));
+    try {
+      const prsContent = [
+        '@meta { id: "test-skill-targets-warn" syntax: "1.0.0" }',
+        '',
+        '@use ./skill.md into "skills/other"',
+        '',
+        '@identity { """test""" }',
+      ].join('\n');
+      const prsFile = join(tmpDir, 'test.prs');
+      await writeFile(prsFile, prsContent);
+
+      await writeFile(
+        join(tmpDir, 'skill.md'),
+        ['---', 'name: warn-skill', 'description: d', '---', '', 'body'].join('\n')
+      );
+
+      const logger = createTestLogger();
+      const resolver = new Resolver({
+        registryPath: tmpDir,
+        localPath: tmpDir,
+        cache: false,
+        skillTargets: { './skill.md': 'skills/marketing' },
+        logger,
+      });
+
+      const result = await resolver.resolve(prsFile);
+      // Verify the resolve completed
+      expect(result.ast).not.toBeNull();
+      // The inline into should win and a warning should be logged
+      const warnMessages = logger.messages.filter((m) => m.startsWith('[warn]'));
+      expect(warnMessages.length).toBeGreaterThan(0);
+      expect(warnMessages[0]).toContain('overrides skillTargets');
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/resolver/src/__tests__/registry-resolution.spec.ts
+++ b/packages/resolver/src/__tests__/registry-resolution.spec.ts
@@ -734,4 +734,76 @@ describe('Resolver — registry marker handling', () => {
     const contextBlock = result.ast?.blocks.find((b) => b.name === 'context');
     expect(contextBlock).toBeDefined();
   });
+
+  it('loads resource files and frontmatter references for registry .md skills', async () => {
+    const tempDir = join(testCacheDir, 'project-md-resources');
+    await fs.mkdir(tempDir, { recursive: true });
+
+    const prsContent = [
+      '@meta {',
+      '  id: "test-md-resources"',
+      '  syntax: "1.0.0"',
+      '}',
+      '',
+      '@use @acme/my-skill.md',
+      '',
+      '@identity { """test""" }',
+    ].join('\n');
+    const prsFile = join(tempDir, 'test.prs');
+    await fs.writeFile(prsFile, prsContent);
+
+    // Mock clone to create a skill directory with a SKILL.md + reference file
+    // alongside it. The resolver currently routes the .md file through
+    // loadAndParseMd, which must now also load nearby resources.
+    mockGit.clone.mockImplementation(async (_url: string, targetDir: string) => {
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.writeFile(
+        join(targetDir, 'my-skill.md'),
+        [
+          '---',
+          'name: registry-skill-with-refs',
+          'description: Has resources and references',
+          'references:',
+          '  - references/checklist.md',
+          '---',
+          '',
+          'Skill body.',
+        ].join('\n')
+      );
+      await fs.mkdir(join(targetDir, 'references'), { recursive: true });
+      await fs.writeFile(
+        join(targetDir, 'references', 'checklist.md'),
+        '# Checklist\n- item one\n- item two\n'
+      );
+      await fs.writeFile(join(targetDir, 'data.txt'), 'sample resource content');
+    });
+
+    const resolver = new Resolver({
+      registryPath: resolve(FIXTURES_DIR, 'registry'),
+      localPath: tempDir,
+      registries: TEST_REGISTRIES,
+      cache: false,
+      cacheDir: join(testCacheDir, 'regcache-md-resources'),
+    });
+
+    const result = await resolver.resolve(prsFile);
+
+    expect(result.errors).toEqual([]);
+    const skillsBlock = result.ast?.blocks.find((b) => b.name === 'skills');
+    expect(skillsBlock).toBeDefined();
+    if (skillsBlock?.content.type !== 'ObjectContent') {
+      throw new Error('skills block should be ObjectContent');
+    }
+    const skill = skillsBlock.content.properties['registry-skill-with-refs'] as
+      | Record<string, unknown>
+      | undefined;
+    expect(skill).toBeDefined();
+    const resources = skill!['resources'] as
+      | Array<{ relativePath: string; content: string }>
+      | undefined;
+    expect(resources).toBeDefined();
+    const paths = (resources ?? []).map((r) => r.relativePath).sort();
+    expect(paths).toContain('references/checklist.md');
+    expect(paths).toContain('data.txt');
+  });
 });

--- a/packages/resolver/src/__tests__/registry-resolution.spec.ts
+++ b/packages/resolver/src/__tests__/registry-resolution.spec.ts
@@ -735,6 +735,83 @@ describe('Resolver — registry marker handling', () => {
     expect(contextBlock).toBeDefined();
   });
 
+  it('resolves a root-level registry import via auto-discovery (no sub-path)', async () => {
+    const tempDir = join(testCacheDir, 'project-root-import');
+    await fs.mkdir(tempDir, { recursive: true });
+
+    const prsContent = [
+      '@meta {',
+      '  id: "test-root-import"',
+      '  syntax: "1.0.0"',
+      '}',
+      '',
+      '@use github.com/cloudflare/skills',
+      '',
+      '@identity { """test""" }',
+    ].join('\n');
+    const prsFile = join(tempDir, 'test.prs');
+    await fs.writeFile(prsFile, prsContent);
+
+    mockGit.clone.mockImplementation(async (_url: string, targetDir: string) => {
+      await fs.mkdir(join(targetDir, 'skills', 'foo'), { recursive: true });
+      await fs.writeFile(
+        join(targetDir, 'skills', 'foo', 'SKILL.md'),
+        ['---', 'name: foo-skill', 'description: A discovered skill', '---', 'Body content.'].join(
+          '\n'
+        )
+      );
+    });
+
+    const resolver = new Resolver({
+      registryPath: resolve(FIXTURES_DIR, 'registry'),
+      localPath: tempDir,
+      cache: false,
+      cacheDir: join(testCacheDir, 'regcache-root'),
+    });
+
+    const result = await resolver.resolve(prsFile);
+
+    expect(result.errors).toEqual([]);
+    const skillsBlock = result.ast?.blocks.find((b) => b.name === 'skills');
+    expect(skillsBlock).toBeDefined();
+  });
+
+  it('reports a helpful error when a root-level repo has no skill content', async () => {
+    const tempDir = join(testCacheDir, 'project-root-empty');
+    await fs.mkdir(tempDir, { recursive: true });
+
+    const prsContent = [
+      '@meta {',
+      '  id: "test-root-empty"',
+      '  syntax: "1.0.0"',
+      '}',
+      '',
+      '@use github.com/foo/empty',
+      '',
+      '@identity { """test""" }',
+    ].join('\n');
+    const prsFile = join(tempDir, 'test.prs');
+    await fs.writeFile(prsFile, prsContent);
+
+    mockGit.clone.mockImplementation(async (_url: string, targetDir: string) => {
+      await fs.mkdir(targetDir, { recursive: true });
+      // Empty repository — no skills, agents or commands.
+    });
+
+    const resolver = new Resolver({
+      registryPath: resolve(FIXTURES_DIR, 'registry'),
+      localPath: tempDir,
+      cache: false,
+      cacheDir: join(testCacheDir, 'regcache-root-empty'),
+    });
+
+    const result = await resolver.resolve(prsFile);
+
+    const messages = result.errors.map((e) => e.message).join('\n');
+    expect(messages).toContain('<repository root>');
+    expect(messages).toContain('Specify a sub-path');
+  });
+
   it('loads resource files and frontmatter references for registry .md skills', async () => {
     const tempDir = join(testCacheDir, 'project-md-resources');
     await fs.mkdir(tempDir, { recursive: true });

--- a/packages/resolver/src/auto-discovery.ts
+++ b/packages/resolver/src/auto-discovery.ts
@@ -253,14 +253,26 @@ async function discoverContext(dir: string): Promise<TextContent | null> {
  * @param dir - Absolute path to the directory to scan
  * @returns A synthesized Program AST, or null if nothing was found or directory doesn't exist
  */
-export async function discoverNativeContent(dir: string): Promise<Program | null> {
-  // Check the directory exists
+/**
+ * Wrapper directory names commonly used by skill repositories to group skills,
+ * agents and commands one level below the repo root.
+ */
+const SKILL_WRAPPER_DIRS = ['skills'] as const;
+const AGENT_WRAPPER_DIRS = ['agents'] as const;
+const COMMAND_WRAPPER_DIRS = ['commands'] as const;
+
+async function safeIsDirectory(dir: string): Promise<boolean> {
   try {
     const stat = await lstat(dir);
-    if (!stat.isDirectory()) return null;
+    return stat.isDirectory();
   } catch {
-    return null;
+    return false;
   }
+}
+
+export async function discoverNativeContent(dir: string): Promise<Program | null> {
+  // Check the directory exists
+  if (!(await safeIsDirectory(dir))) return null;
 
   const blocks: Block[] = [];
 
@@ -270,22 +282,58 @@ export async function discoverNativeContent(dir: string): Promise<Program | null
   // Discover skills in subdirectories
   const subSkills = await discoverSkills(dir);
 
-  // Merge: subdirectory skills take precedence over root skill (more specific wins)
-  const mergedSkills = { ...rootSkill, ...subSkills };
+  // Also walk known wrapper directories (`skills/`) so registry imports against
+  // a repository root pick up the standard `skills/<name>/SKILL.md` layout.
+  const wrappedSkillResults = await Promise.all(
+    SKILL_WRAPPER_DIRS.map(async (name) => {
+      const candidate = resolve(dir, name);
+      if (!(await safeIsDirectory(candidate))) return null;
+      return discoverSkills(candidate);
+    })
+  );
+
+  const mergedSkills: Record<string, Value> = { ...rootSkill, ...subSkills };
+  for (const wrapped of wrappedSkillResults) {
+    if (wrapped) {
+      for (const [key, value] of Object.entries(wrapped)) {
+        if (!(key in mergedSkills)) {
+          mergedSkills[key] = value;
+        }
+      }
+    }
+  }
   if (Object.keys(mergedSkills).length > 0) {
     blocks.push(makeBlock('skills', makeObjectContent(mergedSkills)));
   }
 
-  // Discover agents
-  const agentProperties = await discoverAgents(dir);
-  if (agentProperties) {
-    blocks.push(makeBlock('agents', makeObjectContent(agentProperties)));
+  // Discover agents (root + agents/ wrapper)
+  const rootAgents = (await discoverAgents(dir)) ?? {};
+  const wrappedAgents: Record<string, Value> = {};
+  for (const name of AGENT_WRAPPER_DIRS) {
+    const candidate = resolve(dir, name);
+    if (await safeIsDirectory(candidate)) {
+      const found = await discoverAgents(candidate);
+      if (found) Object.assign(wrappedAgents, found);
+    }
+  }
+  const mergedAgents = { ...wrappedAgents, ...rootAgents };
+  if (Object.keys(mergedAgents).length > 0) {
+    blocks.push(makeBlock('agents', makeObjectContent(mergedAgents)));
   }
 
-  // Discover commands -> @shortcuts
-  const commandProperties = await discoverCommands(dir);
-  if (commandProperties) {
-    blocks.push(makeBlock('shortcuts', makeObjectContent(commandProperties)));
+  // Discover commands -> @shortcuts (root + commands/ wrapper)
+  const rootCommands = (await discoverCommands(dir)) ?? {};
+  const wrappedCommands: Record<string, Value> = {};
+  for (const name of COMMAND_WRAPPER_DIRS) {
+    const candidate = resolve(dir, name);
+    if (await safeIsDirectory(candidate)) {
+      const found = await discoverCommands(candidate);
+      if (found) Object.assign(wrappedCommands, found);
+    }
+  }
+  const mergedCommands = { ...wrappedCommands, ...rootCommands };
+  if (Object.keys(mergedCommands).length > 0) {
+    blocks.push(makeBlock('shortcuts', makeObjectContent(mergedCommands)));
   }
 
   // Discover context

--- a/packages/resolver/src/imports.ts
+++ b/packages/resolver/src/imports.ts
@@ -31,6 +31,24 @@ export const IMPORT_MARKER_PREFIX = '__import__';
  * @returns Updated program with merged blocks
  */
 export function resolveUses(target: Program, use: UseDeclaration, source: Program): Program {
+  // If the @use carries an inline output directory, attach it to every skill
+  // brought in by this import. We operate on a clone so cached source ASTs are
+  // never mutated.
+  if (use.outputDir) {
+    source = deepClone(source);
+    const skillsBlock = source.blocks.find((b) => b.name === 'skills');
+    if (skillsBlock?.content.type === 'ObjectContent') {
+      const props = (skillsBlock.content as ObjectContent).properties;
+      for (const [name, value] of Object.entries(props)) {
+        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          (value as Record<string, Value>)['__outputDir'] = use.outputDir;
+        } else {
+          props[name] = { __outputDir: use.outputDir } as unknown as Value;
+        }
+      }
+    }
+  }
+
   // Pre-merge duplicate skill check: detect collisions in @skills block
   const targetSkillsBlock = target.blocks.find((b) => b.name === 'skills');
   const sourceSkillsBlock = source.blocks.find((b) => b.name === 'skills');

--- a/packages/resolver/src/imports.ts
+++ b/packages/resolver/src/imports.ts
@@ -40,7 +40,8 @@ export function resolveUses(target: Program, use: UseDeclaration, source: Progra
     if (skillsBlock?.content.type === 'ObjectContent') {
       const props = (skillsBlock.content as ObjectContent).properties;
       for (const [name, value] of Object.entries(props)) {
-        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        const isObj = typeof value === 'object' && value !== null && !Array.isArray(value);
+        if (isObj) {
           (value as Record<string, Value>)['__outputDir'] = use.outputDir;
         } else {
           props[name] = { __outputDir: use.outputDir } as unknown as Value;

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { lstat, readdir, readFile } from 'fs/promises';
-import { basename, join } from 'path';
+import { basename, dirname, join } from 'path';
 import { parse } from '@promptscript/parser';
 import {
   noopLogger,
@@ -29,7 +29,10 @@ import {
   resolveNativeAgents,
   parseSkillMd,
   skillNameFromPath,
+  discoverSkillResources,
+  resolveSkillReferences,
   type NativeSkillOptions,
+  type SkillResource,
 } from './skills.js';
 import { detectContentType } from './content-detector.js';
 import { makeBlock, makeObjectContent, makeTextContent, VIRTUAL_LOC } from './ast-factory.js';
@@ -259,7 +262,7 @@ export class Resolver {
 
     // Route .md files through content detection
     if (absPath.endsWith('.md')) {
-      return this.loadAndParseMd(absPath, source, errors);
+      return await this.loadAndParseMd(absPath, source, errors);
     }
 
     const parseResult = parse(source, { filename: absPath });
@@ -283,15 +286,17 @@ export class Resolver {
    *
    * If the content looks like PRS (has @identity block), parse as PRS.
    * If it has YAML frontmatter, treat as a skill and synthesize a Program
-   * with a @skills block.
+   * with a @skills block. Resource files alongside SKILL.md and explicit
+   * `references:` entries are loaded so registry-imported skills behave the
+   * same as locally-discovered ones.
    * Otherwise, treat as raw markdown and synthesize a Program with a @skills
    * block using the filename as the skill name.
    */
-  private loadAndParseMd(
+  private async loadAndParseMd(
     absPath: string,
     source: string,
     errors: ResolveError[]
-  ): { ast: Program | null } {
+  ): Promise<{ ast: Program | null }> {
     const contentType = detectContentType(source);
 
     if (contentType === 'prs') {
@@ -325,6 +330,49 @@ export class Resolver {
     }
     if (parsed.content) {
       skillProps['content'] = makeTextContent(parsed.content, absPath);
+    }
+
+    // Discover resource files alongside the SKILL.md and explicit reference
+    // entries. This mirrors the behaviour of resolveNativeSkills() so a skill
+    // pulled in via a registry import carries the same resources as a locally
+    // discovered one.
+    const skillDir = dirname(absPath);
+    const collected: SkillResource[] = [];
+
+    try {
+      const discovered = await discoverSkillResources(skillDir, this.logger);
+      collected.push(...discovered);
+    } catch (err) {
+      this.logger.verbose(
+        `Failed to discover skill resources in ${skillDir}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    if (parsed.references && parsed.references.length > 0) {
+      try {
+        const refs = await resolveSkillReferences(parsed.references, skillDir, this.logger);
+        collected.push(...refs);
+      } catch (err) {
+        if (err instanceof ResolveError) {
+          errors.push(err);
+        } else {
+          errors.push(new ResolveError(err instanceof Error ? err.message : String(err)));
+        }
+      }
+    }
+
+    if (collected.length > 0) {
+      // Deduplicate by relativePath: explicit references override discovered ones.
+      const byPath = new Map<string, SkillResource>();
+      for (const resource of collected) {
+        byPath.set(resource.relativePath, resource);
+      }
+      skillProps['resources'] = Array.from(byPath.values()).map((r) => ({
+        relativePath: r.relativePath,
+        content: r.content,
+      })) as Value[];
     }
 
     const program: Program = {
@@ -633,7 +681,7 @@ export class Resolver {
         // Found a .md file — route through content detection
         this.logger.debug(`Found .md file: ${resolvedFullPath}`);
         const source = await readFile(resolvedFullPath, 'utf-8');
-        const mdResult = this.loadAndParseMd(resolvedFullPath, source, errors);
+        const mdResult = await this.loadAndParseMd(resolvedFullPath, source, errors);
         resolvedAST = mdResult.ast;
       } else if (existsSync(resolvedFullPath)) {
         // Found a .prs file — parse it

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -666,24 +666,29 @@ export class Resolver {
         await this.registryCache.set(repoUrl, effectiveVersion, commitHash);
       }
 
-      // Resolve the file path within the cached repo
-      const isMdPath = subPath.endsWith('.md');
-      const resolvedFileName = isMdPath
-        ? subPath
-        : subPath.endsWith('.prs')
+      // Resolve the file path within the cached repo. An empty sub-path means
+      // the import targets the repository root (e.g. `@use github.com/foo/bar`)
+      // so we skip the .prs/.md guess and go straight to auto-discovery.
+      const isRoot = subPath === '';
+      const isMdPath = !isRoot && subPath.endsWith('.md');
+      const resolvedFileName = isRoot
+        ? ''
+        : isMdPath
           ? subPath
-          : `${subPath}.prs`;
-      const resolvedFullPath = join(cachePath, resolvedFileName);
+          : subPath.endsWith('.prs')
+            ? subPath
+            : `${subPath}.prs`;
+      const resolvedFullPath = isRoot ? '' : join(cachePath, resolvedFileName);
 
       let resolvedAST: Program | null = null;
 
-      if (existsSync(resolvedFullPath) && isMdPath) {
+      if (!isRoot && existsSync(resolvedFullPath) && isMdPath) {
         // Found a .md file — route through content detection
         this.logger.debug(`Found .md file: ${resolvedFullPath}`);
         const source = await readFile(resolvedFullPath, 'utf-8');
         const mdResult = await this.loadAndParseMd(resolvedFullPath, source, errors);
         resolvedAST = mdResult.ast;
-      } else if (existsSync(resolvedFullPath)) {
+      } else if (!isRoot && existsSync(resolvedFullPath)) {
         // Found a .prs file — parse it
         this.logger.debug(`Found .prs file: ${resolvedFullPath}`);
         const source = await this.loader.load(resolvedFullPath);
@@ -698,14 +703,16 @@ export class Resolver {
         }
       } else {
         // No file found — try auto-discovery of native content
-        const discoverDir = join(cachePath, subPath);
+        const discoverDir = isRoot ? cachePath : join(cachePath, subPath);
         this.logger.debug(`No .prs found, trying auto-discovery: ${discoverDir}`);
         resolvedAST = await discoverNativeContent(discoverDir);
 
         if (!resolvedAST) {
+          const where = isRoot ? '<repository root>' : `'${subPath}'`;
+          const hint = isRoot ? ` Specify a sub-path (e.g. ${repoUrl}/skills/<name>).` : '';
           errors.push(
             new ResolveError(
-              `Cannot resolve registry import: no .prs file or native content at '${subPath}' in ${repoUrl}`
+              `Cannot resolve registry import: no .prs file or native content at ${where} in ${repoUrl}.${hint}`
             )
           );
         }

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -57,6 +57,12 @@ export interface ResolverOptions extends LoaderOptions {
   guardRequiresDepth?: number;
   /** Base directory for the registry cache (defaults to ~/.promptscript/cache) */
   cacheDir?: string;
+  /**
+   * Map from `@use` source `path.raw` to a target output directory.
+   * Provides a config-driven default for skills imported via @use when no
+   * inline `into "<path>"` clause is present on the directive.
+   */
+  skillTargets?: Record<string, string>;
 }
 
 /**
@@ -526,8 +532,26 @@ export class Resolver {
             };
           }
 
-          this.logger.debug(`Merging import${use.alias ? ` as "${use.alias}"` : ''}`);
-          result = resolveUses(result, use, resolvedImport);
+          // If no inline `into "<path>"` was given, fall back to the
+          // skillTargets map from resolver options. When both are set the
+          // inline directive wins and we surface a warning so users notice
+          // the redundant config entry.
+          let effectiveUse = use;
+          const fromConfig = this.options.skillTargets?.[use.path.raw];
+          if (use.outputDir && fromConfig && use.outputDir !== fromConfig) {
+            this.logger.warn(
+              `@use ${use.path.raw} into "${use.outputDir}" overrides skillTargets["${use.path.raw}"]="${fromConfig}"`
+            );
+          } else if (!use.outputDir && fromConfig) {
+            effectiveUse = { ...use, outputDir: fromConfig };
+          }
+
+          this.logger.debug(
+            `Merging import${effectiveUse.alias ? ` as "${effectiveUse.alias}"` : ''}${
+              effectiveUse.outputDir ? ` into "${effectiveUse.outputDir}"` : ''
+            }`
+          );
+          result = resolveUses(result, effectiveUse, resolvedImport);
         }
       } catch (err) {
         if (err instanceof CircularDependencyError) {

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -718,7 +718,7 @@ const noopLogger: Logger = {
  * @param logger - Optional logger for reporting skipped files
  * @returns Array of resource files with relative paths and content
  */
-async function discoverSkillResources(
+export async function discoverSkillResources(
   skillDir: string,
   logger: Logger = noopLogger
 ): Promise<SkillResource[]> {

--- a/schema/config.json
+++ b/schema/config.json
@@ -217,6 +217,14 @@
       "additionalProperties": false,
       "description": "Output configuration. Global output settings applied to all targets."
     },
+    "skillTargets": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Per-source output directories for `@use` imports.\n\nMaps a `@use` source string (matching the path's `raw` value) to a relative directory underneath each target's skill output location. An inline `into \"<path>\"` on the same `@use` declaration overrides the configured value.",
+      "example": "skillTargets:\n  \"github.com/coreyhaines31/marketingskills/skills/seo-audit\": \"skills/seo-audit\""
+    },
     "formatting": {
       "$ref": "#/definitions/FormattingConfig",
       "description": "Formatting configuration. Controls how generated markdown files are formatted.",

--- a/scripts/check-grammar.mts
+++ b/scripts/check-grammar.mts
@@ -30,6 +30,7 @@ const TOKEN_SCOPE_MAP: Record<string, string> = {
   Use: 'keyword.control',
   Extend: 'keyword.control',
   As: 'keyword.control',
+  Into: 'keyword.control',
   At: 'entity.name.tag',
   Range: 'keyword.other',
   Enum: 'keyword.other',


### PR DESCRIPTION
- **feat(cli): install hooks during prs init by default**
- **fix(cli): normalize skill source URLs before validation**
- **fix(cli): reject GitHub web URLs with tree/<ref> or blob/<ref> segments**
- **fix(resolver): load references and skill resources for registry imports**
- **fix(resolver): support root-level registry imports with nested skill layouts**
- **feat(parser,resolver,formatters): @use ... into <path> for skill output dirs**
- **fix(cli): resolve real HEAD commit on prs skills update**
