### PR TITLE
fix(formatters): preserve Factory standards grouping

### DIFF
--- a/packages/formatters/src/__tests__/__golden__/factory/full.md
+++ b/packages/formatters/src/__tests__/__golden__/factory/full.md
@@ -43,19 +43,30 @@ flowchart TB
 
 ## Conventions & Patterns
 
+### TypeScript
+
 - Strict mode enabled
 - Never use `any` type - use `unknown` with type guards
 - Prefer `interface` for object shapes
 - Use `type` for unions and intersections
 - Named exports only, no default exports
 - Explicit return types on public functions
+
+### Naming Conventions
+
 - Files: `kebab-case.ts`
 - Classes/Interfaces: `PascalCase`
 - Functions/Variables: `camelCase`
 - Constants: `UPPER_SNAKE_CASE`
+
+### Error Handling
+
 - Use custom error classes extending `PSError`
 - Always include location information
 - Provide actionable error messages
+
+### Testing
+
 - Test files: `*.spec.ts` next to source
 - Follow AAA (Arrange, Act, Assert) pattern
 - Target >90% coverage for libraries

--- a/packages/formatters/src/__tests__/__golden__/factory/multifile.md
+++ b/packages/formatters/src/__tests__/__golden__/factory/multifile.md
@@ -43,19 +43,30 @@ flowchart TB
 
 ## Conventions & Patterns
 
+### TypeScript
+
 - Strict mode enabled
 - Never use `any` type - use `unknown` with type guards
 - Prefer `interface` for object shapes
 - Use `type` for unions and intersections
 - Named exports only, no default exports
 - Explicit return types on public functions
+
+### Naming Conventions
+
 - Files: `kebab-case.ts`
 - Classes/Interfaces: `PascalCase`
 - Functions/Variables: `camelCase`
 - Constants: `UPPER_SNAKE_CASE`
+
+### Error Handling
+
 - Use custom error classes extending `PSError`
 - Always include location information
 - Provide actionable error messages
+
+### Testing
+
 - Test files: `*.spec.ts` next to source
 - Follow AAA (Arrange, Act, Assert) pattern
 - Target >90% coverage for libraries

--- a/packages/formatters/src/__tests__/__golden__/factory/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/factory/simple.md
@@ -43,19 +43,30 @@ flowchart TB
 
 ## Conventions & Patterns
 
+### TypeScript
+
 - Strict mode enabled
 - Never use `any` type - use `unknown` with type guards
 - Prefer `interface` for object shapes
 - Use `type` for unions and intersections
 - Named exports only, no default exports
 - Explicit return types on public functions
+
+### Naming Conventions
+
 - Files: `kebab-case.ts`
 - Classes/Interfaces: `PascalCase`
 - Functions/Variables: `camelCase`
 - Constants: `UPPER_SNAKE_CASE`
+
+### Error Handling
+
 - Use custom error classes extending `PSError`
 - Always include location information
 - Provide actionable error messages
+
+### Testing
+
 - Test files: `*.spec.ts` next to source
 - Follow AAA (Arrange, Act, Assert) pattern
 - Target >90% coverage for libraries

--- a/packages/formatters/src/__tests__/factory.spec.ts
+++ b/packages/formatters/src/__tests__/factory.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import type { Program, SourceLocation } from '@promptscript/core';
+import type { Program, SourceLocation, Value } from '@promptscript/core';
 import { FactoryFormatter, FACTORY_VERSIONS } from '../formatters/factory.js';
 
 const createLoc = (): SourceLocation => ({
@@ -14,6 +14,22 @@ const createMinimalProgram = (): Program => ({
   blocks: [],
   extends: [],
   loc: createLoc(),
+});
+
+const createStandardsProgram = (properties: Record<string, Value>): Program => ({
+  ...createMinimalProgram(),
+  blocks: [
+    {
+      type: 'Block',
+      name: 'standards',
+      content: {
+        type: 'ObjectContent',
+        properties,
+        loc: createLoc(),
+      },
+      loc: createLoc(),
+    },
+  ],
 });
 
 describe('FactoryFormatter', () => {
@@ -245,6 +261,89 @@ describe('FactoryFormatter', () => {
       // Should not contain sections for absent blocks
       expect(result.content).not.toContain('## Git Workflows');
       expect(result.content).not.toContain("## Don'ts");
+    });
+  });
+
+  describe('standards grouping', () => {
+    it('should group multiple custom entries under titled subsections', () => {
+      const ast = createStandardsProgram({
+        native_sql: ['Use parameterized queries', 'Avoid SELECT *'],
+        'DDL-types': ['Use explicit column types'],
+      });
+
+      const result = formatter.format(ast, { version: 'simple' });
+
+      expect(result.content.match(/^### .+$/gm)).toEqual(['### Native Sql', '### DDL Types']);
+      expect(result.content).toContain(
+        '### Native Sql\n\n- Use parameterized queries\n- Avoid SELECT *'
+      );
+      expect(result.content).toContain('### DDL Types\n\n- Use explicit column types');
+    });
+
+    it('should use known human-readable title mappings', () => {
+      const ast = createStandardsProgram({
+        sql: ['Prefer ANSI SQL'],
+        errors: ['Return actionable errors'],
+      });
+
+      const result = formatter.format(ast, { version: 'simple' });
+
+      expect(result.content).toContain('### SQL\n\n- Prefer ANSI SQL');
+      expect(result.content).toContain('### Error Handling\n\n- Return actionable errors');
+    });
+
+    it('should omit empty entries while preserving source order', () => {
+      const ast = createStandardsProgram({
+        first_rules: ['First rule'],
+        empty_array: [],
+        'empty-object': { enabled: false },
+        'second-rules': ['Second rule'],
+      });
+
+      const result = formatter.format(ast, { version: 'simple' });
+
+      expect(result.content.match(/^### .+$/gm)).toEqual(['### First Rules', '### Second Rules']);
+      expect(result.content.indexOf('### First Rules')).toBeLessThan(
+        result.content.indexOf('### Second Rules')
+      );
+      expect(result.content).not.toContain('Empty Array');
+      expect(result.content).not.toContain('Empty Object');
+    });
+
+    it('should preserve source order when legacy code standards are present', () => {
+      const ast = createStandardsProgram({
+        typescript: ['Use strict mode'],
+        code: {
+          style: ['Prefer immutable data'],
+          patterns: ['Use dependency injection'],
+        },
+        testing: ['Use Vitest'],
+      });
+
+      const result = formatter.format(ast, { version: 'simple' });
+
+      expect(result.content.match(/^### .+$/gm)).toEqual([
+        '### TypeScript',
+        '### Code Style',
+        '### Testing',
+      ]);
+    });
+
+    it('should preserve grouped standards across all Factory versions', () => {
+      const ast = createStandardsProgram({
+        typescript: ['Use strict mode'],
+        testing: ['Use Vitest'],
+      });
+
+      const versions = ['simple', 'multifile', 'full'] as const;
+      const contents = versions.map((version) => formatter.format(ast, { version }).content);
+
+      for (const content of contents) {
+        expect(content).toContain('## Conventions & Patterns');
+        expect(content).toContain('### TypeScript\n\n- Use strict mode');
+        expect(content).toContain('### Testing\n\n- Use Vitest');
+      }
+      expect(new Set(contents).size).toBe(1);
     });
   });
 

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -1,5 +1,6 @@
 import type { Program, Value } from '@promptscript/core';
 import { posix } from 'path';
+import type { ConventionRenderer } from '../convention-renderer.js';
 import {
   MarkdownInstructionFormatter,
   type MarkdownAgentConfig,
@@ -162,6 +163,28 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
 
   override referencesMode(): 'directory' | 'inline' | 'none' {
     return 'directory';
+  }
+
+  protected override codeStandards(ast: Program, renderer: ConventionRenderer): string | null {
+    const standards = this.findBlock(ast, 'standards');
+    if (!standards) return null;
+
+    const extracted = this.standardsExtractor.extract(standards.content);
+    const subsections: string[] = [];
+
+    for (const key of Object.keys(this.getProps(standards.content))) {
+      const entry = extracted.codeStandards.get(key);
+      if (!entry) continue;
+      if (entry.items.length === 0) continue;
+
+      subsections.push(renderer.renderSection(entry.title, renderer.renderList(entry.items), 2));
+    }
+
+    if (subsections.length === 0) return null;
+
+    return (
+      renderer.renderSection(this.getSectionName('codeStandards'), subsections.join('\n\n')) + '\n'
+    );
   }
 
   override format(ast: Program, options?: FormatOptions): FormatterOutput {


### PR DESCRIPTION
## Summary

- Preserve standards group boundaries in Factory output instead of flattening every item into one list.
- Render clear, human-readable subsections under `Conventions & Patterns`.
- Retain original source order, including configurations that mix legacy `code` standards with named groups.
- Keep output behavior consistent across supported Factory versions and update golden coverage.

## User value

Generated instructions retain the structure and ownership model defined by authors, making enterprise standards easier for users and agents to navigate without changing their meaning.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`

Closes #294