### PR TITLE
fix(formatters,compiler): filter Factory frontmatter on injected PromptScript skill

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -407,7 +407,9 @@ export class Compiler {
 
         const skillOutput: FormatterOutput = {
           path: skillPath,
-          content: this.options.skillContent,
+          content: formatter.transformInjectedSkillContent
+            ? formatter.transformInjectedSkillContent(this.options.skillContent)
+            : this.options.skillContent,
         };
         outputs.set(skillPath, addMarkerToOutput(skillOutput, sourceLabel, 'promptscript'));
         this.logger.verbose(`  → ${skillPath} (auto-injected promptscript skill)`);

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -62,6 +62,13 @@ export interface Formatter {
   getSkillFileName(): string | null;
   /** How this formatter handles skill references: 'directory', 'inline', or 'none' */
   referencesMode(): 'directory' | 'inline' | 'none';
+  /**
+   * Optional hook to transform the raw content of a pass-through skill file
+   * (e.g. the bundled PromptScript SKILL.md) before it is written. Formatters
+   * whose target tools enforce frontmatter schemas can override this to strip
+   * unsupported fields.
+   */
+  transformInjectedSkillContent?(content: string): string;
 }
 
 /**

--- a/packages/formatters/src/__tests__/factory.spec.ts
+++ b/packages/formatters/src/__tests__/factory.spec.ts
@@ -2078,6 +2078,54 @@ describe('FactoryFormatter', () => {
     });
   });
 
+  describe('transformInjectedSkillContent', () => {
+    it('strips unsupported frontmatter fields from injected SKILL.md content', () => {
+      const injected = [
+        '---',
+        'name: promptscript',
+        'description: Test description',
+        'license: MIT',
+        'metadata:',
+        '  author: PromptScript',
+        '  homepage: https://example.com',
+        'compatibility:',
+        '  - claude-code',
+        '  - github-copilot',
+        'allowed-tools:',
+        '  - Read',
+        '  - Write',
+        'user-invocable: true',
+        '---',
+        '',
+        '# Body content',
+        'Body text remains untouched.',
+        '',
+      ].join('\n');
+
+      const transformed = formatter.transformInjectedSkillContent(injected);
+
+      expect(transformed).toContain('name: promptscript');
+      expect(transformed).toContain('description: Test description');
+      expect(transformed).toContain('user-invocable: true');
+      expect(transformed).not.toContain('license:');
+      expect(transformed).not.toContain('metadata:');
+      expect(transformed).not.toContain('compatibility:');
+      expect(transformed).not.toContain('allowed-tools:');
+      expect(transformed).toContain('# Body content');
+      expect(transformed).toContain('Body text remains untouched.');
+    });
+
+    it('returns content unchanged when no frontmatter is present', () => {
+      const content = '# Plain skill\n\nNo frontmatter here.\n';
+      expect(formatter.transformInjectedSkillContent(content)).toBe(content);
+    });
+
+    it('returns content unchanged when frontmatter has no closing delimiter', () => {
+      const content = '---\nname: broken\nno closing delimiter\n';
+      expect(formatter.transformInjectedSkillContent(content)).toBe(content);
+    });
+  });
+
   describe('guards as skills', () => {
     it('should generate skill files from @guards named entries', () => {
       const ast: Program = {

--- a/packages/formatters/src/base-formatter.ts
+++ b/packages/formatters/src/base-formatter.ts
@@ -670,6 +670,15 @@ export abstract class BaseFormatter implements Formatter {
   }
 
   /**
+   * Default pass-through for injected skill content. Formatters whose target
+   * tools restrict skill frontmatter (e.g. Factory AI) override this hook to
+   * filter unsupported fields before the compiler writes the file.
+   */
+  transformInjectedSkillContent(content: string): string {
+    return content;
+  }
+
+  /**
    * Generate a provenance comment for a reference file.
    */
   protected referenceProvenance(sourcePath: string): string {

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -731,4 +731,24 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
 
     return filtered;
   }
+
+  /**
+   * Filter the frontmatter of an externally-supplied SKILL.md file (such as
+   * the bundled PromptScript skill injected by the compiler) so it only
+   * contains fields Factory AI recognises. The body is preserved verbatim.
+   * Files without a YAML frontmatter block are returned unchanged.
+   */
+  override transformInjectedSkillContent(content: string): string {
+    if (!content.startsWith('---')) return content;
+
+    const closing = content.indexOf('\n---', 3);
+    if (closing === -1) return content;
+
+    const rawFrontmatter = content.slice(4, closing);
+    const body = content.slice(closing + 4); // skip closing ---
+    const filteredLines = this.filterFactoryFrontmatter(rawFrontmatter);
+    const filteredFrontmatter = filteredLines.join('\n');
+
+    return `---\n${filteredFrontmatter}\n---${body}`;
+  }
 }

--- a/packages/formatters/src/types.ts
+++ b/packages/formatters/src/types.ts
@@ -63,6 +63,15 @@ export interface Formatter {
   getSkillFileName(): string | null;
   /** How this formatter handles skill references: 'directory', 'inline', or 'none' */
   referencesMode(): 'directory' | 'inline' | 'none';
+  /**
+   * Transform the raw content of a pass-through skill file (e.g. the bundled
+   * PromptScript SKILL.md injected by the compiler) before it is written to
+   * disk. Formatters whose target tools enforce frontmatter schemas (such as
+   * Factory AI) can override this to strip unsupported fields.
+   *
+   * Defaults to identity when not implemented.
+   */
+  transformInjectedSkillContent?(content: string): string;
 }
 
 /**


### PR DESCRIPTION
## Problem

Factory AI refuses to load `.factory/skills/promptscript/SKILL.md` when the frontmatter contains fields outside its supported set (`name`, `description`, `user-invocable`, `disable-model-invocation`).

#270 added `filterFactoryFrontmatter()` to strip unsupported fields, but it only runs from `FactoryFormatter.generateSkillFile()` — i.e. for skills emitted from `@skills` blocks in `.prs` sources. The **bundled PromptScript SKILL.md** takes a different path: the compiler injects it directly into every supporting formatter's skill directory via `CompilerOptions.skillContent` (`packages/compiler/src/compiler.ts`), bypassing the formatter altogether. As a result the raw `skills/promptscript/SKILL.md` frontmatter (`license`, `metadata`, `compatibility`, `allowed-tools`, …) shipped verbatim into Factory's skill directory and Droid silently skipped the skill.

## Fix

Introduce an optional formatter hook for post-processing injected skill files:

- `Formatter.transformInjectedSkillContent?(content: string): string` declared in both `packages/formatters/src/types.ts` and the parallel compiler-side `Formatter` interface.
- Identity default on `BaseFormatter` keeps every other formatter unchanged.
- `FactoryFormatter` overrides it: splits the `---` block, reuses the existing `filterFactoryFrontmatter()` on the frontmatter, leaves the body untouched.
- `Compiler` calls `formatter.transformInjectedSkillContent?.(content)` before `addMarkerToOutput()` when writing the auto-injected skill.

## Tests

Existing Factory frontmatter filter coverage in `packages/formatters/src/__tests__/factory.spec.ts` exercises the same code path. All checks green locally: `format`, `lint`, `typecheck`, `test` (1620+ formatter tests), `prs validate --strict`, `schema:check`, `grammar:check`.

## Verification

After this change, `pnpm prs compile` produces:

```yaml
---
# promptscript-generated: …
name: promptscript
description: >-
  …
user-invocable: true
---
```

Factory Droid loads the skill correctly.