### PR TITLE
feat(cli): add named build profiles

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -130,6 +130,7 @@ prs compile [options]
 
 | Option                  | Description                                    |
 | ----------------------- | ---------------------------------------------- |
+| `-b, --build <name>`    | Compile a named build profile from config      |
 | `-t, --target <target>` | Compile to specific target                     |
 | `-f, --format <format>` | Output format (alias for `--target`)           |
 | `-a, --all`             | Compile to all configured targets              |
@@ -164,6 +165,9 @@ prs compile --watch
 # Preview changes
 prs compile --dry-run
 
+# Compile a named build profile
+prs compile --build logstrip-factory
+
 # Custom config
 prs compile --config ./custom.config.yaml
 
@@ -188,6 +192,44 @@ Instead of running `prs compile --watch` in a terminal, you can let your AI tool
 | `opencode`    | `OPENCODE.md`                     | OpenCode           |
 | `gemini`      | `GEMINI.md`                       | Gemini CLI         |
 | `factory`     | `AGENTS.md`                       | Factory AI         |
+
+### prs build
+
+Compile a named build profile from `promptscript.yaml`.
+
+```bash
+prs build <name> [options]
+```
+
+This is a shortcut for:
+
+```bash
+prs compile --build <name>
+```
+
+Build profiles are useful when a project needs extra generated artifacts for a
+subpackage, plugin, or library folder.
+
+```yaml
+builds:
+  logstrip-factory:
+    entry: .promptscript/project.prs
+    output: plugins/logstrip
+    targets:
+      - factory:
+          version: multifile
+          skillBaseDir: skills
+          includeSkills:
+            - logstrip
+```
+
+```bash
+prs build logstrip-factory
+```
+
+The command accepts the same compile options as `prs compile`, including
+`--target`, `--format`, `--output`, `--dry-run`, `--config`, `--force`,
+`--strict`, `--ignore-hashes`, and `--cwd`.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1018,13 +1018,16 @@ watch:
 
 ## Environment Variables
 
-| Variable                | Description                           |
-| ----------------------- | ------------------------------------- |
-| `PROMPTSCRIPT_CONFIG`   | Path to config file                   |
-| `PROMPTSCRIPT_REGISTRY` | Registry path or URL                  |
-| `PROMPTSCRIPT_VERBOSE`  | Enable verbose output (`1` or `true`) |
-| `PROMPTSCRIPT_DEBUG`    | Enable debug output (`1` or `true`)   |
-| `NO_COLOR`              | Disable colored output                |
+| Variable                                 | Description                                |
+| ---------------------------------------- | ------------------------------------------ |
+| `PROMPTSCRIPT_CONFIG`                    | Path to config file                        |
+| `PROMPTSCRIPT_REGISTRY`                  | Registry path or URL                       |
+| `PROMPTSCRIPT_REGISTRY_GIT_URL`          | Git registry URL (HTTPS or SSH)            |
+| `PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL` | Fallback Git URL (retried on auth failure) |
+| `PROMPTSCRIPT_REGISTRY_GIT_REF`          | Git ref (branch, tag, or commit)           |
+| `PROMPTSCRIPT_VERBOSE`                   | Enable verbose output (`1` or `true`)      |
+| `PROMPTSCRIPT_DEBUG`                     | Enable debug output (`1` or `true`)        |
+| `NO_COLOR`                               | Disable colored output                     |
 
 ## Exit Codes
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1018,16 +1018,15 @@ watch:
 
 ## Environment Variables
 
-| Variable                                 | Description                                |
-| ---------------------------------------- | ------------------------------------------ |
-| `PROMPTSCRIPT_CONFIG`                    | Path to config file                        |
-| `PROMPTSCRIPT_REGISTRY`                  | Registry path or URL                       |
-| `PROMPTSCRIPT_REGISTRY_GIT_URL`          | Git registry URL (HTTPS or SSH)            |
-| `PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL` | Fallback Git URL (retried on auth failure) |
-| `PROMPTSCRIPT_REGISTRY_GIT_REF`          | Git ref (branch, tag, or commit)           |
-| `PROMPTSCRIPT_VERBOSE`                   | Enable verbose output (`1` or `true`)      |
-| `PROMPTSCRIPT_DEBUG`                     | Enable debug output (`1` or `true`)        |
-| `NO_COLOR`                               | Disable colored output                     |
+| Variable                        | Description                           |
+| ------------------------------- | ------------------------------------- |
+| `PROMPTSCRIPT_CONFIG`           | Path to config file                   |
+| `PROMPTSCRIPT_REGISTRY`         | Registry path or URL                  |
+| `PROMPTSCRIPT_REGISTRY_GIT_URL` | Git registry URL (HTTPS or SSH)       |
+| `PROMPTSCRIPT_REGISTRY_GIT_REF` | Git ref (branch, tag, or commit)      |
+| `PROMPTSCRIPT_VERBOSE`          | Enable verbose output (`1` or `true`) |
+| `PROMPTSCRIPT_DEBUG`            | Enable debug output (`1` or `true`)   |
+| `NO_COLOR`                      | Disable colored output                |
 
 ## Exit Codes
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -947,9 +947,6 @@ registry:
     ref: main
 ```
 
-You can also set this via the environment variable
-`PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL`.
-
 The same pattern works for registry aliases:
 
 ```yaml

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -50,6 +50,7 @@ registry:
   # Or Git repository (recommended for teams)
   # git:
   #   url: https://github.com/org/promptscript-registry.git
+  #   fallbackUrl: git@github.com:org/promptscript-registry.git  # SSH fallback
   #   ref: main                    # branch, tag, or commit
   #   path: registry/              # subdirectory in repo
   #   auth:
@@ -241,19 +242,20 @@ registry:
 
 **Registry Fields:**
 
-| Field                  | Type    | Default   | Description                    |
-| ---------------------- | ------- | --------- | ------------------------------ |
-| `path`                 | string  | -         | Local registry path            |
-| `url`                  | string  | -         | HTTP registry URL              |
-| `git.url`              | string  | -         | Git repository URL             |
-| `git.ref`              | string  | `main`    | Branch, tag, or commit         |
-| `git.path`             | string  | -         | Subdirectory within the repo   |
-| `git.auth.type`        | string  | -         | Auth type: `token` or `ssh`    |
-| `git.auth.token`       | string  | -         | Personal access token (direct) |
-| `git.auth.tokenEnvVar` | string  | -         | Env var containing the token   |
-| `git.auth.sshKeyPath`  | string  | -         | Path to SSH key (for SSH auth) |
-| `cache.enabled`        | boolean | `true`    | Enable caching                 |
-| `cache.ttl`            | number  | `3600000` | Cache TTL in milliseconds      |
+| Field                  | Type    | Default   | Description                          |
+| ---------------------- | ------- | --------- | ------------------------------------ |
+| `path`                 | string  | -         | Local registry path                  |
+| `url`                  | string  | -         | HTTP registry URL                    |
+| `git.url`              | string  | -         | Git repository URL                   |
+| `git.fallbackUrl`      | string  | -         | Fallback URL (tried on auth failure) |
+| `git.ref`              | string  | `main`    | Branch, tag, or commit               |
+| `git.path`             | string  | -         | Subdirectory within the repo         |
+| `git.auth.type`        | string  | -         | Auth type: `token` or `ssh`          |
+| `git.auth.token`       | string  | -         | Personal access token (direct)       |
+| `git.auth.tokenEnvVar` | string  | -         | Env var containing the token         |
+| `git.auth.sshKeyPath`  | string  | -         | Path to SSH key (for SSH auth)       |
+| `cache.enabled`        | boolean | `true`    | Enable caching                       |
+| `cache.ttl`            | number  | `3600000` | Cache TTL in milliseconds            |
 
 !!! tip "Version-tagged imports"
 With Git registry, you can pin imports to specific versions using Git tags:
@@ -291,7 +293,24 @@ registries:
     url: git@gitlab.internal.acme.com:platform/prs-registry
     auth:
       type: ssh
-      sshKeyPath: ~/.ssh/id_ed25519
+      sshKeyPath: *****************
+```
+
+#### Extended Form (with fallback URL)
+
+When registry files reference HTTPS URLs but you authenticate via SSH (or vice
+versa), set `fallbackUrl` so the clone is retried with the alternative URL
+on auth failures:
+
+```yaml
+registries:
+  '@acme':
+    url: https://github.com/acme/standards.git
+    fallbackUrl: git@github.com:acme/standards.git
+  '@internal':
+    url: https://gitlab.internal.com/team/monorepo.git
+    fallbackUrl: git@gitlab.internal.com:team/monorepo.git
+    root: packages/promptscript
 ```
 
 **Alias Fields:**
@@ -300,6 +319,8 @@ registries:
 | ------------------ | ------ | ---------------------------------------------- |
 | (simple string)    | string | Bare Git host path, e.g. `github.com/org/repo` |
 | `url`              | string | Bare Git host path (extended form)             |
+| `fallbackUrl`      | string | Fallback Git URL (tried on auth failure)       |
+| `root`             | string | Base path within the repository                |
 | `auth.type`        | string | `token` or `ssh`                               |
 | `auth.tokenEnvVar` | string | Env var containing a personal access token     |
 | `auth.sshKeyPath`  | string | Path to SSH private key                        |
@@ -909,5 +930,31 @@ registry:
     ref: v1.0.0 # Pin to specific version
     auth:
       type: ssh
-      sshKeyPath: ~/.ssh/id_ed25519
+      sshKeyPath: *****************
+```
+
+### HTTPS Registry with SSH Fallback
+
+When registry references use HTTPS URLs but you authenticate via SSH keys,
+configure a `fallbackUrl` so PromptScript automatically retries the clone
+with SSH on auth failure:
+
+```yaml
+registry:
+  git:
+    url: https://github.com/org/registry.git
+    fallbackUrl: git@github.com:org/registry.git
+    ref: main
+```
+
+You can also set this via the environment variable
+`PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL`.
+
+The same pattern works for registry aliases:
+
+```yaml
+registries:
+  '@acme':
+    url: https://github.com/acme/standards.git
+    fallbackUrl: git@github.com:acme/standards.git
 ```

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -75,6 +75,25 @@ targets:
   - claude
   - cursor
 
+# =============================
+# Named Build Profiles
+# =============================
+builds:
+  plugin-factory:
+    # Optional entry override for this build only
+    entry: .promptscript/project.prs
+
+    # Optional output directory for this build only
+    output: plugins/logstrip
+
+    # Optional target list for this build only
+    targets:
+      - factory:
+          version: multifile
+          skillBaseDir: skills
+          includeSkills:
+            - logstrip
+
 # =========================
 # Validation Configuration
 # =========================
@@ -476,12 +495,14 @@ targets:
 
 **Target Options:**
 
-| Field        | Type    | Default     | Description                                  |
-| ------------ | ------- | ----------- | -------------------------------------------- |
-| `enabled`    | boolean | `true`      | Whether target is enabled                    |
-| `output`     | string  | (see above) | Custom output path                           |
-| `convention` | string  | `markdown`  | Output convention ('xml' or 'markdown')      |
-| `version`    | string  | `full`      | Format version (varies by target, see below) |
+| Field           | Type                | Default         | Description                                            |
+| --------------- | ------------------- | --------------- | ------------------------------------------------------ |
+| `enabled`       | boolean             | `true`          | Whether target is enabled                              |
+| `output`        | string              | (see above)     | Custom output path                                     |
+| `convention`    | string              | `markdown`      | Output convention ('xml' or 'markdown')                |
+| `version`       | string              | `full`          | Format version (varies by target, see below)           |
+| `skillBaseDir`  | string              | target-specific | Custom base directory for generated skill files        |
+| `includeSkills` | boolean or string[] | `true`          | Emit all skills, no skills, or only listed skill names |
 
 !!! tip "Disabling Targets"
 Setting `enabled: false` skips the target during compilation.
@@ -496,6 +517,31 @@ This is equivalent to removing the target from the list.
     ```
 
 See [Formatters API](../api-reference/formatters/src/README.md) for more details.
+
+!!! tip "Building skills into plugin or library folders"
+Use `skillBaseDir` when you want a target to place generated skills outside
+its default directory. For example, this writes Factory skills under
+`plugins/logstrip/skills` when combined with a build profile output:
+
+    ```yaml
+    builds:
+      logstrip-factory:
+        output: plugins/logstrip
+        targets:
+          - factory:
+              version: multifile
+              skillBaseDir: skills
+              includeSkills:
+                - logstrip
+    ```
+
+    Run it with:
+
+    ```bash
+    prs compile --build logstrip-factory
+    # or
+    prs build logstrip-factory
+    ```
 
 **Built-in Conventions:**
 
@@ -549,6 +595,44 @@ targets:
 | `codeBlock.prefix`          | string  | Code block start marker                |
 | `codeBlock.suffix`          | string  | Code block end marker                  |
 | `codeBlock.languageSupport` | boolean | Whether to include language identifier |
+
+### builds
+
+Defines named build profiles for compiling a specific entry point to a
+specific set of targets and output directories. Build profiles are useful when
+one repository needs to generate extra artifacts for subpackages, plugins, or
+tool-specific distribution folders without changing the default project build.
+
+```yaml
+builds:
+  logstrip-factory:
+    entry: .promptscript/project.prs
+    output: plugins/logstrip
+    targets:
+      - factory:
+          version: multifile
+          skillBaseDir: skills
+          includeSkills:
+            - logstrip
+```
+
+Run a profile with either command:
+
+```bash
+prs compile --build logstrip-factory
+prs build logstrip-factory
+```
+
+**Build Profile Fields:**
+
+| Field     | Type          | Default          | Description                             |
+| --------- | ------------- | ---------------- | --------------------------------------- |
+| `entry`   | string        | `input.entry`    | Entry file to compile for this profile  |
+| `output`  | string        | `output.baseDir` | Base output directory for this profile  |
+| `targets` | TargetEntry[] | `targets`        | Target list to compile for this profile |
+
+CLI flags still take precedence: `--target`/`--format` override the profile's
+target list, and `--output` overrides the profile's `output`.
 
 ### validation
 

--- a/packages/browser-compiler/src/compiler.ts
+++ b/packages/browser-compiler/src/compiler.ts
@@ -36,6 +36,10 @@ export interface TargetConfig {
   convention?: string;
   /** Target version or format variant */
   version?: string;
+  /** Custom base directory for generated skill files */
+  skillBaseDir?: string;
+  /** Controls which skills are emitted for this target */
+  includeSkills?: boolean | string[];
 }
 
 /**
@@ -318,6 +322,7 @@ export class BrowserCompiler {
       outputPath: config?.output,
       version: config?.version,
       prettier: this.prettierOptions,
+      targetConfig: config,
     };
 
     const conventionName = config?.convention;

--- a/packages/cli/src/__tests__/cli.spec.ts
+++ b/packages/cli/src/__tests__/cli.spec.ts
@@ -115,6 +115,13 @@ describe('cli', () => {
       expect(mockCommand).toHaveBeenCalledWith('compile');
     });
 
+    it('should register build command', async () => {
+      const { run } = await import('../cli.js');
+      run(['node', 'prs', 'build']);
+
+      expect(mockCommand).toHaveBeenCalledWith('build <name>');
+    });
+
     it('should register validate command', async () => {
       const { run } = await import('../cli.js');
       run(['node', 'prs', 'validate']);

--- a/packages/cli/src/__tests__/env-config.spec.ts
+++ b/packages/cli/src/__tests__/env-config.spec.ts
@@ -7,7 +7,6 @@ describe('config/env-config', () => {
   beforeEach(() => {
     // Clean relevant env vars
     delete process.env['PROMPTSCRIPT_REGISTRY_GIT_URL'];
-    delete process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'];
     delete process.env['PROMPTSCRIPT_REGISTRY_GIT_REF'];
     delete process.env['PROMPTSCRIPT_REGISTRY_URL'];
     delete process.env['PROMPTSCRIPT_CACHE_TTL'];
@@ -96,24 +95,6 @@ describe('config/env-config', () => {
 
     // gitRef alone should not create a registry.git entry
     expect(overrides.registry?.git).toBeUndefined();
-  });
-
-  it('should map PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL to registry.git.fallbackUrl', () => {
-    process.env['PROMPTSCRIPT_REGISTRY_GIT_URL'] = 'https://github.com/org/reg.git';
-    process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'] = 'git@github.com:org/reg.git';
-
-    const overrides = loadEnvOverrides();
-
-    expect(overrides.registry?.git?.fallbackUrl).toBe('git@github.com:org/reg.git');
-  });
-
-  it('should create git config with fallbackUrl even without primary URL', () => {
-    process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'] = 'git@github.com:org/reg.git';
-
-    const overrides = loadEnvOverrides();
-
-    expect(overrides.registry?.git?.fallbackUrl).toBe('git@github.com:org/reg.git');
-    expect(overrides.registry?.git?.url).toBe('');
   });
 
   it('should combine multiple env vars', () => {

--- a/packages/cli/src/__tests__/env-config.spec.ts
+++ b/packages/cli/src/__tests__/env-config.spec.ts
@@ -7,6 +7,7 @@ describe('config/env-config', () => {
   beforeEach(() => {
     // Clean relevant env vars
     delete process.env['PROMPTSCRIPT_REGISTRY_GIT_URL'];
+    delete process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'];
     delete process.env['PROMPTSCRIPT_REGISTRY_GIT_REF'];
     delete process.env['PROMPTSCRIPT_REGISTRY_URL'];
     delete process.env['PROMPTSCRIPT_CACHE_TTL'];
@@ -95,6 +96,24 @@ describe('config/env-config', () => {
 
     // gitRef alone should not create a registry.git entry
     expect(overrides.registry?.git).toBeUndefined();
+  });
+
+  it('should map PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL to registry.git.fallbackUrl', () => {
+    process.env['PROMPTSCRIPT_REGISTRY_GIT_URL'] = 'https://github.com/org/reg.git';
+    process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'] = 'git@github.com:org/reg.git';
+
+    const overrides = loadEnvOverrides();
+
+    expect(overrides.registry?.git?.fallbackUrl).toBe('git@github.com:org/reg.git');
+  });
+
+  it('should create git config with fallbackUrl even without primary URL', () => {
+    process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'] = 'git@github.com:org/reg.git';
+
+    const overrides = loadEnvOverrides();
+
+    expect(overrides.registry?.git?.fallbackUrl).toBe('git@github.com:org/reg.git');
+    expect(overrides.registry?.git?.url).toBe('');
   });
 
   it('should combine multiple env vars', () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -101,6 +101,7 @@ program
 program
   .command('compile')
   .description('Compile PromptScript to target formats')
+  .option('-b, --build <name>', 'Named build profile from config.builds')
   .option('-t, --target <target>', 'Specific target (github, claude, cursor)')
   .option('-f, --format <format>', 'Output format (alias for --target)')
   .option('-a, --all', 'All configured targets', true)
@@ -114,6 +115,22 @@ program
   .option('--ignore-hashes', 'Skip reference integrity hash verification')
   .option('--cwd <dir>', 'Working directory (project root)')
   .action((opts) => compileCommand(opts));
+
+program
+  .command('build <name>')
+  .description('Compile a named build profile')
+  .option('-t, --target <target>', 'Specific target (github, claude, cursor)')
+  .option('-f, --format <format>', 'Output format (alias for --target)')
+  .option('-w, --watch', 'Watch mode')
+  .option('-o, --output <dir>', 'Output directory')
+  .option('--dry-run', 'Preview changes')
+  .option('--registry <path>', 'Registry path (overrides config)')
+  .option('-c, --config <path>', 'Path to custom config file')
+  .option('--force', 'Force overwrite existing files without prompts')
+  .option('--strict', 'Treat output path conflicts as errors')
+  .option('--ignore-hashes', 'Skip reference integrity hash verification')
+  .option('--cwd <dir>', 'Working directory (project root)')
+  .action((name, opts) => compileCommand({ ...opts, build: name }));
 
 program
   .command('validate')

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -8,6 +8,7 @@ import type { CliServices } from '../../services.js';
  * private but whose warn path (lines 100-101) must be covered.
  */
 let capturedLogger: Logger | undefined;
+let capturedCompilerOptions: Record<string, unknown> | undefined;
 
 const {
   mockCompile,
@@ -17,6 +18,7 @@ const {
   mockMkdir,
   mockReadFile,
   mockWarn,
+  mockError,
 } = vi.hoisted(() => {
   const mockCompile = vi.fn();
   const mockLoadConfig = vi.fn();
@@ -25,6 +27,7 @@ const {
   const mockMkdir = vi.fn();
   const mockReadFile = vi.fn();
   const mockWarn = vi.fn();
+  const mockError = vi.fn();
   return {
     mockCompile,
     mockLoadConfig,
@@ -33,13 +36,15 @@ const {
     mockMkdir,
     mockReadFile,
     mockWarn,
+    mockError,
   };
 });
 
 vi.mock('@promptscript/compiler', () => ({
   Compiler: class {
-    constructor(opts: { logger?: Logger }) {
+    constructor(opts: { logger?: Logger } & Record<string, unknown>) {
       capturedLogger = opts.logger;
+      capturedCompilerOptions = opts;
     }
     compile = mockCompile;
   },
@@ -81,7 +86,7 @@ vi.mock('../../output/console.js', () => ({
   }),
   ConsoleOutput: {
     success: vi.fn(),
-    error: vi.fn(),
+    error: mockError,
     muted: vi.fn(),
     newline: vi.fn(),
     info: vi.fn(),
@@ -130,6 +135,7 @@ describe('compile command - createCliLogger warn path', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedLogger = undefined;
+    capturedCompilerOptions = undefined;
     process.exitCode = undefined;
 
     mockLoadConfig.mockResolvedValue({
@@ -183,5 +189,94 @@ describe('compile command - createCliLogger warn path', () => {
 
     // Assert: ConsoleOutput.warn was called with the message
     expect(mockWarn).toHaveBeenCalledWith('test warning message');
+  });
+
+  it('should apply a named build profile entry, output, and targets', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['claude'],
+      builds: {
+        logstrip: {
+          entry: '.promptscript/logstrip.prs',
+          output: '../logstrip',
+          targets: [
+            {
+              factory: {
+                version: 'full',
+                skillBaseDir: 'plugins/logstrip/.factory/skills',
+                includeSkills: ['logstrip'],
+              },
+            },
+          ],
+        },
+      },
+    });
+    mockExistsSync.mockImplementation((path: string) => String(path).endsWith('logstrip.prs'));
+    mockCompile.mockResolvedValue({
+      success: true,
+      outputs: new Map([['AGENTS.md', { path: 'AGENTS.md', content: '# Agents\n' }]]),
+      stats: { totalTime: 10, resolveTime: 5, validateTime: 3, formatTime: 2 },
+      warnings: [],
+      errors: [],
+    });
+
+    await compileCommand({ build: 'logstrip', cwd: '/repo/promptscript' }, mockServices);
+
+    expect(mockCompile).toHaveBeenCalledWith('/repo/promptscript/.promptscript/logstrip.prs');
+    expect(capturedCompilerOptions?.['formatters']).toEqual([
+      {
+        name: 'factory',
+        config: {
+          version: 'full',
+          skillBaseDir: 'plugins/logstrip/.factory/skills',
+          includeSkills: ['logstrip'],
+        },
+      },
+    ]);
+    expect(mockWriteFile).toHaveBeenCalledWith('/repo/logstrip/AGENTS.md', '# Agents\n', 'utf-8');
+  });
+
+  it('should let --output override a build profile output', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['claude'],
+      builds: {
+        logstrip: {
+          entry: '.promptscript/logstrip.prs',
+          output: '../logstrip',
+          targets: ['factory'],
+        },
+      },
+    });
+    mockExistsSync.mockImplementation((path: string) => String(path).endsWith('logstrip.prs'));
+    mockCompile.mockResolvedValue({
+      success: true,
+      outputs: new Map([['AGENTS.md', { path: 'AGENTS.md', content: '# Agents\n' }]]),
+      stats: { totalTime: 10, resolveTime: 5, validateTime: 3, formatTime: 2 },
+      warnings: [],
+      errors: [],
+    });
+
+    await compileCommand(
+      { build: 'logstrip', output: '/tmp/prs-build', cwd: '/repo/promptscript' },
+      mockServices
+    );
+
+    expect(mockWriteFile).toHaveBeenCalledWith('/tmp/prs-build/AGENTS.md', '# Agents\n', 'utf-8');
+  });
+
+  it('should fail for an unknown build profile', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['claude'],
+      builds: {
+        known: { targets: ['factory'] },
+      },
+    });
+
+    await compileCommand({ build: 'missing', cwd: '/repo/promptscript' }, mockServices);
+
+    expect(process.exitCode).toBe(1);
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(
+      'Unknown build profile: missing. Available build profiles: known.'
+    );
   });
 });

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,4 +1,4 @@
-import { resolve, dirname } from 'path';
+import { resolve, dirname, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { writeFile, mkdir, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -9,6 +9,7 @@ import type {
   PromptScriptConfig,
   TargetEntry,
   TargetConfig,
+  BuildProfileConfig,
   Lockfile,
 } from '@promptscript/core';
 import { isValidLockfile } from '@promptscript/core';
@@ -122,6 +123,28 @@ function parseTargets(targets: TargetEntry[]): { name: string; config?: TargetCo
       return { name, config };
     })
     .filter((target) => target.config?.enabled !== false);
+}
+
+function getBuildProfile(
+  config: PromptScriptConfig,
+  buildName: string | undefined
+): BuildProfileConfig | undefined {
+  if (!buildName) return undefined;
+
+  const profile = config.builds?.[buildName];
+  if (!profile) {
+    const available = Object.keys(config.builds ?? {});
+    const suffix =
+      available.length > 0 ? ` Available build profiles: ${available.join(', ')}.` : '';
+    throw new Error(`Unknown build profile: ${buildName}.${suffix}`);
+  }
+
+  return profile;
+}
+
+function resolveOutputBase(projectRoot: string, output: string | undefined): string {
+  if (!output) return projectRoot;
+  return isAbsolute(output) ? output : resolve(projectRoot, output);
 }
 
 /**
@@ -437,10 +460,12 @@ export async function compileCommand(
         ? findConfigInDir(projectRoot)
         : undefined;
     const config = await loadConfig(configPath);
+    const buildProfile = getBuildProfile(config, options.build);
 
     // --format is an alias for --target
     const selectedTarget = options.target ?? options.format;
-    const targets = selectedTarget ? [{ name: selectedTarget }] : parseTargets(config.targets);
+    const targetEntries = buildProfile?.targets ?? config.targets;
+    const targets = selectedTarget ? [{ name: selectedTarget }] : parseTargets(targetEntries);
 
     // Detect output path conflicts before doing any work
     const conflicts = detectOutputConflicts(targets);
@@ -511,6 +536,7 @@ export async function compileCommand(
       resolver: {
         registryPath,
         localPath,
+        projectRoot,
         skills: resolveUniversalDir(config.universalDir),
         registries: config.registries,
         lockfile,
@@ -525,9 +551,8 @@ export async function compileCommand(
       ignoreHashes: options.ignoreHashes,
     });
 
-    const entryPath = config.input?.entry
-      ? resolve(projectRoot, config.input.entry)
-      : resolve(localPath, 'project.prs');
+    const entry = buildProfile?.entry ?? config.input?.entry;
+    const entryPath = entry ? resolve(projectRoot, entry) : resolve(localPath, 'project.prs');
 
     if (!existsSync(entryPath)) {
       spinner.fail('Entry file not found');
@@ -555,8 +580,11 @@ export async function compileCommand(
       logger.verbose('Tip: Run "prs lock" to pin remote dependencies for reproducible builds.');
     }
 
-    // When --cwd is set, default output to projectRoot so files land in the right place
-    const effectiveOptions = options.output ? options : { ...options, output: projectRoot };
+    const configuredOutput = options.output ?? buildProfile?.output ?? config.output?.baseDir;
+    const effectiveOptions = {
+      ...options,
+      output: resolveOutputBase(projectRoot, configuredOutput),
+    };
     const writeResult = await writeOutputs(result.outputs, effectiveOptions, config, services);
     if (writeResult.unchanged.length > 0) {
       ConsoleOutput.muted(`Unchanged ${writeResult.unchanged.length} file(s)`);

--- a/packages/cli/src/config/env-config.ts
+++ b/packages/cli/src/config/env-config.ts
@@ -5,6 +5,7 @@ import type { PromptScriptConfig } from '@promptscript/core';
  *
  * Supported env vars:
  * - PROMPTSCRIPT_REGISTRY_GIT_URL → registry.git.url
+ * - PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL → registry.git.fallbackUrl
  * - PROMPTSCRIPT_REGISTRY_GIT_REF → registry.git.ref
  * - PROMPTSCRIPT_REGISTRY_URL → registry.url
  * - PROMPTSCRIPT_CACHE_TTL → registry.cache.ttl (parsed as number)
@@ -14,13 +15,14 @@ export function loadEnvOverrides(): Partial<PromptScriptConfig> {
   const overrides: Partial<PromptScriptConfig> = {};
 
   const gitUrl = process.env['PROMPTSCRIPT_REGISTRY_GIT_URL'];
+  const gitFallbackUrl = process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'];
   const gitRef = process.env['PROMPTSCRIPT_REGISTRY_GIT_REF'];
   const registryUrl = process.env['PROMPTSCRIPT_REGISTRY_URL'];
   const cacheTtl = process.env['PROMPTSCRIPT_CACHE_TTL'];
   const cacheEnabled = process.env['PROMPTSCRIPT_CACHE_ENABLED'];
 
   const hasCache = cacheTtl || cacheEnabled;
-  const hasRegistry = gitUrl || gitRef || registryUrl || hasCache;
+  const hasRegistry = gitUrl || gitFallbackUrl || gitRef || registryUrl || hasCache;
 
   if (!hasRegistry) {
     return overrides;
@@ -28,11 +30,18 @@ export function loadEnvOverrides(): Partial<PromptScriptConfig> {
 
   const registry: NonNullable<PromptScriptConfig['registry']> = {};
 
-  if (gitUrl) {
+  if (gitUrl || gitFallbackUrl || gitRef) {
     registry.git = {
-      url: gitUrl,
+      url: gitUrl ?? '',
+      ...(gitFallbackUrl ? { fallbackUrl: gitFallbackUrl } : {}),
       ...(gitRef ? { ref: gitRef } : {}),
     };
+  }
+
+  // Only set git config when a URL is actually provided (not just ref or fallback)
+  if (gitUrl === undefined && gitFallbackUrl === undefined && gitRef !== undefined) {
+    // gitRef alone should not create a registry.git entry — keep old behavior
+    delete registry.git;
   }
 
   if (registryUrl) {

--- a/packages/cli/src/config/env-config.ts
+++ b/packages/cli/src/config/env-config.ts
@@ -5,7 +5,6 @@ import type { PromptScriptConfig } from '@promptscript/core';
  *
  * Supported env vars:
  * - PROMPTSCRIPT_REGISTRY_GIT_URL → registry.git.url
- * - PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL → registry.git.fallbackUrl
  * - PROMPTSCRIPT_REGISTRY_GIT_REF → registry.git.ref
  * - PROMPTSCRIPT_REGISTRY_URL → registry.url
  * - PROMPTSCRIPT_CACHE_TTL → registry.cache.ttl (parsed as number)
@@ -15,14 +14,13 @@ export function loadEnvOverrides(): Partial<PromptScriptConfig> {
   const overrides: Partial<PromptScriptConfig> = {};
 
   const gitUrl = process.env['PROMPTSCRIPT_REGISTRY_GIT_URL'];
-  const gitFallbackUrl = process.env['PROMPTSCRIPT_REGISTRY_GIT_FALLBACK_URL'];
   const gitRef = process.env['PROMPTSCRIPT_REGISTRY_GIT_REF'];
   const registryUrl = process.env['PROMPTSCRIPT_REGISTRY_URL'];
   const cacheTtl = process.env['PROMPTSCRIPT_CACHE_TTL'];
   const cacheEnabled = process.env['PROMPTSCRIPT_CACHE_ENABLED'];
 
   const hasCache = cacheTtl || cacheEnabled;
-  const hasRegistry = gitUrl || gitFallbackUrl || gitRef || registryUrl || hasCache;
+  const hasRegistry = gitUrl || gitRef || registryUrl || hasCache;
 
   if (!hasRegistry) {
     return overrides;
@@ -30,18 +28,11 @@ export function loadEnvOverrides(): Partial<PromptScriptConfig> {
 
   const registry: NonNullable<PromptScriptConfig['registry']> = {};
 
-  if (gitUrl || gitFallbackUrl || gitRef) {
+  if (gitUrl) {
     registry.git = {
-      url: gitUrl ?? '',
-      ...(gitFallbackUrl ? { fallbackUrl: gitFallbackUrl } : {}),
+      url: gitUrl,
       ...(gitRef ? { ref: gitRef } : {}),
     };
-  }
-
-  // Only set git config when a URL is actually provided (not just ref or fallback)
-  if (gitUrl === undefined && gitFallbackUrl === undefined && gitRef !== undefined) {
-    // gitRef alone should not create a registry.git entry — keep old behavior
-    delete registry.git;
   }
 
   if (registryUrl) {

--- a/packages/cli/src/config/merge-config.ts
+++ b/packages/cli/src/config/merge-config.ts
@@ -48,6 +48,7 @@ function userConfigToProjectRegistry(
   if (userRegistry.git) {
     registry.git = {
       url: userRegistry.git.url,
+      ...(userRegistry.git.fallbackUrl ? { fallbackUrl: userRegistry.git.fallbackUrl } : {}),
       ...(userRegistry.git.ref ? { ref: userRegistry.git.ref } : {}),
       ...(userRegistry.git.path ? { path: userRegistry.git.path } : {}),
       ...(userRegistry.git.auth ? { auth: userRegistry.git.auth } : {}),

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -50,6 +50,8 @@ export interface MigrateOptions {
  * Options for the compile command.
  */
 export interface CompileOptions {
+  /** Named build profile from config.builds */
+  build?: string;
   /** Specific target to compile (github, claude, cursor) */
   target?: string;
   /** Output format (github, claude, cursor) - alias for target */

--- a/packages/cli/src/utils/registry-resolver.ts
+++ b/packages/cli/src/utils/registry-resolver.ts
@@ -68,6 +68,7 @@ export async function resolveRegistryPath(config: PromptScriptConfig): Promise<R
     // will be written by ensureCloned() when we call fetch().
     const registry = createGitRegistry({
       url: gitConfig.url,
+      fallbackUrl: gitConfig.fallbackUrl,
       ref,
       path: gitConfig.path,
       auth: gitConfig.auth,

--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -940,6 +940,58 @@ describe('Compiler', () => {
       expect(skillOutput?.content).toContain('PromptScript Language Skill');
     });
 
+    it('should inject skill into configured skillBaseDir', async () => {
+      const ast = createTestProgram();
+      const formatter = createMockFormatter('factory', 'AGENTS.md', '.factory/skills', 'SKILL.md');
+      vi.spyOn(FormatterRegistry, 'get').mockReturnValue(formatter);
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = createTestCompiler({
+        formatters: [
+          {
+            name: 'factory',
+            config: { skillBaseDir: 'plugins/logstrip/.factory/skills' },
+          },
+        ],
+        skillContent,
+      });
+      const result = await compiler.compile('test.prs');
+
+      expect(result.success).toBe(true);
+      expect(result.outputs.has('plugins/logstrip/.factory/skills/promptscript/SKILL.md')).toBe(
+        true
+      );
+
+      vi.restoreAllMocks();
+    });
+
+    it('should skip injected skill when includeSkills excludes promptscript', async () => {
+      const ast = createTestProgram();
+      const formatter = createMockFormatter('factory', 'AGENTS.md', '.factory/skills', 'SKILL.md');
+      vi.spyOn(FormatterRegistry, 'get').mockReturnValue(formatter);
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = createTestCompiler({
+        formatters: [
+          {
+            name: 'factory',
+            config: { includeSkills: ['logstrip'] },
+          },
+        ],
+        skillContent,
+      });
+      const result = await compiler.compile('test.prs');
+
+      expect(result.success).toBe(true);
+      expect(result.outputs.has('.factory/skills/promptscript/SKILL.md')).toBe(false);
+
+      vi.restoreAllMocks();
+    });
+
     it('should skip injection when skillContent is not provided', async () => {
       const ast = createTestProgram();
       const formatter = createMockFormatter('claude', 'CLAUDE.md', '.claude/skills', 'SKILL.md');

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -96,6 +96,23 @@ function addMarkerToOutput(
   return { ...output, content: lines.join('\n') };
 }
 
+function normalizeOutputDir(dir: string): string {
+  return dir
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/g, '')
+    .split('/')
+    .filter((segment) => segment.length > 0 && segment !== '.' && segment !== '..')
+    .join('/');
+}
+
+function shouldIncludeSkill(name: string, config?: TargetConfig): boolean {
+  const includeSkills = config?.includeSkills;
+  if (includeSkills === false) return false;
+  if (Array.isArray(includeSkills)) return includeSkills.includes(name);
+  return true;
+}
+
 /**
  * Compiler that orchestrates the PromptScript compilation pipeline.
  *
@@ -348,8 +365,17 @@ export class Compiler {
 
     // Inject PromptScript SKILL.md into each formatter's skill directory
     if (this.options.skillContent) {
-      for (const { formatter } of this.loadedFormatters) {
-        const skillBasePath = formatter.getSkillBasePath();
+      for (const { formatter, config } of this.loadedFormatters) {
+        if (!shouldIncludeSkill('promptscript', config)) {
+          this.logger.debug(
+            `  Skipping skill injection for ${formatter.name} (promptscript not included)`
+          );
+          continue;
+        }
+
+        const skillBasePath = config?.skillBaseDir
+          ? normalizeOutputDir(config.skillBaseDir)
+          : formatter.getSkillBasePath();
         const skillFileName = formatter.getSkillFileName();
         if (!skillBasePath || !skillFileName) {
           this.logger.debug(`  Skipping skill injection for ${formatter.name} (no skill support)`);

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -91,6 +91,12 @@ export interface TargetConfig {
 
   /** List generated guard skills in main output file (Factory). @default true */
   guardsSkillsListing?: boolean;
+
+  /** Custom base directory for generated skill files. */
+  skillBaseDir?: string;
+
+  /** Controls which skills are emitted for this target. */
+  includeSkills?: boolean | string[];
 }
 
 /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -174,6 +174,18 @@ export interface PromptScriptConfig {
       /** Git repository URL (HTTPS or SSH) */
       url: string;
       /**
+       * Fallback Git URL to try when the primary `url` fails with an auth error.
+       * Useful when the registry references an HTTPS URL but the user authenticates
+       * via SSH (or vice versa).
+       *
+       * @example
+       * registry:
+       *   git:
+       *     url: 'https://github.com/org/registry.git'
+       *     fallbackUrl: 'git@github.com:org/registry.git'
+       */
+      fallbackUrl?: string;
+      /**
        * Git ref to checkout (branch, tag, or commit hash).
        * @default 'main'
        */
@@ -356,6 +368,7 @@ export interface UserConfig {
   registry?: {
     git?: {
       url: string;
+      fallbackUrl?: string;
       ref?: string;
       path?: string;
       auth?: {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -90,12 +90,39 @@ export interface TargetConfig {
 
   /** List generated guard skills in main output file (Factory). @default true */
   guardsSkillsListing?: boolean;
+
+  /**
+   * Custom base directory for generated skill files.
+   * When set, skill files are emitted under this directory instead of the
+   * target's native skill directory (for example `.factory/skills`).
+   */
+  skillBaseDir?: string;
+
+  /**
+   * Controls which skills are emitted for this target.
+   * - `true` or omitted: emit all skills
+   * - `false`: emit no skills
+   * - string array: emit only the listed skill names
+   */
+  includeSkills?: boolean | string[];
 }
 
 /**
  * Target can be a simple string name or a full configuration object.
  */
 export type TargetEntry = TargetName | { [key in TargetName]?: TargetConfig };
+
+/**
+ * Named build profile for compiling a specific entry point to specific outputs.
+ */
+export interface BuildProfileConfig {
+  /** Entry file path for this build profile */
+  entry?: string;
+  /** Output directory for this build profile */
+  output?: string;
+  /** Target list for this build profile */
+  targets?: TargetEntry[];
+}
 
 /**
  * PromptScript configuration file (promptscript.yaml).
@@ -227,6 +254,13 @@ export interface PromptScriptConfig {
     /** Whether to overwrite existing files without warning */
     overwrite?: boolean;
   };
+
+  /**
+   * Named per-command build profiles.
+   * Profiles let one repository build multiple instruction artifacts to
+   * different target directories without changing the default project compile.
+   */
+  builds?: Record<string, BuildProfileConfig>;
 
   /**
    * Per-source output directories for `@use` imports.

--- a/packages/core/src/types/registries.ts
+++ b/packages/core/src/types/registries.ts
@@ -4,6 +4,18 @@
 export interface RegistryAliasEntry {
   /** Git repository URL (HTTPS or SSH) */
   url: string;
+  /**
+   * Fallback Git URL to try when the primary `url` fails with an auth error.
+   * Useful when registries reference HTTPS URLs but the user authenticates
+   * via SSH (or vice versa).
+   *
+   * @example
+   * registries:
+   *   '@acme':
+   *     url: 'https://github.com/acme/standards.git'
+   *     fallbackUrl: 'git@github.com:acme/standards.git'
+   */
+  fallbackUrl?: string;
   /** Base path within the repository */
   root?: string;
 }

--- a/packages/formatters/src/__tests__/factory.spec.ts
+++ b/packages/formatters/src/__tests__/factory.spec.ts
@@ -2359,5 +2359,69 @@ describe('FactoryFormatter', () => {
       const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
       expect(skillFile?.path).toBe('.factory/etc/SKILL.md');
     });
+
+    it('combines skillBaseDir with non-skills __outputDir', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                audit: {
+                  description: 'Audit skill',
+                  content: 'Audit content.',
+                  __outputDir: 'audit/seo-audit',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, {
+        version: 'multifile',
+        targetConfig: { skillBaseDir: 'plugins/logstrip/.factory/skills' },
+      });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      // Non-skills prefix outputDir is kept under skillBaseDir as-is
+      expect(skillFile?.path).toBe('plugins/logstrip/.factory/skills/audit/seo-audit/SKILL.md');
+    });
+
+    it('uses skillBaseDir with skillName when __outputDir is just skills/', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                myskill: {
+                  description: 'My skill',
+                  content: 'My content.',
+                  __outputDir: 'skills',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, {
+        version: 'multifile',
+        targetConfig: { skillBaseDir: 'plugins/logstrip/.factory/skills' },
+      });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      // "skills" as outputDir strips the skills prefix, leaving empty → falls back to skillName
+      expect(skillFile?.path).toBe('plugins/logstrip/.factory/skills/myskill/SKILL.md');
+    });
   });
 });

--- a/packages/formatters/src/__tests__/factory.spec.ts
+++ b/packages/formatters/src/__tests__/factory.spec.ts
@@ -2208,6 +2208,130 @@ describe('FactoryFormatter', () => {
       expect(skillFile?.path).toBe('.factory/skills/marketing/seo-audit/SKILL.md');
     });
 
+    it('honors target skillBaseDir when generating skill files', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                logstrip: {
+                  description: 'Logstrip skill',
+                  content: 'Compress logs.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, {
+        version: 'multifile',
+        targetConfig: { skillBaseDir: 'plugins/logstrip/.factory/skills' },
+      });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      expect(skillFile?.path).toBe('plugins/logstrip/.factory/skills/logstrip/SKILL.md');
+    });
+
+    it('combines skillBaseDir with __outputDir without duplicating skills segment', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                'seo-audit': {
+                  description: 'SEO audit skill',
+                  content: 'Audit content',
+                  __outputDir: 'skills/marketing/seo-audit',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, {
+        version: 'multifile',
+        targetConfig: { skillBaseDir: 'plugins/logstrip/.factory/skills' },
+      });
+      const skillFile = result.additionalFiles?.find((f) => f.path.endsWith('SKILL.md'));
+      expect(skillFile?.path).toBe('plugins/logstrip/.factory/skills/marketing/seo-audit/SKILL.md');
+    });
+
+    it('filters emitted skills with includeSkills', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                keep: {
+                  description: 'Keep skill',
+                  content: 'Keep content.',
+                },
+                skip: {
+                  description: 'Skip skill',
+                  content: 'Skip content.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, {
+        version: 'multifile',
+        targetConfig: { includeSkills: ['keep'] },
+      });
+      const skillFiles = result.additionalFiles?.filter((f) => f.path.endsWith('SKILL.md')) ?? [];
+      expect(skillFiles.map((f) => f.path)).toEqual(['.factory/skills/keep/SKILL.md']);
+    });
+
+    it('disables emitted skills when includeSkills is false', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'skills',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                logstrip: {
+                  description: 'Logstrip skill',
+                  content: 'Compress logs.',
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, {
+        version: 'multifile',
+        targetConfig: { includeSkills: false },
+      });
+      expect(result.additionalFiles?.some((f) => f.path.endsWith('SKILL.md')) ?? false).toBe(false);
+    });
+
     it('strips traversal segments from __outputDir', () => {
       const ast: Program = {
         ...createMinimalProgram(),

--- a/packages/formatters/src/base-formatter.ts
+++ b/packages/formatters/src/base-formatter.ts
@@ -493,6 +493,50 @@ export abstract class BaseFormatter implements Formatter {
   }
 
   /**
+   * Return true when the target configuration allows emitting the given skill.
+   */
+  protected shouldIncludeSkill(name: string, options?: FormatOptions): boolean {
+    const includeSkills = options?.targetConfig?.includeSkills;
+    if (includeSkills === false) return false;
+    if (Array.isArray(includeSkills)) return includeSkills.includes(name);
+    return true;
+  }
+
+  /**
+   * Resolve the directory for a generated skill, respecting per-target skill
+   * base overrides while preserving existing `@use ... into` behavior.
+   */
+  protected resolveSkillDir(
+    defaultSkillBasePath: string,
+    skillName: string,
+    outputDir?: string,
+    options?: FormatOptions
+  ): string {
+    const configuredBaseDir = options?.targetConfig?.skillBaseDir;
+    const skillBasePath = configuredBaseDir
+      ? this.normalizeOutputDir(configuredBaseDir)
+      : defaultSkillBasePath;
+
+    if (!outputDir) {
+      return `${skillBasePath}/${skillName}`;
+    }
+
+    const normalizedOutputDir = this.normalizeOutputDir(outputDir);
+    if (!configuredBaseDir) {
+      const targetRoot = defaultSkillBasePath.replace(/\/skills$/, '');
+      return `${targetRoot}/${normalizedOutputDir}`;
+    }
+
+    const outputSegments = normalizedOutputDir.split('/').filter((segment) => segment.length > 0);
+    const relativeOutputDir =
+      outputSegments[0] === 'skills' ? outputSegments.slice(1).join('/') : outputSegments.join('/');
+
+    return relativeOutputDir
+      ? `${skillBasePath}/${relativeOutputDir}`
+      : `${skillBasePath}/${skillName}`;
+  }
+
+  /**
    * Filter resource files to only include safe paths.
    * Rejects paths with traversal, absolute paths, and unsafe names.
    */

--- a/packages/formatters/src/formatters/claude.ts
+++ b/packages/formatters/src/formatters/claude.ts
@@ -273,9 +273,9 @@ export class ClaudeFormatter extends BaseFormatter {
     }
 
     // Generate skill files
-    const skills = this.extractSkills(ast);
+    const skills = this.extractSkills(ast, options);
     for (const skill of skills) {
-      additionalFiles.push(this.generateSkillFile(skill));
+      additionalFiles.push(this.generateSkillFile(skill, options));
     }
 
     // Generate agent files
@@ -504,7 +504,7 @@ export class ClaudeFormatter extends BaseFormatter {
   /**
    * Extract skill configurations from @skills block.
    */
-  private extractSkills(ast: Program): ClaudeSkillConfig[] {
+  private extractSkills(ast: Program, options?: FormatOptions): ClaudeSkillConfig[] {
     const skillsBlock = this.findBlock(ast, 'skills');
     if (!skillsBlock) return [];
 
@@ -513,6 +513,7 @@ export class ClaudeFormatter extends BaseFormatter {
 
     for (const [name, value] of Object.entries(props)) {
       if (value && typeof value === 'object' && !Array.isArray(value)) {
+        if (!this.shouldIncludeSkill(name, options)) continue;
         if (!this.isSafeSkillName(name)) continue;
         const obj = value as Record<string, Value>;
         skills.push({
@@ -550,7 +551,7 @@ export class ClaudeFormatter extends BaseFormatter {
   /**
    * Generate a .claude/skills/<name>/SKILL.md file.
    */
-  private generateSkillFile(config: ClaudeSkillConfig): FormatterOutput {
+  private generateSkillFile(config: ClaudeSkillConfig, options?: FormatOptions): FormatterOutput {
     const lines: string[] = [];
 
     // YAML frontmatter (use quotes compatible with Prettier)
@@ -597,9 +598,12 @@ export class ClaudeFormatter extends BaseFormatter {
       lines.push(normalizedContent);
     }
 
-    const skillDirPath = config.outputDir
-      ? `.claude/${this.normalizeOutputDir(config.outputDir)}`
-      : `.claude/skills/${config.name}`;
+    const skillDirPath = this.resolveSkillDir(
+      '.claude/skills',
+      config.name,
+      config.outputDir,
+      options
+    );
     const resourceFiles = this.sanitizeResourceFiles(config.resources, skillDirPath);
 
     const resourcesWithProvenance = resourceFiles.map((f) => {

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -245,7 +245,7 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
   // Skill File Generation (Factory-specific)
   // ============================================================
 
-  protected override extractSkills(ast: Program): FactorySkillConfig[] {
+  protected override extractSkills(ast: Program, options?: FormatOptions): FactorySkillConfig[] {
     const skillsBlock = this.findBlock(ast, 'skills');
     if (!skillsBlock) return [];
 
@@ -255,6 +255,7 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
     for (const [name, value] of Object.entries(props)) {
       if (value && typeof value === 'object' && !Array.isArray(value)) {
         if (!this.isSafeSkillName(name)) continue;
+        if (!this.shouldIncludeSkill(name, options)) continue;
         const obj = value as Record<string, Value>;
         skills.push({
           name,
@@ -284,7 +285,10 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
     return skills;
   }
 
-  protected override generateSkillFile(config: MarkdownSkillConfig): FormatterOutput {
+  protected override generateSkillFile(
+    config: MarkdownSkillConfig,
+    options?: FormatOptions
+  ): FormatterOutput {
     const factoryConfig = config as FactorySkillConfig;
     const lines: string[] = [];
 
@@ -327,9 +331,12 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
       lines.push(dedentedContent);
     }
 
-    const skillDirPath = factoryConfig.outputDir
-      ? `.factory/${this.normalizeOutputDir(factoryConfig.outputDir)}`
-      : `.factory/skills/${factoryConfig.name}`;
+    const skillDirPath = this.resolveSkillDir(
+      '.factory/skills',
+      factoryConfig.name,
+      factoryConfig.outputDir,
+      options
+    );
     const resourceFiles = this.sanitizeResourceFiles(factoryConfig.resources, skillDirPath);
 
     const resourcesWithProvenance = resourceFiles.map((f) => {
@@ -489,7 +496,9 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
   ): FactorySkillConfig[] {
     if (options?.targetConfig?.guardsAsSkills === false) return [];
     const existingNames = new Set(regularSkills.map((s) => s.name));
-    return this.extractGuardSkills(ast, existingNames);
+    return this.extractGuardSkills(ast, existingNames).filter((skill) =>
+      this.shouldIncludeSkill(skill.name, options)
+    );
   }
 
   /**
@@ -525,16 +534,16 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
 
     const regularSkills: FactorySkillConfig[] = [];
     if (this.config.hasSkills && this.config.skillsInMultifile) {
-      const skills = this.extractSkills(ast);
+      const skills = this.extractSkills(ast, options);
       for (const skill of skills) {
-        additionalFiles.push(this.generateSkillFile(skill));
+        additionalFiles.push(this.generateSkillFile(skill, options));
         regularSkills.push(skill as FactorySkillConfig);
       }
     }
 
     const guardSkills = this.maybeExtractGuardSkills(ast, regularSkills, options);
     for (const skill of guardSkills) {
-      additionalFiles.push(this.generateSkillFile(skill));
+      additionalFiles.push(this.generateSkillFile(skill, options));
     }
 
     // Main file content
@@ -565,16 +574,16 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
 
     const regularSkills: FactorySkillConfig[] = [];
     if (this.config.hasSkills) {
-      const skills = this.extractSkills(ast);
+      const skills = this.extractSkills(ast, options);
       for (const skill of skills) {
-        additionalFiles.push(this.generateSkillFile(skill));
+        additionalFiles.push(this.generateSkillFile(skill, options));
         regularSkills.push(skill as FactorySkillConfig);
       }
     }
 
     const guardSkills = this.maybeExtractGuardSkills(ast, regularSkills, options);
     for (const skill of guardSkills) {
-      additionalFiles.push(this.generateSkillFile(skill));
+      additionalFiles.push(this.generateSkillFile(skill, options));
     }
 
     if (this.config.hasAgents) {

--- a/packages/formatters/src/formatters/github.ts
+++ b/packages/formatters/src/formatters/github.ts
@@ -322,9 +322,9 @@ export class GitHubFormatter extends BaseFormatter {
     }
 
     // Generate skill files
-    const skills = this.extractSkills(ast);
+    const skills = this.extractSkills(ast, options);
     for (const skill of skills) {
-      additionalFiles.push(this.generateSkillFile(skill));
+      additionalFiles.push(this.generateSkillFile(skill, options));
     }
 
     // Generate custom agent files (.github/agents/)
@@ -567,7 +567,7 @@ export class GitHubFormatter extends BaseFormatter {
   /**
    * Extract skill configurations from @skills block.
    */
-  private extractSkills(ast: Program): SkillConfig[] {
+  private extractSkills(ast: Program, options?: FormatOptions): SkillConfig[] {
     const skillsBlock = this.findBlock(ast, 'skills');
     if (!skillsBlock) return [];
 
@@ -576,6 +576,7 @@ export class GitHubFormatter extends BaseFormatter {
 
     for (const [name, value] of Object.entries(props)) {
       if (value && typeof value === 'object' && !Array.isArray(value)) {
+        if (!this.shouldIncludeSkill(name, options)) continue;
         const obj = value as Record<string, Value>;
         skills.push({
           name,
@@ -603,7 +604,7 @@ export class GitHubFormatter extends BaseFormatter {
   /**
    * Generate a .github/skills/<name>/SKILL.md file.
    */
-  private generateSkillFile(config: SkillConfig): FormatterOutput {
+  private generateSkillFile(config: SkillConfig, options?: FormatOptions): FormatterOutput {
     const lines: string[] = [];
 
     // YAML frontmatter
@@ -635,9 +636,12 @@ export class GitHubFormatter extends BaseFormatter {
 
     // Strip leading slashes from name for clean file paths
     const cleanName = config.name.replace(/^\/+/, '');
-    const skillDirPath = config.outputDir
-      ? `.github/${this.normalizeOutputDir(config.outputDir)}`
-      : `.github/skills/${cleanName}`;
+    const skillDirPath = this.resolveSkillDir(
+      '.github/skills',
+      cleanName,
+      config.outputDir,
+      options
+    );
     const resourceFiles = this.sanitizeResourceFiles(config.resources, skillDirPath);
 
     const resourcesWithProvenance = resourceFiles.map((f) => {

--- a/packages/formatters/src/markdown-instruction-formatter.ts
+++ b/packages/formatters/src/markdown-instruction-formatter.ts
@@ -207,9 +207,9 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     }
 
     if (this.config.hasSkills && this.config.skillsInMultifile) {
-      const skills = this.extractSkills(ast);
+      const skills = this.extractSkills(ast, options);
       for (const skill of skills) {
-        additionalFiles.push(this.generateSkillFile(skill));
+        additionalFiles.push(this.generateSkillFile(skill, options));
       }
     }
 
@@ -243,9 +243,9 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     }
 
     if (this.config.hasSkills) {
-      const skills = this.extractSkills(ast);
+      const skills = this.extractSkills(ast, options);
       for (const skill of skills) {
-        additionalFiles.push(this.generateSkillFile(skill));
+        additionalFiles.push(this.generateSkillFile(skill, options));
       }
     }
 
@@ -356,7 +356,7 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
   // Skill Extraction & File Generation
   // ============================================================
 
-  protected extractSkills(ast: Program): MarkdownSkillConfig[] {
+  protected extractSkills(ast: Program, options?: FormatOptions): MarkdownSkillConfig[] {
     const skillsBlock = this.findBlock(ast, 'skills');
     if (!skillsBlock) return [];
 
@@ -366,6 +366,7 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     for (const [name, value] of Object.entries(props)) {
       if (value && typeof value === 'object' && !Array.isArray(value)) {
         if (!this.isSafeSkillName(name)) continue;
+        if (!this.shouldIncludeSkill(name, options)) continue;
         const obj = value as Record<string, Value>;
         skills.push({
           name,
@@ -390,7 +391,10 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     return skills;
   }
 
-  protected generateSkillFile(config: MarkdownSkillConfig): FormatterOutput {
+  protected generateSkillFile(
+    config: MarkdownSkillConfig,
+    options?: FormatOptions
+  ): FormatterOutput {
     const lines: string[] = [];
 
     // YAML frontmatter
@@ -435,9 +439,12 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
       }
     }
 
-    const skillDirPath = config.outputDir
-      ? `${this.config.dotDir}/${this.normalizeOutputDir(config.outputDir)}`
-      : `${this.config.dotDir}/skills/${config.name}`;
+    const skillDirPath = this.resolveSkillDir(
+      `${this.config.dotDir}/skills`,
+      config.name,
+      config.outputDir,
+      options
+    );
     const resourceFiles = this.sanitizeResourceFiles(config.resources, skillDirPath);
 
     return {

--- a/packages/resolver/src/__tests__/alias-resolver.spec.ts
+++ b/packages/resolver/src/__tests__/alias-resolver.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { expandAlias, validateAlias, validateRegistriesConfig } from '../alias-resolver.js';
+import {
+  expandAlias,
+  validateAlias,
+  validateRegistriesConfig,
+  findFallbackUrl,
+} from '../alias-resolver.js';
 import { UnknownAliasError } from '@promptscript/core';
 
 describe('alias-resolver', () => {
@@ -119,6 +124,7 @@ describe('alias-resolver', () => {
         repoUrl: 'https://github.com/acme/prs-standards.git',
         path: 'standards/security',
         version: undefined,
+        fallbackUrl: undefined,
       });
     });
 
@@ -136,6 +142,7 @@ describe('alias-resolver', () => {
         repoUrl: 'https://github.com/acme/prs-standards.git',
         path: 'standards/security',
         version: '1.2.0',
+        fallbackUrl: undefined,
       });
     });
 
@@ -153,6 +160,7 @@ describe('alias-resolver', () => {
         repoUrl: 'https://github.com/acme/prs-standards.git',
         path: 'base',
         version: 'v2.0.0-beta.1',
+        fallbackUrl: undefined,
       });
     });
 
@@ -173,6 +181,7 @@ describe('alias-resolver', () => {
         repoUrl: 'git@gitlab.internal.com:company/monorepo.git',
         path: 'packages/prs/auth',
         version: undefined,
+        fallbackUrl: undefined,
       });
     });
 
@@ -193,6 +202,7 @@ describe('alias-resolver', () => {
         repoUrl: 'git@gitlab.internal.com:company/monorepo.git',
         path: 'packages/prs/auth',
         version: '1.0.0',
+        fallbackUrl: undefined,
       });
     });
 
@@ -213,6 +223,7 @@ describe('alias-resolver', () => {
         repoUrl: 'git@gitlab.internal.com:company/monorepo.git',
         path: 'packages/prs',
         version: undefined,
+        fallbackUrl: undefined,
       });
     });
 
@@ -230,6 +241,7 @@ describe('alias-resolver', () => {
         repoUrl: 'https://github.com/acme/prs-standards.git',
         path: '',
         version: undefined,
+        fallbackUrl: undefined,
       });
     });
 
@@ -274,7 +286,82 @@ describe('alias-resolver', () => {
         repoUrl: 'https://github.com/acme/prs-standards.git',
         path: 'security',
         version: undefined,
+        fallbackUrl: undefined,
       });
+    });
+
+    it('should propagate fallbackUrl from extended entry', () => {
+      // Arrange
+      const registries = {
+        '@acme': {
+          url: 'https://github.com/acme/standards.git',
+          fallbackUrl: 'git@github.com:acme/standards.git',
+        },
+      };
+
+      // Act
+      const result = expandAlias('@acme/security', registries);
+
+      // Assert
+      expect(result.repoUrl).toBe('https://github.com/acme/standards.git');
+      expect(result.fallbackUrl).toBe('git@github.com:acme/standards.git');
+    });
+
+    it('should not set fallbackUrl for string entries', () => {
+      // Arrange
+      const registries = {
+        '@acme': 'https://github.com/acme/standards.git',
+      };
+
+      // Act
+      const result = expandAlias('@acme/base', registries);
+
+      // Assert
+      expect(result.fallbackUrl).toBeUndefined();
+    });
+  });
+
+  describe('findFallbackUrl', () => {
+    it('should find fallback URL for a matching repo URL', () => {
+      const registries = {
+        '@acme': {
+          url: 'https://github.com/acme/standards.git',
+          fallbackUrl: 'git@github.com:acme/standards.git',
+        },
+      };
+
+      expect(findFallbackUrl('https://github.com/acme/standards.git', registries)).toBe(
+        'git@github.com:acme/standards.git'
+      );
+    });
+
+    it('should return undefined when no fallbackUrl is configured', () => {
+      const registries = {
+        '@acme': {
+          url: 'https://github.com/acme/standards.git',
+        },
+      };
+
+      expect(findFallbackUrl('https://github.com/acme/standards.git', registries)).toBeUndefined();
+    });
+
+    it('should return undefined for string-only entries', () => {
+      const registries = {
+        '@acme': 'https://github.com/acme/standards.git',
+      };
+
+      expect(findFallbackUrl('https://github.com/acme/standards.git', registries)).toBeUndefined();
+    });
+
+    it('should return undefined when repo URL is not found', () => {
+      const registries = {
+        '@acme': {
+          url: 'https://github.com/acme/standards.git',
+          fallbackUrl: 'git@github.com:acme/standards.git',
+        },
+      };
+
+      expect(findFallbackUrl('https://github.com/other/repo.git', registries)).toBeUndefined();
     });
   });
 });

--- a/packages/resolver/src/__tests__/git-registry-extensions.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry-extensions.spec.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, promises as fs } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { GitRegistry, GitRefNotFoundError, GitCloneError } from '../git-registry.js';
+import { GitRegistry, GitRefNotFoundError, GitCloneError, GitAuthError } from '../git-registry.js';
 import { RegistryCache } from '../registry-cache.js';
 
 // ---------------------------------------------------------------------------
@@ -357,6 +357,166 @@ describe('GitRegistry — extended methods', () => {
           'src/'
         )
       ).rejects.toThrow(GitCloneError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fallbackUrl — cloneAtTag
+  // -------------------------------------------------------------------------
+
+  describe('cloneAtTag() — fallbackUrl', () => {
+    it('retries with fallback URL on auth error', async () => {
+      // Arrange — primary URL fails with auth error, fallback succeeds
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockResolvedValueOnce(undefined);
+
+      // Act
+      await registry.cloneAtTag(
+        'https://github.com/org/repo.git',
+        'v1.0.0',
+        join(testCacheDir, 'fb1'),
+        'git@github.com:org/repo.git'
+      );
+
+      // Assert — called twice: once with primary, once with fallback
+      expect(mockGit.clone).toHaveBeenCalledTimes(2);
+      expect(mockGit.clone).toHaveBeenNthCalledWith(
+        1,
+        'https://github.com/org/repo.git',
+        expect.any(String),
+        expect.arrayContaining(['--branch=v1.0.0'])
+      );
+      expect(mockGit.clone).toHaveBeenNthCalledWith(
+        2,
+        'git@github.com:org/repo.git',
+        expect.any(String),
+        expect.arrayContaining(['--branch=v1.0.0'])
+      );
+    });
+
+    it('throws combined GitAuthError when both URLs fail with auth', async () => {
+      // Arrange — both primary and fallback fail with auth errors
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('Permission denied (publickey)'));
+
+      // Act / Assert
+      await expect(
+        registry.cloneAtTag(
+          'https://github.com/org/repo.git',
+          'v1.0.0',
+          join(testCacheDir, 'fb2'),
+          'git@github.com:org/repo.git'
+        )
+      ).rejects.toThrow(GitAuthError);
+
+      // Verify error message mentions both URLs
+      try {
+        await registry.cloneAtTag(
+          'https://github.com/org/repo.git',
+          'v1.0.0',
+          join(testCacheDir, 'fb2b'),
+          'git@github.com:org/repo.git'
+        );
+      } catch (err) {
+        expect(err).toBeInstanceOf(GitAuthError);
+        expect((err as GitAuthError).message).toContain('both');
+      }
+    });
+
+    it('does not retry with fallback on non-auth error', async () => {
+      // Arrange — primary fails with non-auth error
+      mockGit.clone.mockRejectedValueOnce(new Error('Could not find remote branch v9.9.9'));
+
+      // Act / Assert
+      await expect(
+        registry.cloneAtTag(
+          'https://github.com/org/repo.git',
+          'v9.9.9',
+          join(testCacheDir, 'fb3'),
+          'git@github.com:org/repo.git'
+        )
+      ).rejects.toThrow(GitRefNotFoundError);
+
+      // Only called once — no fallback attempt for ref errors
+      expect(mockGit.clone).toHaveBeenCalledTimes(1);
+    });
+
+    it('succeeds immediately without fallback when primary URL works', async () => {
+      // Arrange — primary URL succeeds
+      mockGit.clone.mockResolvedValueOnce(undefined);
+
+      // Act
+      await registry.cloneAtTag(
+        'https://github.com/org/repo.git',
+        'v1.0.0',
+        join(testCacheDir, 'fb4'),
+        'git@github.com:org/repo.git'
+      );
+
+      // Assert — only one clone call
+      expect(mockGit.clone).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws GitCloneError when fallback fails with non-auth error', async () => {
+      // Arrange — primary auth error, fallback non-auth error
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('Network timeout'));
+
+      // Act / Assert
+      await expect(
+        registry.cloneAtTag(
+          'https://github.com/org/repo.git',
+          'v1.0.0',
+          join(testCacheDir, 'fb5'),
+          'git@github.com:org/repo.git'
+        )
+      ).rejects.toThrow(GitCloneError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fallbackUrl — cloneSparse
+  // -------------------------------------------------------------------------
+
+  describe('cloneSparse() — fallbackUrl', () => {
+    it('retries with fallback URL on auth error', async () => {
+      // Arrange — primary URL fails with auth error, fallback succeeds
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockResolvedValueOnce(undefined);
+
+      // Act
+      await registry.cloneSparse(
+        'https://github.com/org/repo.git',
+        'main',
+        join(testCacheDir, 'sparse-fb1'),
+        'src/',
+        'git@github.com:org/repo.git'
+      );
+
+      // Assert
+      expect(mockGit.clone).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws combined GitAuthError when both sparse URLs fail with auth', async () => {
+      // Arrange
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('Permission denied (publickey)'));
+
+      // Act / Assert
+      await expect(
+        registry.cloneSparse(
+          'https://github.com/org/repo.git',
+          'main',
+          join(testCacheDir, 'sparse-fb2'),
+          'src/',
+          'git@github.com:org/repo.git'
+        )
+      ).rejects.toThrow(GitAuthError);
     });
   });
 });

--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -478,6 +478,60 @@ describe('GitRegistry', () => {
 
       await expect(registry.fetch('@company/base')).rejects.toThrow(GitRefNotFoundError);
     });
+
+    it('should retry with fallbackUrl on auth error', async () => {
+      // Primary URL fails with auth error, fallback succeeds
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockImplementationOnce(async (_url: string, targetPath: string) => {
+          await fs.mkdir(targetPath, { recursive: true });
+          await fs.mkdir(join(targetPath, '@company'), { recursive: true });
+          await fs.writeFile(join(targetPath, '@company', 'base.prs'), '@meta\nname = "base"');
+        });
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        fallbackUrl: 'git@github.com:org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      const content = await registry.fetch('@company/base');
+      expect(content).toContain('name = "base"');
+      expect(mockGit.clone).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw combined auth error when both primary and fallback fail', async () => {
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('Permission denied (publickey)'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        fallbackUrl: 'git@github.com:org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.fetch('@company/base')).rejects.toThrow(GitAuthError);
+      try {
+        await registry.fetch('@company/base');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GitAuthError);
+        expect((err as GitAuthError).message).toContain('both');
+      }
+    });
+
+    it('should not try fallback on non-auth errors', async () => {
+      mockGit.clone.mockRejectedValueOnce(new Error('Network timeout'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        fallbackUrl: 'git@github.com:org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.fetch('@company/base')).rejects.toThrow(GitCloneError);
+      expect(mockGit.clone).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('stale cache handling', () => {

--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -532,6 +532,71 @@ describe('GitRegistry', () => {
       await expect(registry.fetch('@company/base')).rejects.toThrow(GitCloneError);
       expect(mockGit.clone).toHaveBeenCalledTimes(1);
     });
+
+    it('should try fallback ref-error recovery when fallback clone hits ref error', async () => {
+      // Primary: auth error → fallback: ref error → retry without branch
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('Could not find remote branch feature'))
+        .mockImplementationOnce(async (_url: string, targetPath: string) => {
+          await fs.mkdir(targetPath, { recursive: true });
+          await fs.mkdir(join(targetPath, '@company'), { recursive: true });
+          await fs.writeFile(join(targetPath, '@company', 'base.prs'), '@meta\nname = "base"');
+        });
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        fallbackUrl: 'git@github.com:org/repo.git',
+        ref: 'feature',
+        cacheDir: testCacheDir,
+      });
+
+      const content = await registry.fetch('@company/base');
+      expect(content).toContain('name = "base"');
+      // 3 clone calls: primary (auth fail), fallback w/ branch (ref fail), fallback w/o branch
+      expect(mockGit.clone).toHaveBeenCalledTimes(3);
+    });
+
+    it('should throw GitRefNotFoundError when fallback ref does not exist at all', async () => {
+      // Primary: auth error → fallback: ref error → retry without branch → fetch also ref error
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('Could not find remote branch nonexistent'))
+        .mockImplementationOnce(async (_url: string, targetPath: string) => {
+          await fs.mkdir(targetPath, { recursive: true });
+        });
+      mockGit.fetch.mockRejectedValueOnce(new Error('Could not find remote branch nonexistent'));
+      mockGit.checkout.mockRejectedValueOnce(new Error("pathspec 'nonexistent' did not match any"));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        fallbackUrl: 'git@github.com:org/repo.git',
+        ref: 'nonexistent',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.fetch('@company/base')).rejects.toThrow(GitRefNotFoundError);
+    });
+
+    it('should throw GitCloneError when fallback ref-recovery fetch fails with non-ref error', async () => {
+      // Primary: auth error → fallback: ref error → retry without branch → fetch: network error
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('Could not find remote branch feature'))
+        .mockImplementationOnce(async (_url: string, targetPath: string) => {
+          await fs.mkdir(targetPath, { recursive: true });
+        });
+      mockGit.fetch.mockRejectedValueOnce(new Error('Network timeout'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        fallbackUrl: 'git@github.com:org/repo.git',
+        ref: 'feature',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.fetch('@company/base')).rejects.toThrow(GitCloneError);
+    });
   });
 
   describe('stale cache handling', () => {

--- a/packages/resolver/src/__tests__/loader.spec.ts
+++ b/packages/resolver/src/__tests__/loader.spec.ts
@@ -208,6 +208,25 @@ describe('FileLoader', () => {
       );
     });
 
+    it('should allow .promptscript entries to import sibling project directories', () => {
+      const loader = new FileLoader({
+        registryPath: '/registry',
+        localPath: '/project/.promptscript',
+      });
+
+      const ref = {
+        type: 'PathReference' as const,
+        raw: '../skills/specwire-operator',
+        segments: ['..', 'skills', 'specwire-operator'],
+        isRelative: true,
+        loc: { file: '<test>', line: 1, column: 1 },
+      };
+
+      expect(loader.resolveRef(ref, '/project/.promptscript/project.prs')).toBe(
+        '/project/skills/specwire-operator.prs'
+      );
+    });
+
     it('should allow ../sibling from a deeply nested subdirectory', () => {
       const loader = new FileLoader({
         registryPath: '/registry',

--- a/packages/resolver/src/alias-resolver.ts
+++ b/packages/resolver/src/alias-resolver.ts
@@ -17,6 +17,11 @@ import { UnknownAliasError } from '@promptscript/core';
 export interface ExpandedAlias {
   /** Resolved Git repository URL (HTTPS or SSH) */
   repoUrl: string;
+  /**
+   * Fallback Git URL to try when the primary `repoUrl` fails with an auth error.
+   * Populated from `fallbackUrl` in the registry alias entry.
+   */
+  fallbackUrl?: string;
   /** Path within the repository (subPath, with root prepended if configured) */
   path: string;
   /** Optional version tag or semver string (e.g., 'v1.2.0', '1.2.3') */
@@ -179,6 +184,7 @@ export function expandAlias(aliasPath: string, registries: RegistriesConfig): Ex
 
   let repoUrl: string;
   let resolvedPath: string;
+  let fallbackUrl: string | undefined;
 
   if (typeof entry === 'string') {
     repoUrl = entry;
@@ -186,6 +192,7 @@ export function expandAlias(aliasPath: string, registries: RegistriesConfig): Ex
   } else {
     const extEntry = entry as RegistryAliasEntry;
     repoUrl = extEntry.url;
+    fallbackUrl = extEntry.fallbackUrl;
     // Prepend root to subPath when root is configured
     if (extEntry.root) {
       resolvedPath = subPath ? `${extEntry.root}/${subPath}` : extEntry.root;
@@ -194,5 +201,38 @@ export function expandAlias(aliasPath: string, registries: RegistriesConfig): Ex
     }
   }
 
-  return { repoUrl, path: resolvedPath, version };
+  return { repoUrl, path: resolvedPath, version, fallbackUrl };
+}
+
+/**
+ * Find the fallback URL for a given repository URL by scanning the registries config.
+ *
+ * This is used when resolving registry imports where only the expanded `repoUrl`
+ * is available (from the registry marker), but the `fallbackUrl` from the
+ * original alias entry is still needed for clone retries.
+ *
+ * @param repoUrl - The primary repository URL to look up
+ * @param registries - Registry alias configuration to search
+ * @returns The fallback URL if found, or undefined
+ *
+ * @example
+ * ```typescript
+ * findFallbackUrl('https://github.com/acme/standards.git', {
+ *   '@acme': { url: 'https://github.com/acme/standards.git', fallbackUrl: 'git@github.com:acme/standards.git' },
+ * });
+ * // 'git@github.com:acme/standards.git'
+ * ```
+ */
+export function findFallbackUrl(repoUrl: string, registries: RegistriesConfig): string | undefined {
+  for (const entry of Object.values(registries)) {
+    if (typeof entry === 'string') {
+      if (entry === repoUrl) return undefined;
+    } else {
+      const extEntry = entry as RegistryAliasEntry;
+      if (extEntry.url === repoUrl) {
+        return extEntry.fallbackUrl;
+      }
+    }
+  }
+  return undefined;
 }

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -52,6 +52,12 @@ export interface GitAuthOptions {
 export interface GitRegistryOptions {
   /** Git repository URL */
   url: string;
+  /**
+   * Fallback Git URL to try when the primary `url` fails with an auth error.
+   * Useful when the registry references an HTTPS URL but the user authenticates
+   * via SSH (or vice versa).
+   */
+  fallbackUrl?: string;
   /** Git ref to checkout (branch/tag/commit). Defaults to 'main' */
   ref?: string;
   /** Subdirectory within the repository to use as registry root */
@@ -124,6 +130,7 @@ export class GitRefNotFoundError extends Error {
 export class GitRegistry implements Registry {
   private readonly url: string;
   private readonly originalUrl: string;
+  private readonly fallbackUrl: string | undefined;
   private readonly defaultRef: string;
   private readonly subPath: string;
   private readonly auth?: GitAuthOptions;
@@ -135,6 +142,7 @@ export class GitRegistry implements Registry {
   constructor(options: GitRegistryOptions) {
     this.originalUrl = options.url;
     this.url = normalizeGitUrl(options.url);
+    this.fallbackUrl = options.fallbackUrl;
     this.defaultRef = options.ref ?? 'main';
     this.subPath = options.path ?? '';
     this.auth = options.auth;
@@ -247,12 +255,20 @@ export class GitRegistry implements Registry {
 
   /**
    * Clone a repo at a specific Git tag (shallow, depth=1).
+   * When a `fallbackRepoUrl` is provided, auth errors trigger an automatic
+   * retry with the fallback URL.
    *
    * @param repoUrl - Repository URL to clone
    * @param tag - Git tag to check out
    * @param targetDir - Directory to clone into
+   * @param fallbackRepoUrl - Optional fallback URL to try on auth failure
    */
-  async cloneAtTag(repoUrl: string, tag: string, targetDir: string): Promise<void> {
+  async cloneAtTag(
+    repoUrl: string,
+    tag: string,
+    targetDir: string,
+    fallbackRepoUrl?: string
+  ): Promise<void> {
     if (existsSync(targetDir)) {
       await fs.rm(targetDir, { recursive: true, force: true });
     }
@@ -267,6 +283,31 @@ export class GitRegistry implements Registry {
         throw new GitRefNotFoundError(tag, repoUrl);
       }
       if (this.isAuthError(error)) {
+        if (fallbackRepoUrl) {
+          try {
+            await git.clone(fallbackRepoUrl, targetDir, [
+              '--depth=1',
+              `--branch=${tag}`,
+              '--single-branch',
+            ]);
+            return;
+          } catch (fallbackErr) {
+            const fbError =
+              fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
+            if (this.isAuthError(fbError)) {
+              throw new GitAuthError(
+                `Authentication failed for both ${repoUrl} and fallback ${fallbackRepoUrl}`,
+                fallbackRepoUrl,
+                fbError
+              );
+            }
+            throw new GitCloneError(
+              `Failed to clone ${fallbackRepoUrl} at tag ${tag}: ${fbError.message}`,
+              fallbackRepoUrl,
+              fbError
+            );
+          }
+        }
         throw new GitAuthError(`Authentication failed for ${repoUrl}`, repoUrl, error);
       }
       throw new GitCloneError(
@@ -335,17 +376,21 @@ export class GitRegistry implements Registry {
 
   /**
    * Clone with sparse checkout — only fetch the requested path within the repo.
+   * When a `fallbackRepoUrl` is provided, auth errors trigger an automatic
+   * retry with the fallback URL.
    *
    * @param repoUrl - Repository URL
    * @param ref - Git ref (branch, tag, or commit)
    * @param targetDir - Directory to clone into
    * @param sparsePath - Subdirectory path to include in the sparse checkout
+   * @param fallbackRepoUrl - Optional fallback URL to try on auth failure
    */
   async cloneSparse(
     repoUrl: string,
     ref: string,
     targetDir: string,
-    sparsePath: string
+    sparsePath: string,
+    fallbackRepoUrl?: string
   ): Promise<void> {
     if (existsSync(targetDir)) {
       await fs.rm(targetDir, { recursive: true, force: true });
@@ -354,18 +399,30 @@ export class GitRegistry implements Registry {
 
     const git = this.createGit();
     try {
-      await git.clone(repoUrl, targetDir, [
-        '--depth=1',
-        `--branch=${ref}`,
-        '--single-branch',
-        '--filter=blob:none',
-        '--sparse',
-      ]);
-
-      const repoGit = this.createGit(targetDir);
-      await repoGit.raw(['sparse-checkout', 'set', sparsePath]);
+      await this.doCloneSparse(git, repoUrl, ref, targetDir, sparsePath);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      if (this.isAuthError(error) && fallbackRepoUrl) {
+        try {
+          await this.doCloneSparse(git, fallbackRepoUrl, ref, targetDir, sparsePath);
+          return;
+        } catch (fallbackErr) {
+          const fbError =
+            fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
+          if (this.isAuthError(fbError)) {
+            throw new GitAuthError(
+              `Authentication failed for both ${repoUrl} and fallback ${fallbackRepoUrl}`,
+              fallbackRepoUrl,
+              fbError
+            );
+          }
+          throw new GitCloneError(
+            `Failed to sparse-clone ${fallbackRepoUrl} at ${ref}: ${fbError.message}`,
+            fallbackRepoUrl,
+            fbError
+          );
+        }
+      }
       if (this.isRefError(error)) {
         throw new GitRefNotFoundError(ref, repoUrl);
       }
@@ -378,6 +435,33 @@ export class GitRegistry implements Registry {
         error
       );
     }
+  }
+
+  /**
+   * Internal sparse-clone implementation (no fallback logic).
+   */
+  private async doCloneSparse(
+    git: SimpleGit,
+    repoUrl: string,
+    ref: string,
+    targetDir: string,
+    sparsePath: string
+  ): Promise<void> {
+    if (existsSync(targetDir)) {
+      await fs.rm(targetDir, { recursive: true, force: true });
+    }
+    await fs.mkdir(targetDir, { recursive: true });
+
+    await git.clone(repoUrl, targetDir, [
+      '--depth=1',
+      `--branch=${ref}`,
+      '--single-branch',
+      '--filter=blob:none',
+      '--sparse',
+    ]);
+
+    const repoGit = this.createGit(targetDir);
+    await repoGit.raw(['sparse-checkout', 'set', sparsePath]);
   }
 
   /**
@@ -419,6 +503,8 @@ export class GitRegistry implements Registry {
 
   /**
    * Clone the repository to the specified path.
+   * When a `fallbackUrl` is configured, auth errors trigger an automatic
+   * retry with the fallback URL.
    */
   private async clone(targetPath: string, ref: string): Promise<void> {
     // Remove existing directory if present
@@ -461,12 +547,73 @@ export class GitRegistry implements Registry {
         return;
       }
 
-      // Check if it's an auth error
+      // Check if it's an auth error — try fallback URL if available
       if (this.isAuthError(error)) {
+        if (this.fallbackUrl) {
+          try {
+            await this.cloneWithUrl(this.fallbackUrl, targetPath, ref, git);
+            return;
+          } catch (fallbackErr) {
+            const fbError =
+              fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
+            // If fallback also fails with auth error, throw combined message
+            if (this.isAuthError(fbError)) {
+              throw new GitAuthError(
+                `Authentication failed for both ${this.url} and fallback ${this.fallbackUrl}`,
+                this.fallbackUrl,
+                fbError
+              );
+            }
+            // Re-throw non-auth fallback errors as-is
+            throw fbError;
+          }
+        }
         throw new GitAuthError(`Authentication failed for ${this.url}`, this.url, error);
       }
 
       throw new GitCloneError(`Failed to clone repository: ${error.message}`, this.url, error);
+    }
+  }
+
+  /**
+   * Clone using a specific URL (used for fallback attempts).
+   * Handles both branch-specific and fallback-to-full-clone strategies.
+   */
+  private async cloneWithUrl(
+    url: string,
+    targetPath: string,
+    ref: string,
+    git: SimpleGit
+  ): Promise<void> {
+    if (existsSync(targetPath)) {
+      await fs.rm(targetPath, { recursive: true, force: true });
+    }
+    await fs.mkdir(targetPath, { recursive: true });
+
+    try {
+      await git.clone(url, targetPath, ['--depth=1', `--branch=${ref}`, '--single-branch']);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (this.isRefError(error)) {
+        try {
+          await git.clone(url, targetPath, ['--depth=1']);
+          const repoGit = this.createGit(targetPath);
+          await repoGit.fetch(['origin', ref, '--depth=1']);
+          await repoGit.checkout(ref);
+        } catch (fetchErr) {
+          const fetchError = fetchErr instanceof Error ? fetchErr : new Error(String(fetchErr));
+          if (this.isRefError(fetchError)) {
+            throw new GitRefNotFoundError(ref, url);
+          }
+          throw new GitCloneError(
+            `Failed to clone repository: ${fetchError.message}`,
+            url,
+            fetchError
+          );
+        }
+        return;
+      }
+      throw new GitCloneError(`Failed to clone repository: ${error.message}`, url, error);
     }
   }
 

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -125,6 +125,7 @@ export {
 // Alias resolver
 export {
   expandAlias,
+  findFallbackUrl,
   validateAlias,
   validateRegistriesConfig,
   type ExpandedAlias,

--- a/packages/resolver/src/loader.ts
+++ b/packages/resolver/src/loader.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'fs/promises';
-import { resolve, dirname, isAbsolute, relative } from 'path';
+import { resolve, dirname, basename, isAbsolute, relative } from 'path';
 import type { PathReference, RegistriesConfig, Lockfile } from '@promptscript/core';
 import { FileNotFoundError } from '@promptscript/core';
 import type { Registry } from './registry.js';
@@ -58,6 +58,8 @@ export interface LoaderOptions {
   registryPath: string;
   /** Base path for local/relative file resolution */
   localPath?: string;
+  /** Project root used as the traversal safety boundary */
+  projectRoot?: string;
   /** Optional Registry implementation for file fetching */
   registry?: Registry;
   /** Registry alias configuration for remote imports */
@@ -72,11 +74,16 @@ export interface LoaderOptions {
 export class FileLoader {
   private readonly registryPath: string;
   private readonly localPath: string;
+  private readonly projectRoot: string;
   private readonly options: LoaderOptions;
 
   constructor(options: LoaderOptions) {
     this.registryPath = options.registryPath;
     this.localPath = resolve(options.localPath ?? process.cwd());
+    this.projectRoot = resolve(
+      options.projectRoot ??
+        (basename(this.localPath) === '.promptscript' ? dirname(this.localPath) : this.localPath)
+    );
     this.options = options;
   }
 
@@ -147,10 +154,10 @@ export class FileLoader {
         ref.raw.endsWith('.prs') || ref.raw.endsWith('.md') ? ref.raw : `${ref.raw}.prs`;
       const resolved = resolve(dir, rawPath);
 
-      // Path traversal check: resolved path must remain under the project root (localPath).
+      // Path traversal check: resolved path must remain under the project root.
       // Uses relative() instead of startsWith() so the check works with both
       // forward-slash (Unix) and backslash (Windows) path separators.
-      const rel = relative(this.localPath, resolved);
+      const rel = relative(this.projectRoot, resolved);
       if (rel.startsWith('..') || isAbsolute(rel)) {
         throw new Error(`Path traversal outside project root is not allowed: ${ref.raw}`);
       }

--- a/packages/resolver/src/registry-cache.ts
+++ b/packages/resolver/src/registry-cache.ts
@@ -47,7 +47,7 @@ export class RegistryCache {
       const raw = await readFile(metaPath, 'utf-8');
       const parsed: unknown = JSON.parse(raw);
       const meta = parsed as CacheMeta;
-      return Date.now() - meta.cachedAt > ttlMs;
+      return Date.now() - meta.cachedAt >= ttlMs;
     } catch {
       return true;
     }

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -42,6 +42,7 @@ import { resolveSkillComposition } from './skill-composition.js';
 import { GitRegistry } from './git-registry.js';
 import { RegistryCache } from './registry-cache.js';
 import { discoverNativeContent } from './auto-discovery.js';
+import { findFallbackUrl } from './alias-resolver.js';
 
 /**
  * Options for the resolver.
@@ -682,8 +683,13 @@ export class Resolver {
         this.logger.verbose(`Registry cache miss, cloning: ${repoUrl}@${tag}`);
         cachePath = this.registryCache.getCachePath(repoUrl, effectiveVersion);
 
+        // Look up fallback URL from registries config (for HTTPS→SSH auth retry)
+        const fallbackRepoUrl = this.options.registries
+          ? findFallbackUrl(repoUrl, this.options.registries)
+          : undefined;
+
         // Clone using GitRegistry
-        await this.gitRegistry.cloneAtTag(repoUrl, tag, cachePath);
+        await this.gitRegistry.cloneAtTag(repoUrl, tag, cachePath, fallbackRepoUrl);
 
         // Record in RegistryCache
         const commitHash = lockEntry?.commit ?? 'unknown';

--- a/schema/config.json
+++ b/schema/config.json
@@ -69,6 +69,11 @@
               "type": "string",
               "description": "Git repository URL (HTTPS or SSH)"
             },
+            "fallbackUrl": {
+              "type": "string",
+              "description": "Fallback Git URL to try when the primary `url` fails with an auth error. Useful when the registry references an HTTPS URL but the user authenticates via SSH (or vice versa).",
+              "example": "registry:\n  git:\n    url: 'https://github.com/org/registry.git'\n    fallbackUrl: 'git@github.com:org/registry.git'"
+            },
             "ref": {
               "type": "string",
               "description": "Git ref to checkout (branch, tag, or commit hash).",
@@ -330,6 +335,11 @@
         "url": {
           "type": "string",
           "description": "Git repository URL (HTTPS or SSH)"
+        },
+        "fallbackUrl": {
+          "type": "string",
+          "description": "Fallback Git URL to try when the primary `url` fails with an auth error. Useful when registries reference HTTPS URLs but the user authenticates via SSH (or vice versa).",
+          "example": "registries:\n  '@acme':\n    url: 'https://github.com/acme/standards.git'\n    fallbackUrl: 'git@github.com:acme/standards.git'"
         },
         "root": {
           "type": "string",

--- a/schema/config.json
+++ b/schema/config.json
@@ -217,6 +217,13 @@
       "additionalProperties": false,
       "description": "Output configuration. Global output settings applied to all targets."
     },
+    "builds": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/BuildProfileConfig"
+      },
+      "description": "Named per-command build profiles. Profiles let one repository build multiple instruction artifacts to different target directories without changing the default project compile."
+    },
     "skillTargets": {
       "type": "object",
       "additionalProperties": {
@@ -335,71 +342,27 @@
       "additionalProperties": false,
       "description": "Extended registry alias entry for monorepos or custom roots."
     },
-    "FormattingConfig": {
+    "BuildProfileConfig": {
       "type": "object",
       "properties": {
-        "prettier": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/PrettierMarkdownOptions"
-            }
-          ],
-          "description": "Enable Prettier formatting.\n- `true`: Auto-detect .prettierrc in project\n- `string`: Path to Prettier config file\n- `PrettierMarkdownOptions`: Explicit options",
-          "example": "formatting:\n  prettier: true  # Auto-detect\n\nformatting:\n  prettier: \"./config/.prettierrc\"  # Explicit path\n\nformatting:\n  proseWrap: always\n  tabWidth: 4"
-        },
-        "proseWrap": {
+        "entry": {
           "type": "string",
-          "enum": [
-            "always",
-            "never",
-            "preserve"
-          ],
-          "description": "Explicit proseWrap setting (shorthand for prettier.proseWrap)."
+          "description": "Entry file path for this build profile"
         },
-        "tabWidth": {
-          "type": "number",
-          "description": "Explicit tabWidth setting (shorthand for prettier.tabWidth)."
+        "output": {
+          "type": "string",
+          "description": "Output directory for this build profile"
         },
-        "printWidth": {
-          "type": "number",
-          "description": "Explicit printWidth setting (shorthand for prettier.printWidth)."
+        "targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TargetEntry"
+          },
+          "description": "Target list for this build profile"
         }
       },
       "additionalProperties": false,
-      "description": "Formatting configuration for output files. Controls how generated markdown is formatted."
-    },
-    "PrettierMarkdownOptions": {
-      "type": "object",
-      "properties": {
-        "proseWrap": {
-          "type": "string",
-          "enum": [
-            "always",
-            "never",
-            "preserve"
-          ],
-          "description": "How to wrap prose.\n- 'always': Wrap prose at printWidth\n- 'never': Do not wrap prose\n- 'preserve': Preserve original wrapping",
-          "default": "preserve"
-        },
-        "tabWidth": {
-          "type": "number",
-          "description": "Number of spaces per indentation level.",
-          "default": 2
-        },
-        "printWidth": {
-          "type": "number",
-          "description": "Maximum line width for prose wrapping.",
-          "default": 80
-        }
-      },
-      "additionalProperties": false,
-      "description": "Prettier markdown formatting options. These options control how markdown output is formatted."
+      "description": "Named build profile for compiling a specific entry point to specific outputs."
     },
     "TargetEntry": {
       "anyOf": [
@@ -616,6 +579,24 @@
           "type": "boolean",
           "description": "List generated guard skills in main output file (Factory).",
           "default": true
+        },
+        "skillBaseDir": {
+          "type": "string",
+          "description": "Custom base directory for generated skill files. When set, skill files are emitted under this directory instead of the target's native skill directory (for example `.factory/skills`)."
+        },
+        "includeSkills": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Controls which skills are emitted for this target.\n- `true` or omitted: emit all skills\n- `false`: emit no skills\n- string array: emit only the listed skill names"
         }
       },
       "additionalProperties": false,
@@ -639,6 +620,72 @@
         "markdown"
       ],
       "description": "Built-in convention names."
+    },
+    "FormattingConfig": {
+      "type": "object",
+      "properties": {
+        "prettier": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/PrettierMarkdownOptions"
+            }
+          ],
+          "description": "Enable Prettier formatting.\n- `true`: Auto-detect .prettierrc in project\n- `string`: Path to Prettier config file\n- `PrettierMarkdownOptions`: Explicit options",
+          "example": "formatting:\n  prettier: true  # Auto-detect\n\nformatting:\n  prettier: \"./config/.prettierrc\"  # Explicit path\n\nformatting:\n  proseWrap: always\n  tabWidth: 4"
+        },
+        "proseWrap": {
+          "type": "string",
+          "enum": [
+            "always",
+            "never",
+            "preserve"
+          ],
+          "description": "Explicit proseWrap setting (shorthand for prettier.proseWrap)."
+        },
+        "tabWidth": {
+          "type": "number",
+          "description": "Explicit tabWidth setting (shorthand for prettier.tabWidth)."
+        },
+        "printWidth": {
+          "type": "number",
+          "description": "Explicit printWidth setting (shorthand for prettier.printWidth)."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Formatting configuration for output files. Controls how generated markdown is formatted."
+    },
+    "PrettierMarkdownOptions": {
+      "type": "object",
+      "properties": {
+        "proseWrap": {
+          "type": "string",
+          "enum": [
+            "always",
+            "never",
+            "preserve"
+          ],
+          "description": "How to wrap prose.\n- 'always': Wrap prose at printWidth\n- 'never': Do not wrap prose\n- 'preserve': Preserve original wrapping",
+          "default": "preserve"
+        },
+        "tabWidth": {
+          "type": "number",
+          "description": "Number of spaces per indentation level.",
+          "default": 2
+        },
+        "printWidth": {
+          "type": "number",
+          "description": "Maximum line width for prose wrapping.",
+          "default": 80
+        }
+      },
+      "additionalProperties": false,
+      "description": "Prettier markdown formatting options. These options control how markdown output is formatted."
     },
     "OutputConvention": {
       "type": "object",


### PR DESCRIPTION
## Summary
- add named build profiles via `prs compile --build <name>` and `prs build <name>`
- support per-target `skillBaseDir` and `includeSkills` for generated skill outputs
- allow .promptscript entries to import sibling project directories safely
- document build profiles and update the JSON schema

## Validation
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm prs compile --cwd /Users/wogu/Work/Comarch/specwire --dry-run`
- `pnpm prs compile --config /tmp/prs-logstrip-build.yaml --cwd /Users/wogu/Work/Projects/logstrip --build logstrip-factory --dry-run`