### PR TITLE
feat(ci): harden self-hosted runner security with dual runner and least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'self-hosted' }}
 
     strategy:
       matrix:
@@ -108,7 +111,7 @@ jobs:
   cli-smoke-test:
     name: CLI Smoke Test (Node ${{ matrix.node-version }})
     needs: build
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'self-hosted' }}
     container:
       image: node:${{ matrix.node-version }}-slim
 
@@ -436,7 +439,7 @@ jobs:
 
   codeql:
     name: CodeQL Analysis
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'self-hosted' }}
     permissions:
       security-events: write
       actions: read
@@ -455,7 +458,7 @@ jobs:
 
   dependency-review:
     name: Dependency Review
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'self-hosted' }}
     if: github.event_name == 'pull_request'
 
     steps:
@@ -468,7 +471,7 @@ jobs:
 
   docker-build:
     name: Docker Build & Security Scan
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'self-hosted' }}
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,10 +17,13 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     name: Git Registry Integration
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'self-hosted' }}
 
     steps:
       - name: Checkout with submodules

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -9,9 +9,12 @@ on:
     paths: ['apps/vscode/**', 'packages/parser/src/lexer/**']
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   package:
-    runs-on: self-hosted
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
- Fork PRs now run on ubuntu-latest (isolated), push/main on self-hosted
- Added workflow-level permissions: contents: read (ci, integration, vscode)
- Prevents arbitrary code execution from untrusted forks on self-hosted runner
