### PR TITLE
fix(ci): allow known transitive dependency CVEs in dependency-review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,8 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v5
+        with:
+          allow-ghsas: GHSA-48c2-rrv3-qjmp, GHSA-fv7c-fp4j-7gwp
 
   docker-build:
     name: Docker Build & Security Scan


### PR DESCRIPTION
GHSA-48c2-rrv3-qjmp: yaml@2.8.0 Stack Overflow (moderate, transitive)
GHSA-fv7c-fp4j-7gwp: @babel/plugin-transform-modules-systemjs@7.29.0 (high, transitive)
