### PR TITLE
test(formatters): add agent platform contract fixtures

### DIFF
--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/README.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/README.md
@@ -1,0 +1,72 @@
+# Agent Platform Contract Fixtures
+
+Captured upstream contracts for every formatter target this plan touches.
+Each fixture records the minimal valid file shape, the source URL, the
+observed upstream version, the retrieval date, and the expected project-local
+path PromptScript should emit. Formatters MUST NOT add a path or feature that
+is not backed by a fixture in this tree.
+
+## Fixture record format
+
+Every fixture directory contains an `INDEX.md` with one row per captured file:
+
+| Field         | Purpose                                                     |
+| ------------- | ----------------------------------------------------------- |
+| File          | Fixture filename in this directory                          |
+| Source URL    | Official documentation page used to capture the contract    |
+| Version       | Upstream version observed on the retrieval date             |
+| Retrieved     | ISO date the source was fetched and verified                |
+| Expected path | Project-local path PromptScript must emit for this artifact |
+| Notes         | Contract constraints, scope, or out-of-scope classification |
+
+## Directory layout
+
+```
+platform-contracts/
+├── README.md            # This file
+├── claude/              # Claude Code workflows, hooks, settings, routines OOS
+├── github/              # GitHub Copilot custom agents
+├── cursor/              # Cursor skills, subagents, hooks, automations
+├── antigravity/         # Antigravity AGENTS.md, AgentKit, workflows
+├── codex/               # Codex skills, agent TOML, hooks, plugins, nesting
+├── gemini/              # Gemini CLI skills alias, nested GEMINI.md
+├── grok/                # Grok Build AGENTS.md + Claude compatibility
+├── agents-md-spec/      # AGENTS.md open spec + v1.1 proposal status
+├── skill-md-spec/       # SKILL.md open standard (agentskills.io)
+├── factory/             # Factory AGENTS.md discovery hierarchy
+├── agents-md-only/      # AGENTS.md-only targets family
+│   ├── amazon-q/
+│   ├── warp/
+│   ├── zed/
+│   ├── aider/
+│   ├── jules/
+│   └── devin/
+└── priority-b/
+    ├── kimi/
+    ├── mimo/
+    ├── deep-agents/
+    └── forgecode/
+```
+
+## Scope classification
+
+Each INDEX.md marks every target as one of:
+
+- `formatter-scope` - project-local instruction or skill file emitted by a formatter
+- `out-of-scope` - runtime/hosted/user-level feature with no project-local contract
+- `rejected` - no stable project-local contract exists; no formatter will be added
+
+Runtime-only features (Claude hosted routines, Cursor automations, Codex Goal
+mode, etc.) are recorded as out-of-scope so future tasks do not re-investigate
+them without an upstream versioned project-local schema.
+
+## Verification policy
+
+- Sources are official vendor documentation or canonical spec repositories.
+- Retrieval dates use ISO 8601 (`YYYY-MM-DD`).
+- Versions come from the source page's "Last updated" stamp, changelog entry,
+  or release tag visible on the retrieval date.
+- When the source has no version stamp, `Version` records `unversioned` plus
+  the changelog entry or release that the contract reflects.
+- A fixture is the contract. Implementation tasks reference fixtures by
+  relative path so changes to upstream docs surface as fixture diffs.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/INDEX.md
@@ -1,0 +1,83 @@
+# AGENTS.md-Only Target Family
+
+These platforms read `AGENTS.md` natively and have no target-specific
+instruction file contract beyond it. PromptScript emits a single `AGENTS.md`
+per target with `hasSkills: false`, `hasAgents: false`, `hasCommands: false`
+(Task 6).
+
+## Family index
+
+| Target    | Source URL                                                | Retrieved  | Expected path | Scope           |
+| --------- | --------------------------------------------------------- | ---------- | ------------- | --------------- |
+| amazon-q  | https://github.com/aws/amazon-q-developer-cli/issues/2712 | 2026-07-17 | `AGENTS.md`   | formatter-scope |
+| warp      | https://docs.warp.dev/agent-platform/capabilities/rules/  | 2026-07-17 | `AGENTS.md`   | formatter-scope |
+| zed       | https://zed.dev/docs/ai/instructions                      | 2026-07-17 | `AGENTS.md`   | formatter-scope |
+| aider     | https://aider.chat/docs/usage/conventions.html            | 2026-07-17 | `AGENTS.md`   | formatter-scope |
+| jules     | https://jules.google/docs/                                | 2026-07-17 | `AGENTS.md`   | formatter-scope |
+| devin     | https://docs.devin.ai/cli/extensibility/rules             | 2026-07-17 | `AGENTS.md`   | formatter-scope |
+| phoenix   | (rejected - see phoenix/INDEX.md)                         | 2026-07-17 | n/a           | rejected        |
+| swe-agent | (rejected - see swe-agent/INDEX.md)                       | 2026-07-17 | n/a           | rejected        |
+
+## Shared contract
+
+- Output path: `AGENTS.md` (root) or `<package>/AGENTS.md` (nested, via build
+  profiles in Task 19).
+- Plain Markdown, no frontmatter (AGENTS.md v1.1 frontmatter is experimental
+  and opt-in - Task 20).
+- Target-neutral Markdown content; no target branding inside the instruction
+  body.
+- `hasSkills: false`, `hasAgents: false`, `hasCommands: false`.
+- `simple`, `multifile`, and `full` versions emit the same single file
+  (compatibility aliases).
+
+## Per-target notes
+
+- **Warp** also reads `WARP.md` for backwards compatibility; if both exist in
+  the same directory, `WARP.md` takes priority. Filename must be all caps.
+  Warp links `CLAUDE.md`, `.cursorrules`, `AGENT.md`, `GEMINI.md`,
+  `.clinerules`, `.windsurfrules`, `.github/copilot-instructions.md` as
+  external rules files. PromptScript emits `AGENTS.md` only; `WARP.md` is a
+  legacy alias and not generated.
+- **Zed** uses `AGENTS.md` as the primary instruction file. Zed also reads
+  `.rules`, `.cursorrules`, `.windsurfrules`, `.clinerules`,
+  `.github/copilot-instructions.md`, `AGENT.md`, `CLAUDE.md`, `GEMINI.md` as
+  fallbacks (first match wins). Project instructions override personal
+  `~/.config/zed/AGENTS.md`. Skills live at `.agents/skills/` (project) and
+  `~/.agents/skills/` (user) - separate from the AGENTS.md instruction file.
+- **Aider** loads conventions via `--read CONVENTIONS.md` or always-load via
+  `.aider.conf.yml` `read:`. AGENTS.md is loaded as project-level
+  conventions. No frontmatter, no skill directory.
+- **Jules** automatically looks for `AGENTS.md` in the root of the repo.
+  Cloud coding agent; no project-local skill or agent file contract.
+- **Devin CLI** reads `AGENTS.md` (recommended), `AGENTS.local.md`
+  (gitignored personal), `AGENT.md`, `.windsurfrules`, `CLAUDE.md`. Also reads
+  `.cursor/rules/*.md{,c}`, `.windsurf/rules/*.md`, `.claude/`. AGENTS.md is
+  always-on. Personal `~/.config/devin/AGENTS.md` is user-level (out of
+  scope). Skills are recommended over rules where possible, but no
+  project-local skill directory contract is documented for the CLI; skills
+  belong to Devin Desktop / Cascade.
+- **Amazon Q Developer CLI** has an open feature request to read AGENTS.md
+  (issue #2712). Custom agents exist but use Amazon Q's own agent
+  configuration, not AGENTS.md. Treat as AGENTS.md-only with the caveat that
+  upstream AGENTS.md support is tracked but not yet GA in the CLI. If a
+  fixture confirms AGENTS.md is not read, move to `rejected`.
+
+## Collision handling (Task 6)
+
+- If two AGENTS.md-only targets in one build generate identical content,
+  coalesce output owners and report an informational diagnostic instead of an
+  overwrite warning.
+- If generated content differs, retain collision warning behavior.
+- Identical shared output is deterministic regardless of target order.
+
+## Rejected targets
+
+- **Phoenix**: The "Phoenix" name in the research doc refers to a platform
+  listed as AGENTS.md-native. Search results show "Phoenix" is Arize Phoenix
+  (AI observability) and "Phoenix" the Elixir web framework - neither is an
+  AGENTS.md-reading coding agent. No stable project-local instruction file
+  contract can be confirmed. Rejected until a verified Phoenix coding agent
+  fixture is captured.
+- **SWE-agent**: Uses `.yaml` config files passed via `--config`, not
+  AGENTS.md. SWE-agent is now in maintenance-only mode, superseded by
+  mini-swe-agent. No AGENTS.md contract. Rejected.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/aider/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/aider/INDEX.md
@@ -1,0 +1,40 @@
+# Aider
+
+Source: https://aider.chat/docs/usage/conventions.html
+Retrieved: 2026-07-17
+Version: Aider (current)
+
+## Contract
+
+Aider loads conventions via `--read CONVENTIONS.md` (or `/read
+CONVENTIONS.md` in chat), marked as read-only and cached if prompt caching is
+enabled. Always-load conventions can be configured in `.aider.conf.yml`:
+
+```yaml
+# alone
+read: CONVENTIONS.md
+
+# multiple files
+read: [CONVENTIONS.md, anotherfile.txt]
+```
+
+Aider reads `AGENTS.md` as project-level conventions (the cross-tool
+standard). No frontmatter, no skill directory, no agent file. Aider is a
+pair-programming tool that works via diffs/patches.
+
+## Expected path
+
+`AGENTS.md` (root).
+
+## Scope classification
+
+`formatter-scope`. Aider has no project-local skill or agent file contract.
+
+## PromptScript action (Task 6)
+
+- `outputPath: 'AGENTS.md'`
+- `hasSkills: false`, `hasAgents: false`, `hasCommands: false`
+- Target-neutral Markdown content; no Aider branding inside the body.
+- `simple`, `multifile`, `full` versions emit the same single file.
+- Aider does not document nested AGENTS.md discovery; emit root only unless a
+  later fixture confirms nested support.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/amazon-q/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/amazon-q/INDEX.md
@@ -1,0 +1,37 @@
+# Amazon Q Developer CLI
+
+Source: https://github.com/aws/amazon-q-developer-cli (repo),
+https://github.com/aws/amazon-q-developer-cli/issues/2712 (AGENTS.md feature
+request),
+https://aws.amazon.com/blogs/devops/overcome-development-disarray-with-amazon-q-developer-cli/
+Retrieved: 2026-07-17
+Version: amazon-q-developer-cli (current)
+
+## Contract
+
+Amazon Q Developer CLI is an agentic terminal chat experience. Custom agents
+exist but use Amazon Q's own agent configuration format, not AGENTS.md.
+
+An open feature request (issue #2712, Aug 28 2025) asks Amazon Q to read
+`AGENTS.md` on project start, noting that "most of these seem to be
+converging to using AGENTS.md in the project folder for agent instructions
+and project specific tools, conventions and hints." The issue is not confirmed
+merged as of the retrieval date.
+
+## Expected path
+
+`AGENTS.md` (root) - contingent on issue #2712 landing.
+
+## Scope classification
+
+`formatter-scope` with a caveat: upstream AGENTS.md support is tracked but
+not yet GA in the CLI. PromptScript emits `AGENTS.md` for the `amazon-q`
+target. If a later fixture confirms AGENTS.md is not read by Amazon Q, move
+this target to `rejected`.
+
+## PromptScript action (Task 6)
+
+- `outputPath: 'AGENTS.md'`
+- `hasSkills: false`, `hasAgents: false`, `hasCommands: false`
+- Target-neutral Markdown content; no AWS branding inside the body.
+- `simple`, `multifile`, `full` versions emit the same single file.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/devin/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/devin/INDEX.md
@@ -1,0 +1,72 @@
+# Devin CLI
+
+Source: https://docs.devin.ai/cli/extensibility/rules,
+https://docs.devin.ai/desktop/cascade/agents-md
+Retrieved: 2026-07-17
+Version: Devin CLI (current)
+
+## Contract
+
+Devin CLI reads rules from any of these files:
+
+| File              | Notes                           |
+| ----------------- | ------------------------------- |
+| `AGENTS.md`       | Recommended                     |
+| `AGENTS.local.md` | Personal rules (gitignored)     |
+| `AGENT.md`        | Singular alternative            |
+| `.windsurfrules`  | Legacy Windsurf workspace rules |
+| `CLAUDE.md`       | Compatible with Claude Code     |
+
+All are treated identically - loaded as always-on rules. Files can exist at
+multiple levels in the project. Files at the workspace root are loaded at
+session start. Files in subdirectories are discovered lazily when the agent
+accesses files in that directory.
+
+Global rules: `~/.config/devin/AGENTS.md` (Linux/macOS) or
+`%APPDATA%\devin\AGENTS.md` (Windows) - user-level, out of scope. `AGENT.md`
+is also supported at the global location. If you use Claude Code, Devin CLI
+also reads `~/.claude/CLAUDE.md` as a global rule.
+
+Devin CLI also reads `.cursor/rules/*.md{,c}`, `.windsurf/rules/*.md`, and
+`.claude/` directory contents from other tools. Cursor rules frontmatter
+(`description`, `globs`, `alwaysApply`) and Windsurf rules frontmatter
+(`description`, `trigger`) are honored.
+
+Devin recommends Skills over Rules where possible. Skills are injected only
+when relevant; rules are always-on. The recommended pattern is a rule that
+references skills. Project-local skill directory contract for Devin CLI is
+not documented in the rules page; skills belong to Devin Desktop / Cascade.
+
+`read_config_from` in `~/.config/devin/config.json` (or `.devin/config.json`)
+controls imports:
+
+```json
+{
+  "read_config_from": {
+    "agents_standard": true,
+    "cursor": true,
+    "windsurf": true,
+    "claude": true
+  }
+}
+```
+
+## Expected path
+
+`AGENTS.md` (root) or `<package>/AGENTS.md` (nested, lazy discovery).
+
+`AGENTS.local.md` is personal (gitignored) - PromptScript must NOT emit it.
+
+## Scope classification
+
+`formatter-scope` for `AGENTS.md`.
+
+## PromptScript action (Task 6)
+
+- `outputPath: 'AGENTS.md'`
+- `hasSkills: false`, `hasAgents: false`, `hasCommands: false`
+- Target-neutral Markdown content; no Devin branding inside the body.
+- `simple`, `multifile`, `full` versions emit the same single file.
+- Nested `AGENTS.md` through build profiles (Task 19). Devin discovers
+  subdirectory rules lazily.
+- Never emit `AGENTS.local.md` (personal, gitignored).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/jules/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/jules/INDEX.md
@@ -1,0 +1,38 @@
+# Jules
+
+Source: https://jules.google/docs/
+Retrieved: 2026-07-17
+Version: Jules (current)
+
+## Contract
+
+Jules is an autonomous coding agent that runs in a virtual machine where it
+clones your code, installs dependencies, and modifies files. It integrates
+with GitHub.
+
+"Jules now automatically looks for a file named AGENTS.md in the root of your
+repository. This file can describe the agents or tools in your codebase, such
+as what they do, how to interact with them, or any input and output
+conventions. Jules uses this file to better understand your code and generate
+more relevant plans and completions."
+
+Keep AGENTS.md up to date - it helps Jules and teammates work with your repo.
+
+## Expected path
+
+`AGENTS.md` (root). Jules reads only the root `AGENTS.md`; nested discovery
+is not documented.
+
+## Scope classification
+
+`formatter-scope`. Jules is a cloud coding agent with no project-local skill
+or agent file contract.
+
+## PromptScript action (Task 6)
+
+- `outputPath: 'AGENTS.md'`
+- `hasSkills: false`, `hasAgents: false`, `hasCommands: false`
+- Target-neutral Markdown content; no Jules/Google branding inside the body.
+- `simple`, `multifile`, `full` versions emit the same single file.
+- Jules reads root `AGENTS.md` only. Do not emit nested AGENTS.md for Jules
+  unless a later fixture confirms nested discovery.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/phoenix/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/phoenix/INDEX.md
@@ -1,0 +1,36 @@
+# Phoenix - Rejected
+
+Source: web search 2026-07-17
+Retrieved: 2026-07-17
+Scope: rejected
+
+## Why rejected
+
+The "Phoenix" entry in the research doc (Section 2, Priority A) refers to a
+platform listed as AGENTS.md-native with "AI development platform" as the
+note. Search results on 2026-07-17 return two distinct products named
+"Phoenix", neither of which is an AGENTS.md-reading coding agent:
+
+1. **Arize Phoenix** (https://github.com/Arize-ai/phoenix) - AI Observability
+   & Evaluation tool. Integrates with coding agents via CLI, MCP, and skills
+   (https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents)
+   but is itself an observability product, not a coding agent that reads
+   project-level instructions.
+2. **Phoenix (Elixir web framework)** - the web framework, not a coding agent.
+
+No stable project-local instruction file contract for an AGENTS.md-reading
+"Phoenix" coding agent can be confirmed.
+
+## What PromptScript must not do
+
+- Do NOT add a `phoenix` target to `KnownTarget`.
+- Do NOT add a Phoenix formatter.
+- Do NOT add Phoenix to the AGENTS.md-only family.
+
+## Reopen condition
+
+Reopen only if a verified Phoenix coding agent with a stable project-local
+AGENTS.md contract is identified and a fixture is captured under this
+directory. The research doc's Priority C already lists niche/emerging
+candidates that require discovery before implementation; Phoenix belongs in
+that backlog until verified.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/swe-agent/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/swe-agent/INDEX.md
@@ -1,0 +1,40 @@
+# SWE-agent - Rejected
+
+Source: https://swe-agent.com/latest/config/config/,
+https://swe-agent.com/latest/reference/agent_config/
+Retrieved: 2026-07-17
+Version: SWE-agent (maintenance-only, superseded by mini-swe-agent)
+Scope: rejected
+
+## Why rejected
+
+SWE-agent does NOT read `AGENTS.md`. It uses `.yaml` configuration files
+passed via the `--config` flag on the command line:
+
+```
+sweagent run --config config/your_config.yaml
+sweagent run-batch --config config/your_config.yaml
+```
+
+Config files define tools, prompts, demonstrations, model behavior, and the
+I/O interface between agent and environment. Relative paths resolve to
+`SWE_AGENT_CONFIG_ROOT` or the SWE-agent repository root. The default config
+is `config/default.yaml`.
+
+SWE-agent is now in maintenance-only mode and has been superseded by
+mini-swe-agent (https://mini-swe-agent.com/). The docs explicitly redirect
+users to mini-swe-agent.
+
+No project-local AGENTS.md instruction file contract exists.
+
+## What PromptScript must not do
+
+- Do NOT add a `swe-agent` target to `KnownTarget`.
+- Do NOT add an SWE-agent formatter.
+- Do NOT add SWE-agent to the AGENTS.md-only family.
+
+## Reopen condition
+
+Reopen only if SWE-agent or mini-swe-agent ships a stable project-local
+AGENTS.md instruction file contract and a fixture is captured. The
+maintenance-only status makes this unlikely.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/warp/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/warp/INDEX.md
@@ -1,0 +1,50 @@
+# Warp
+
+Source: https://docs.warp.dev/agent-platform/capabilities/rules/
+Retrieved: 2026-07-17
+Version: Warp (changelog updated July 10 2026)
+
+## Contract
+
+Warp's Project Rules live in an `AGENTS.md` file (or `WARP.md` for backwards
+compatibility) and can be placed in the root of the repository or in
+subdirectories for more targeted guidance.
+
+The filename must be in all caps for Warp to recognize it (`AGENTS.md`, not
+`agents.md` or `Agents.md`). If both `WARP.md` and `AGENTS.md` exist in the
+same directory, `WARP.md` takes priority.
+
+Warp automatically applies the `AGENTS.md` (or `WARP.md`) in the root and in
+the current directory. If you edit files in another subdirectory, Warp makes
+a best-effort attempt to include that subdirectory's rules file as well.
+
+Rules precedence:
+
+1. Rules in the current subdirectory's project rules file
+2. Rules in the root directory's project rules file
+3. Global Rules (user-level, out of scope)
+
+Warp's `/init` slash command generates an `AGENTS.md` file with initial
+context, or links an existing Rules file to `AGENTS.md`. Warp supports
+linking these external Rules files: `CLAUDE.md`, `.cursorrules`, `AGENT.md`,
+`GEMINI.md`, `.clinerules`, `.windsurfrules`,
+`.github/copilot-instructions.md`.
+
+## Expected path
+
+`AGENTS.md` (root) or `<package>/AGENTS.md` (nested).
+
+`WARP.md` is a legacy alias. PromptScript emits `AGENTS.md` only; `WARP.md`
+is not generated.
+
+## Scope classification
+
+`formatter-scope`.
+
+## PromptScript action (Task 6)
+
+- `outputPath: 'AGENTS.md'`
+- `hasSkills: false`, `hasAgents: false`, `hasCommands: false`
+- Target-neutral Markdown content; no Warp branding inside the body.
+- `simple`, `multifile`, `full` versions emit the same single file.
+- Nested `AGENTS.md` through build profiles (Task 19).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/zed/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-only/zed/INDEX.md
@@ -1,0 +1,59 @@
+# Zed
+
+Source: https://zed.dev/docs/ai/instructions, https://zed.dev/docs/ai/skills,
+https://zed.dev/docs/ai/zed-agent
+Retrieved: 2026-07-17
+Version: Zed (agent panel updated May 22 2026)
+
+## Contract
+
+Zed uses `AGENTS.md` as the primary instruction file for personal and
+project-level agent guidance.
+
+Personal instructions: `~/.config/zed/AGENTS.md` (user-level, out of scope).
+On Windows: `%APPDATA%\Zed\AGENTS.md`.
+
+Project instruction files - Zed uses the first matching file in this list:
+
+1. `.rules`
+2. `.cursorrules`
+3. `.windsurfrules`
+4. `.clinerules`
+5. `.github/copilot-instructions.md`
+6. `AGENT.md`
+7. `AGENTS.md`
+8. `CLAUDE.md`
+9. `GEMINI.md`
+
+Project instructions override personal `AGENTS.md` when they conflict.
+
+Skills (separate from instructions):
+
+- Global: `~/.agents/skills/` (user-level, out of scope)
+- Project-local: `<worktree>/.agents/skills/` (formatter-scope, but only
+  loaded from trusted worktrees)
+
+Skills follow the Agent Skills open standard. `SKILL.md` frontmatter: `name`
+(required), `description` (required), `disable-model-invocation` (optional).
+Other Agent Skills spec fields planned for the future. Flat layout only -
+skills must be direct children of the skills root. 50KB catalog budget.
+
+## Expected path
+
+`AGENTS.md` (root) or `<package>/AGENTS.md` (nested).
+
+## Scope classification
+
+`formatter-scope` for `AGENTS.md`. Project-local skills at
+`.agents/skills/` are also formatter-scope but require worktree trust; the
+AGENTS.md-only target family emits the instruction file only.
+
+## PromptScript action (Task 6)
+
+- `outputPath: 'AGENTS.md'`
+- `hasSkills: false`, `hasAgents: false`, `hasCommands: false`
+- Target-neutral Markdown content; no Zed branding inside the body.
+- `simple`, `multifile`, `full` versions emit the same single file.
+- Nested `AGENTS.md` through build profiles (Task 19).
+- Zed reads `AGENTS.md` before fallbacks, so emitting `AGENTS.md` is
+  preferred over `.github/copilot-instructions.md` when Zed is a target.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-spec/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-spec/INDEX.md
@@ -1,0 +1,83 @@
+# AGENTS.md Open Specification
+
+Source: https://github.com/agentsmd/agents.md (repo), https://agents.md/
+Retrieved: 2026-07-17
+Version: spec repo last commit d1ac7f0 (Mar 12 2026); v1.1 proposal open
+
+## Contract (v1.0, shipped)
+
+AGENTS.md is a simple, open Markdown format for guiding coding agents. It is
+plain Markdown; headings provide semantic hints. There is no frontmatter in
+the shipped v1.0 spec.
+
+Minimal example:
+
+```markdown
+# Sample AGENTS.md file
+
+## Dev environment tips
+
+- Use `pnpm dlx turbo run where <project_name>` to jump to a package.
+- Run `pnpm install --filter <project_name>` to add the package to your workspace.
+
+## Testing instructions
+
+- Find the CI plan in the .github/workflows folder.
+- Run `pnpm turbo run test --filter <project_name>` to run every check.
+
+## PR instructions
+
+- Title format: [<project_name>] <Title>
+- Always run `pnpm lint` and `pnpm test` before committing.
+```
+
+## v1.1 proposal (open, not merged)
+
+Source: https://github.com/agentsmd/agents.md/issues/135
+
+The v1.1 proposal adds optional YAML frontmatter:
+
+- `description` (<=200 chars)
+- `tags` array
+
+Purpose: progressive disclosure in monorepos with nested AGENTS.md files.
+
+## Risk
+
+YAML frontmatter remains an open proposal. Enabling it by default could break
+consumers that expect Markdown from the first line.
+
+## PromptScript action (Task 20)
+
+Implement only behind an experimental target option:
+
+```yaml
+targets:
+  - factory:
+      agentsFrontmatter: experimental
+```
+
+- Read `description` and `tags` from entry `@meta`.
+- Enforce description length (<=200 chars) and normalized unique tags.
+- Emit no frontmatter by default.
+- Reject the option for a target whose fixture does not accept frontmatter.
+- Remove the `experimental` name only after the standard is merged and
+  consumers pass compatibility tests.
+
+Existing output remains byte-compatible when the option is absent.
+
+## Nested AGENTS.md
+
+Confirmed native in: Codex (88 nested files in OpenAI's own monorepo),
+Factory (nearest-first walk), Cursor, Kilo Code, GitHub Copilot, Warp, Grok,
+Zed, Devin, Jules.
+
+## AGENTS.override.md (Codex-only)
+
+Replaces rather than extends parent instructions. Codex-only. PromptScript
+must reject the override filename for non-Codex targets (Task 19).
+
+## 32 KiB cap (Codex)
+
+Codex enforces a 32 KiB cap per AGENTS.md file. PromptScript must validate
+root and nested AGENTS.md against this cap for the Codex target (Task 12).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-spec/agents-md.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-spec/agents-md.md
@@ -1,0 +1,21 @@
+# Sample AGENTS.md file
+
+## Dev environment tips
+
+- Use `pnpm dlx turbo run where <project_name>` to jump to a package instead of scanning with `ls`.
+- Run `pnpm install --filter <project_name>` to add the package to your workspace so Vite, ESLint, and TypeScript can see it.
+
+## Testing instructions
+
+- Find the CI plan in the .github/workflows folder.
+- Run `pnpm turbo run test --filter <project_name>` to run every check defined for that package.
+- From the package root you can just call `pnpm test`. The commit should pass all tests before you merge.
+- To focus on one step, add the Vitest pattern: `pnpm vitest run -t "<test name>"`.
+- Fix any test or type errors until the whole suite is green.
+- After moving files or changing imports, run `pnpm lint --filter <project_name>` to be sure ESLint and TypeScript rules still pass.
+- Add or update tests for the code you change, even if nobody asked.
+
+## PR instructions
+
+- Title format: [<project_name>] <Title>
+- Always run `pnpm lint` and `pnpm test` before committing.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-spec/v1-1-frontmatter.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/agents-md-spec/v1-1-frontmatter.md
@@ -1,0 +1,11 @@
+---
+description: Brief monorepo package description for progressive disclosure.
+tags:
+  - frontend
+  - react
+---
+
+# Frontend Package
+
+Conventions for the frontend package. Use React functional components with
+hooks. Co-locate tests with source files.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/INDEX.md
@@ -1,0 +1,78 @@
+# Antigravity Contracts
+
+Source: https://antigravity.google/changelog,
+https://antigravity.google/docs/cli/gcli-migration,
+https://antigravity.google/docs/rules-workflows
+
+## Fixture index
+
+| File              | Source URL                                         | Version         | Retrieved  | Expected path                        | Scope           |
+| ----------------- | -------------------------------------------------- | --------------- | ---------- | ------------------------------------ | --------------- |
+| agents-md.md      | https://antigravity.google/docs/cli/gcli-migration | Antigravity 2.x | 2026-07-17 | `AGENTS.md` (repo root or nested)    | formatter-scope |
+| gemini-md.md      | https://antigravity.google/docs/cli/gcli-migration | Antigravity 2.x | 2026-07-17 | `GEMINI.md` (workspace local)        | formatter-scope |
+| skills-path.md    | https://antigravity.google/docs/cli/gcli-migration | Antigravity 2.x | 2026-07-17 | `.agents/skills/<name>/SKILL.md`     | formatter-scope |
+| mcp-config.json   | https://antigravity.google/docs/cli/gcli-migration | Antigravity 2.x | 2026-07-17 | `.agents/mcp_config.json`            | formatter-scope |
+| agentkit.md       | https://antigravity.google/changelog               | I/O 2026        | 2026-07-17 | none (no project-local contract yet) | out-of-scope    |
+| walkthroughs.md   | https://antigravity.google/changelog               | April 2026      | 2026-07-17 | none (no project-local contract yet) | out-of-scope    |
+| browser-agents.md | https://antigravity.google/changelog               | April 2026      | 2026-07-17 | none (runtime feature)               | out-of-scope    |
+
+## Scope notes
+
+### Workspace context files (formatter-scope)
+
+Antigravity CLI (AGY) parses and enforces workspace-local context from
+`GEMINI.md` and `AGENTS.md` in the active directory. Global developer context
+lives at `~/.gemini/GEMINI.md` (user-level, out of compiler scope).
+
+The existing PromptScript Antigravity formatter emits `.agent/rules/project.md`
+only. Adding root `AGENTS.md` output and scoped nested `AGENTS.md` through
+build profiles is in scope (Task 23).
+
+### Skills path (formatter-scope)
+
+Antigravity CLI moved workspace project skills from Gemini CLI's
+`.gemini/skills/` to `.agents/skills/`. Action required when migrating:
+rename or relocate the folder. Global shared skills moved to
+`~/.gemini/antigravity-cli/skills/` (user-level, out of compiler scope).
+
+PromptScript Antigravity formatter should emit `.agents/skills/<name>/SKILL.md`
+for the workspace project path. The existing `.agent/rules/project.md` output
+stays backward compatible.
+
+### MCP config (formatter-scope)
+
+Antigravity CLI separates MCP servers into a standalone `mcp_config.json`:
+
+- Global: `~/.gemini/config/mcp_config.json` (user-level, out of scope)
+- Workspace: `.agents/mcp_config.json` (project-local, formatter-scope)
+
+Schema: `mcpServers: { <name>: { serverUrl | url | command, env? } }`. Modern
+key is `serverUrl`; legacy `url` and `httpUrl` still accepted.
+
+### AgentKit 2.0 (out-of-scope, pending fixture)
+
+AgentKit 2.0 was announced at I/O 2026 as a multi-agent framework. No
+project-local file contract is documented in the changelog or migration guide.
+Marked out-of-scope until Antigravity publishes a stable project-local
+AgentKit schema. Task 23 may add AgentKit output only after a fixture is
+captured.
+
+### Walkthroughs (out-of-scope, pending fixture)
+
+Walkthroughs shipped April 2026. No project-local walkthrough file contract
+documented. Out-of-scope until a fixture is captured.
+
+### Browser Agents (out-of-scope)
+
+Upgraded April 2026. Runtime feature, no instructions gap.
+
+### Science Skills (out-of-scope)
+
+I/O 2026. Specialized runtime feature, outside instruction compilation scope.
+
+### Gemini CLI -> Antigravity CLI transition
+
+Announced June 18 2026 for unpaid tier and Google One users. Keep Gemini
+target stable. Add an explicit Antigravity compatibility mode only after
+Antigravity's project-local CLI file contract is confirmed (this fixture set).
+The Antigravity CLI migration guide confirms the contracts above.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/agentkit.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/agentkit.md
@@ -1,0 +1,20 @@
+# Antigravity AgentKit 2.0 - Out of Scope (pending fixture)
+
+Source: https://antigravity.google/changelog (I/O 2026 announcement)
+Retrieved: 2026-07-17
+
+## Why out of scope
+
+AgentKit 2.0 was announced at I/O 2026 as a multi-agent framework. The
+changelog and CLI migration guide do not document a project-local file
+contract for AgentKit agents.
+
+## What PromptScript must not do
+
+- Add AgentKit output to the Antigravity formatter until a fixture is captured.
+
+## Reopen condition
+
+Task 23 may add AgentKit output only after Antigravity publishes a stable
+project-local AgentKit schema and a fixture is checked in under this
+directory.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/agents-md.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/agents-md.md
@@ -1,0 +1,27 @@
+# Antigravity AGENTS.md
+
+Source: https://antigravity.google/docs/cli/gcli-migration
+Retrieved: 2026-07-17
+Version: Antigravity 2.x (changelog 2.3.1, July 16 2026)
+
+## Contract
+
+Antigravity CLI (AGY) parses and enforces rule constraints defined inside the
+active directory's `AGENTS.md` and `GEMINI.md` files. This is the same
+workspace-local context model Gemini CLI uses.
+
+## Expected path
+
+- Repo root: `AGENTS.md`
+- Nested package: `<package>/AGENTS.md` (scoped to subtree)
+
+## Content shape
+
+Standard Markdown. No frontmatter contract has shipped (AGENTS.md v1.1
+frontmatter remains an open proposal - see `agents-md-spec/`).
+
+## PromptScript action
+
+- Task 23: Antigravity formatter adds optional root `AGENTS.md` output.
+- Task 19: scoped nested `AGENTS.md` through build profiles.
+- Existing `.agent/rules/project.md` output remains backward compatible.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/browser-agents.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/browser-agents.md
@@ -1,0 +1,14 @@
+# Antigravity Browser Agents - Out of Scope
+
+Source: https://antigravity.google/changelog (April 2026)
+Retrieved: 2026-07-17
+
+## Why out of scope
+
+Browser Agents were upgraded April 2026. They are a runtime feature: the agent
+controls a browser through MCP tooling. No project-local instruction file
+contract.
+
+## What PromptScript must not do
+
+- Add a browser agents formatter or language block.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/gemini-md.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/gemini-md.md
@@ -1,0 +1,21 @@
+# Antigravity GEMINI.md
+
+Source: https://antigravity.google/docs/cli/gcli-migration
+Retrieved: 2026-07-17
+Version: Antigravity 2.x
+
+## Contract
+
+Workspace-local context file. Parsed and enforced alongside `AGENTS.md`.
+
+## Expected path
+
+- Workspace local: `GEMINI.md` (active directory)
+- Global developer context: `~/.gemini/GEMINI.md` (user-level, out of scope)
+
+## PromptScript action
+
+The Antigravity formatter does not need to emit `GEMINI.md`. The Gemini target
+already emits `GEMINI.md`. Antigravity reads both `AGENTS.md` and `GEMINI.md`
+in the active directory, so existing Gemini output remains valid when Antigravity
+is installed alongside it. Document this in Task 23.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/mcp-config.json
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/mcp-config.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "remote-indexer": {
+      "serverUrl": "https://mcp.internal.enterprise.com/sse",
+      "env": {
+        "AUTH_TOKEN": "secure_alpha_token"
+      }
+    }
+  }
+}

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/skills-path.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/skills-path.md
@@ -1,0 +1,27 @@
+# Antigravity Skills Path
+
+Source: https://antigravity.google/docs/cli/gcli-migration
+Retrieved: 2026-07-17
+Version: Antigravity 2.x
+
+## Contract
+
+| Configuration          | Gemini CLI          | Antigravity CLI                     |
+| ---------------------- | ------------------- | ----------------------------------- |
+| Global shared path     | `~/.gemini/skills/` | `~/.gemini/antigravity-cli/skills/` |
+| Workspace project path | `.gemini/skills/`   | `.agents/skills/`                   |
+
+The workspace project path moved to `.agents/skills/`. Projects with custom
+workspace skills in `.gemini/skills/` must rename or relocate the folder to
+`.agents/skills/` for the Antigravity agent to recognize them.
+
+## Expected path
+
+`.agents/skills/<name>/SKILL.md`
+
+## PromptScript action
+
+- Task 23: Antigravity formatter should emit skills to `.agents/skills/`
+  (matching Codex, Cursor, and the SKILL.md open standard).
+- Existing `.agent/rules/project.md` output stays.
+- Global shared path is user-level, out of compiler scope.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/walkthroughs.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/antigravity/walkthroughs.md
@@ -1,0 +1,13 @@
+# Antigravity Walkthroughs - Out of Scope (pending fixture)
+
+Source: https://antigravity.google/changelog (April 2026)
+Retrieved: 2026-07-17
+
+## Why out of scope
+
+Walkthroughs shipped April 2026. The changelog does not document a
+project-local walkthrough file contract.
+
+## Reopen condition
+
+Reopen only if Antigravity publishes a stable project-local walkthrough schema.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/INDEX.md
@@ -1,0 +1,100 @@
+# Claude Code Contracts
+
+Source: https://code.claude.com/docs/en/workflows, /routines, /agent-teams,
+/auto-mode-config, /hooks, /sub-agents
+
+## Fixture index
+
+| File                    | Source URL                                       | Version                 | Retrieved  | Expected path                         | Scope           |
+| ----------------------- | ------------------------------------------------ | ----------------------- | ---------- | ------------------------------------- | --------------- |
+| workflow.md             | https://code.claude.com/docs/en/workflows        | Claude Code v2.1.154+   | 2026-07-17 | `.claude/workflows/<name>.md`         | formatter-scope |
+| settings-hooks.json     | https://code.claude.com/docs/en/hooks            | Claude Code v2.1.191+   | 2026-07-17 | `.claude/settings.json` (merged)      | formatter-scope |
+| subagent.md             | https://code.claude.com/docs/en/sub-agents       | Claude Code v2.1.198+   | 2026-07-17 | `.claude/agents/<name>.md`            | formatter-scope |
+| auto-mode-settings.json | https://code.claude.com/docs/en/auto-mode-config | Claude Code v2.1.198+   | 2026-07-17 | `~/.claude/settings.json` (user only) | out-of-scope    |
+| routines-hosted.md      | https://code.claude.com/docs/en/routines         | research preview        | 2026-07-17 | none (hosted cloud)                   | out-of-scope    |
+| agent-teams.md          | https://code.claude.com/docs/en/agent-teams      | experimental, v2.1.178+ | 2026-17-17 | none (no project-level team config)   | out-of-scope    |
+
+## Scope notes
+
+### Workflows (formatter-scope)
+
+Dynamic workflows ship as JavaScript scripts written by Claude. Saved
+workflows land at `.claude/workflows/<name>.md` in the project (shared with
+clones) or `~/.claude/workflows/<name>.md` (personal, user-level, not project).
+Project workflows load from every `.claude/workflows/` along the path from
+working directory to repository root, nearest-first. Only the project location
+is in formatter scope; `~/.claude/workflows/` is user-level and outside the
+compiler.
+
+The saved file shape is a `meta` block (`name`, `description`) followed by a
+JavaScript body that orchestrates subagents via `agent()` and `pipeline()`.
+PromptScript `@workflows` maps `description` and `content` (portable Markdown
+guidance) into this file. The workflow runtime, size guideline, and ultracode
+trigger are runtime-only and stay out of the language.
+
+### Hooks (formatter-scope)
+
+Hooks live in `.claude/settings.json` under a `hooks` key. The structure is
+`<EventName>: [ { matcher: string, hooks: [ { type, command, args?, ... } ] } ]`.
+Supported events: `SessionStart`, `Setup`, `UserPromptSubmit`,
+`UserPromptExpansion`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`,
+`PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Notification`,
+`MessageDisplay`, `SubagentStart`, `SubagentStop`, `TaskCreated`,
+`TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`,
+`ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`,
+`WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`,
+`ElicitationResult`, `SessionEnd`.
+
+Handler types: `command` (default), `http`, `mcp_tool`, `prompt`, `agent`.
+Command hooks accept `command`, `args`, `async`, `asyncRewake`, `shell`,
+`timeout`, `statusMessage`, `if` (permission rule syntax), `once` (skills
+only). Output is JSON on stdout with `hookSpecificOutput` plus event-specific
+fields. Exit code 2 blocks and feeds stderr to Claude.
+
+PromptScript must emit hooks through a structured settings merge, never by
+overwriting unrelated user settings. Ownership is stored in a valid
+target-specific data key, never a JSON comment.
+
+### Subagents (formatter-scope)
+
+Subagents are Markdown files with YAML frontmatter at `.claude/agents/<name>.md`
+(project) or `~/.claude/agents/<name>.md` (user). Required frontmatter: `name`,
+`description`. Optional: `tools`, `disallowedTools`, `model`, `permissionMode`,
+`maxTurns`, `skills`, `mcpServers`, `hooks`, `memory`, `background`, `effort`,
+`isolation`, `color`, `initialPrompt`. Plugin subagents cannot use `hooks`,
+`mcpServers`, or `permissionMode`.
+
+`name` must be lowercase letters and hyphens. The body is the system prompt.
+Nested `.claude/agents/` directories are scanned recursively; nearest
+definition wins on name conflicts.
+
+PromptScript `@agents` maps to this file through the Claude formatter. The
+existing `ClaudeAgentConfig.hooks` field is dead and must be removed or wired
+to the `@hooks` block in Task 15.
+
+### Auto mode (out-of-scope)
+
+`autoMode` (environment, allow, soft_deny, hard_deny, classifyAllShell) is read
+from `~/.claude/settings.json` and managed settings only. The classifier
+explicitly does NOT read `.claude/settings.json` or `.claude/settings.local.json`
+to prevent repository-injected allow rules. PromptScript cannot emit a
+project-local auto-mode file. Auto mode stays out of compiler scope until an
+upstream versioned project-local schema appears.
+
+### Routines (out-of-scope)
+
+Routines are research-preview cloud sessions hosted at claude.ai/code/routines.
+Triggers: schedule, API (`/fire` endpoint with bearer token), GitHub events.
+Configuration lives in the claude.ai account, not the repository. No
+project-local routine file contract exists. `/schedule` CLI creates cloud
+routines only. Desktop scheduled tasks and `/loop` are runtime/local features.
+No `@routines` block, no formatter adapter.
+
+### Agent Teams (out-of-scope)
+
+Agent Teams are experimental, gated by `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`.
+Team config lives at `~/.claude/teams/{team-name}/config.json` and is generated
+at session startup. The docs explicitly state: "There is no project-level
+equivalent of the team config. A file like `.claude/teams/teams.json` in your
+project directory is not recognized as configuration." PromptScript must not
+add a `team: string` field or a team file model.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/agent-teams.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/agent-teams.md
@@ -1,0 +1,28 @@
+# Claude Agent Teams - Out of Scope
+
+Agent Teams are experimental, disabled by default, gated by
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`.
+
+## Why out of scope
+
+- Team config lives at `~/.claude/teams/{team-name}/config.json` and is
+  generated automatically at session startup.
+- The official documentation states: "There is no project-level equivalent of
+  the team config. A file like `.claude/teams/teams.json` in your project
+  directory is not recognized as configuration; Claude treats it as an ordinary
+  file."
+- Team topology (lead, teammates, mailboxes, shared task list) is a runtime
+  session construct. Teammates are independent Claude Code sessions.
+- `/resume` and `/rewind` do not restore in-process teammates.
+
+## What PromptScript must not do
+
+- Add a `team: string` field on `@agents`. A string cannot represent the
+  leader/teammate topology.
+- Add a project-level team configuration file.
+- Emit team mailbox or task list files.
+
+## Reopen condition
+
+Reopen only if Claude ships a versioned project-level team schema that
+PromptScript can validate against fixtures.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/auto-mode-settings.json
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/auto-mode-settings.json
@@ -1,0 +1,11 @@
+{
+  "autoMode": {
+    "environment": [
+      "$defaults",
+      "Source control: github.example.com/acme-corp and all repos under it",
+      "Trusted cloud buckets: s3://acme-build-artifacts",
+      "Trusted internal domains: *.corp.example.com"
+    ],
+    "classifyAllShell": true
+  }
+}

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/routines-hosted.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/routines-hosted.md
@@ -1,0 +1,25 @@
+# Claude Routines - Out of Scope
+
+Routines are research-preview cloud sessions hosted at claude.ai/code/routines.
+
+## Why out of scope
+
+- Routines run on Anthropic-managed cloud infrastructure, not the repository.
+- Configuration lives in the claude.ai account, not the project tree.
+- Triggers (schedule, API `/fire`, GitHub events) are managed at
+  https://claude.ai/code/routines or via `/schedule` in the CLI.
+- The `/fire` endpoint ships under `experimental-cc-routine-2026-04-01` beta
+  header; request/response shapes may change.
+- Desktop scheduled tasks run on the user's machine; `/loop` is an in-session
+  command. Neither has a project-local file contract.
+
+## What PromptScript must not do
+
+- Add a `@routines` block.
+- Add schedule validation or formatter adapters for routines.
+- Emit a routines file into the project.
+
+## Reopen condition
+
+Reopen language design only if an upstream versioned project-local schema or a
+supported management API becomes available.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/settings-hooks.json
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/settings-hooks.json
@@ -1,0 +1,54 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(rm *)",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-rm.sh",
+            "args": []
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/run-tests-async.sh",
+            "args": [],
+            "async": true,
+            "timeout": 300
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/session_start.py",
+            "statusMessage": "Loading session notes"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/stop_continue.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/subagent.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/subagent.md
@@ -1,0 +1,9 @@
+---
+name: code-reviewer
+description: Reviews code for quality and best practices
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+You are a code reviewer. When invoked, analyze the code and provide
+specific, actionable feedback on quality, security, and best practices.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/workflow.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/claude/workflow.md
@@ -1,0 +1,22 @@
+---
+name: audit-routes
+description: Audit every route handler for missing auth checks
+---
+
+# Audit Routes
+
+const found = await agent('List every .ts file under src/routes/.', {
+schema: {
+type: 'object',
+required: ['files'],
+properties: {
+files: { type: 'array', items: { type: 'string' } },
+},
+},
+})
+
+const audits = await pipeline(found.files, (file) =>
+agent(`Audit ${file} for missing authentication checks.`, { label: file }),
+)
+
+return audits.filter(Boolean)

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/INDEX.md
@@ -1,0 +1,171 @@
+# Codex (OpenAI) Contracts
+
+Source: https://developers.openai.com/codex/subagents, /skills, /hooks,
+https://learn.chatgpt.com/docs/agent-configuration/agents-md
+
+## Fixture index
+
+| File                   | Source URL                                                   | Version       | Retrieved  | Expected path                                    | Scope           |
+| ---------------------- | ------------------------------------------------------------ | ------------- | ---------- | ------------------------------------------------ | --------------- |
+| agents-md.md           | https://learn.chatgpt.com/docs/agent-configuration/agents-md | Codex current | 2026-07-17 | `AGENTS.md` (root, nested, `AGENTS.override.md`) | formatter-scope |
+| skill.md               | https://developers.openai.com/codex/skills                   | Codex current | 2026-07-17 | `.agents/skills/<name>/SKILL.md`                 | formatter-scope |
+| agent.toml             | https://developers.openai.com/codex/subagents                | Codex current | 2026-07-17 | `.codex/agents/<name>.toml`                      | formatter-scope |
+| hooks.json             | https://developers.openai.com/codex/hooks                    | Codex current | 2026-07-17 | `.codex/hooks.json`                              | formatter-scope |
+| config-toml-hooks.toml | https://developers.openai.com/codex/hooks                    | Codex current | 2026-07-17 | `.codex/config.toml` (inline `[hooks]`)          | formatter-scope |
+| plugin.json            | https://developers.openai.com/codex/build-plugins            | Codex current | 2026-07-17 | `<plugin>/.codex-plugin/plugin.json`             | out-of-scope    |
+| goal-mode.md           | https://developers.openai.com/codex/subagents                | GA            | 2026-07-17 | none (runtime interaction)                       | out-of-scope    |
+| record-replay.md       | https://learn.chatgpt.com/docs/extend/record-and-replay      | GA (macOS)    | 2026-07-17 | none (runtime feature)                           | out-of-scope    |
+
+## Scope notes
+
+### AGENTS.md (formatter-scope)
+
+Codex reads `AGENTS.md` walked from cwd to repo root. OpenAI's own monorepo
+has 88 nested `AGENTS.md` files. 32 KiB cap per file. `AGENTS.override.md`
+replaces rather than extends parent instructions (Codex-only).
+
+PromptScript Codex formatter must:
+
+- Extend `MarkdownInstructionFormatter` for root `AGENTS.md`.
+- Validate root and nested AGENTS.md against the 32 KiB limit.
+- Support `AGENTS.override.md` only for scoped Codex build profiles
+  (Task 19). Reject the override filename for non-Codex targets.
+
+### Skills (formatter-scope)
+
+Codex scans `.agents/skills` in every directory from cwd up to repo root.
+Skill = folder + `SKILL.md` (required `name`, `description`). Optional dirs:
+`scripts/`, `references/`, `assets/`, `agents/` (with `openai.yaml` for UI
+metadata, invocation policy, tool dependencies).
+
+Frontmatter follows the SKILL.md open standard. Optional `agents/openai.yaml`:
+
+```yaml
+interface:
+  display_name: '...'
+  short_description: '...'
+  icon_small: './assets/small-logo.svg'
+  icon_large: './assets/large-logo.png'
+  brand_color: '#3B82F6'
+  default_prompt: '...'
+policy:
+  allow_implicit_invocation: false
+dependencies:
+  tools:
+    - type: 'mcp'
+      value: 'openaiDeveloperDocs'
+      description: 'OpenAI Docs MCP server'
+      transport: 'streamable_http'
+      url: 'https://developers.openai.com/mcp'
+```
+
+`~/.codex/config.toml` can disable a skill via `[[skills.config]]`:
+
+```toml
+[[skills.config]]
+path = "/path/to/skill/SKILL.md"
+enabled = false
+```
+
+PromptScript preserves the canonical `.agents/skills/<name>/SKILL.md` project
+path when replacing the generic Codex formatter (Task 12).
+
+### Custom agents (formatter-scope)
+
+Standalone TOML files under `~/.codex/agents/` (personal) or
+`.codex/agents/` (project). Each file defines one agent. Codex loads them as
+config layers, so any supported `config.toml` key can appear.
+
+Required fields:
+
+| Field                    | Type   | Purpose                                    |
+| ------------------------ | ------ | ------------------------------------------ |
+| `name`                   | string | Agent name used when spawning or referring |
+| `description`            | string | Human-facing guidance for when to use      |
+| `developer_instructions` | string | Core instructions (multiline)              |
+
+Optional fields:
+
+| Field                    | Type     | Purpose                                                             |
+| ------------------------ | -------- | ------------------------------------------------------------------- |
+| `nickname_candidates`    | string[] | Display nicknames for spawned agents; non-empty unique list         |
+| `model`                  | string   | e.g. `gpt-5.6`, `gpt-5.6-terra`, `gpt-5.4`, `gpt-5.4-mini`          |
+| `model_reasoning_effort` | enum     | `ultra`, `max`, `xhigh`, `high`, `medium`, `low`, `minimal`, `none` |
+| `sandbox_mode`           | enum     | `read-only`, `workspace-write`, `danger-full-access`                |
+| `mcp_servers`            | table    | Inline MCP server definitions                                       |
+| `skills.config`          | array    | Skill enable/disable entries                                        |
+
+Global settings in `config.toml` `[agents]`:
+
+| Field                            | Default | Purpose                                              |
+| -------------------------------- | ------- | ---------------------------------------------------- |
+| `agents.max_threads`             | `6`     | Concurrent open agent thread cap                     |
+| `agents.max_depth`               | `1`     | Spawned agent nesting depth (root starts at 0)       |
+| `agents.job_max_runtime_seconds` | 1800    | Default per-worker timeout for `spawn_agents_on_csv` |
+| `agents.interrupt_message`       | `true`  | Record model-visible interruption message            |
+
+PromptScript mapping (Task 11 + Task 12):
+
+- `content` -> `developer_instructions` (NO separate `developerInstructions`)
+- `reasoningEffort` -> `model_reasoning_effort` (reuse existing property)
+- `sandboxMode` -> `sandbox_mode`
+- `nicknameCandidates` -> `nickname_candidates`
+- `mcpServers` -> `mcp_servers`
+- `skills` -> `skills.config`
+- Do NOT add `developerInstructions`, generic `mode`, or `modelReasoningEffort`.
+
+### Hooks (formatter-scope)
+
+Codex discovers hooks next to active config layers as `hooks.json` or inline
+`[hooks]` tables in `config.toml`. Locations:
+
+- `~/.codex/hooks.json` and `~/.codex/config.toml` (user)
+- `<repo>/.codex/hooks.json` and `<repo>/.codex/config.toml` (project)
+- Enabled plugins (default `hooks/hooks.json` or manifest `hooks` entry)
+
+Three levels: event -> matcher group -> handlers. Events with matcher support:
+`PermissionRequest`, `PostToolUse`, `PostCompact`, `PreCompact`, `PreToolUse`,
+`SessionStart`, `SubagentStart`, `SubagentStop`. Events without matcher:
+`UserPromptSubmit`, `Stop`.
+
+Only `type: "command"` handlers run today; `prompt` and `agent` are parsed
+but skipped. `async` is parsed but unsupported. Handler fields: `type`,
+`command`, `command_windows`/`commandWindows`, `timeout` (default 600s),
+`statusMessage`. Output JSON: `continue`, `stopReason`, `systemMessage`,
+`suppressOutput`, plus event-specific `hookSpecificOutput`.
+
+Turn off: `[features] hooks = false` in `config.toml`. Managed hooks via
+`requirements.toml` with `allow_managed_hooks_only = true`.
+
+PromptScript emits Codex hooks through the same structured merge
+infrastructure as Claude (Task 15), never overwriting user `[hooks]` tables.
+
+### Plugins (out-of-scope, blocked by Task 25)
+
+Plugin manifest at `<plugin>/.codex-plugin/plugin.json` with optional `hooks`
+entry (path, array of paths, inline object, or array of objects). Plugin hooks
+load alongside other sources and use the same trust-review flow. Bundles
+skills, MCP servers, hooks, app mappings, and presentation assets.
+
+PromptScript `@plugins` (Task 26) is blocked on project MCP definitions
+(Task 25). Codex plugin output is deferred until then.
+
+### Goal mode (out-of-scope)
+
+GA, no longer experimental. Runtime interaction mode. No instruction
+representation required unless a stable project-local configuration contract
+is confirmed.
+
+### Record & Replay (out-of-scope)
+
+GA on macOS. Turns a demonstrated workflow into a reusable skill. Runtime
+feature, no instructions gap.
+
+### `spawn_agents_on_csv` (out-of-scope)
+
+Experimental. Out of scope per plan.
+
+### `agents.max_threads` / `agents.max_depth` (config, not instructions)
+
+Target configuration, not instruction content. Must be structurally merged
+into `.codex/config.toml` and never written into `AGENTS.md` (Task 13).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/agent.toml
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/agent.toml
@@ -1,0 +1,11 @@
+name = "reviewer"
+description = "PR reviewer focused on correctness, security, and missing tests."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Review code like an owner.
+Prioritize correctness, security, behavior regressions, and missing test coverage.
+Lead with concrete findings, include reproduction steps when possible, and avoid style-only comments unless they hide a real bug.
+"""
+nickname_candidates = ["Atlas", "Delta", "Echo"]

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/agents-md.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/agents-md.md
@@ -1,0 +1,32 @@
+# Codex AGENTS.md
+
+Source: https://learn.chatgpt.com/docs/agent-configuration/agents-md
+https://developers.openai.com/codex/subagents
+Retrieved: 2026-07-17
+Version: Codex current (subagents GA)
+
+## Contract
+
+Codex reads `AGENTS.md` walked from cwd to repo root. OpenAI's own monorepo
+has 88 nested `AGENTS.md` files. 32 KiB cap per file.
+
+`AGENTS.override.md` (Codex-only) replaces rather than extends parent
+instructions.
+
+## Expected paths
+
+- Repo root: `AGENTS.md`
+- Nested package: `<package>/AGENTS.md` (scoped to subtree)
+- Override: `<package>/AGENTS.override.md` (Codex-only, replacement semantics)
+
+## Content shape
+
+Standard Markdown. No frontmatter (AGENTS.md v1.1 frontmatter is still an open
+proposal - see `agents-md-spec/`).
+
+## PromptScript action
+
+- Task 12: extend `MarkdownInstructionFormatter` for root `AGENTS.md`.
+- Task 12: validate root and nested AGENTS.md against the 32 KiB cap.
+- Task 19: support `AGENTS.override.md` only for scoped Codex build profiles.
+  Reject the override filename for non-Codex targets.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/config-toml-hooks.toml
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/config-toml-hooks.toml
@@ -1,0 +1,17 @@
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/pre_tool_use_policy.py"'
+timeout = 30
+statusMessage = "Checking Bash command"
+
+[[hooks.PostToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/post_tool_use_review.py"'
+timeout = 30
+statusMessage = "Reviewing Bash output"

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/goal-mode.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/goal-mode.md
@@ -1,0 +1,14 @@
+# Codex Goal Mode - Out of Scope
+
+Source: https://developers.openai.com/codex/subagents
+Retrieved: 2026-07-17
+
+## Why out of scope
+
+Goal mode is GA (no longer experimental). It is a runtime interaction mode:
+the user pins a goal and Codex works toward it. No project-local
+configuration contract has been documented.
+
+## Reopen condition
+
+Reopen only if Codex publishes a stable project-local goal-mode schema.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/hooks.json
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/hooks.json
@@ -1,0 +1,73 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/session_start.py",
+            "statusMessage": "Loading session notes"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/pre_tool_use_policy.py\"",
+            "statusMessage": "Checking Bash command"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/permission_request.py\"",
+            "statusMessage": "Checking approval request"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/post_tool_use_review.py\"",
+            "statusMessage": "Reviewing Bash output"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/user_prompt_submit_data_flywheel.py\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/stop_continue.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/plugin.json
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "repo-policy",
+  "hooks": "./hooks/hooks.json"
+}

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/record-replay.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/record-replay.md
@@ -1,0 +1,14 @@
+# Codex Record & Replay - Out of Scope
+
+Source: https://learn.chatgpt.com/docs/extend/record-and-replay
+Retrieved: 2026-07-17
+
+## Why out of scope
+
+Record & Replay is GA on macOS. It turns a demonstrated workflow into a
+reusable skill by recording the user's actions. Runtime feature, no
+instructions gap.
+
+## What PromptScript must not do
+
+- Add a Record & Replay formatter or language block.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/skill.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/codex/skill.md
@@ -1,0 +1,18 @@
+---
+name: deploy-app
+description: Deploy the application to staging or production environments. Use when deploying code or when the user mentions deployment, releases, or environments.
+---
+
+# Deploy App
+
+Deploy the application using the provided scripts.
+
+## Usage
+
+Run the deployment script: `scripts/deploy.sh <environment>`
+
+Where `<environment>` is either `staging` or `production`.
+
+## Pre-deployment Validation
+
+Before deploying, run the validation script: `python scripts/validate.py`

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/INDEX.md
@@ -1,0 +1,94 @@
+# Cursor Contracts
+
+Source: https://cursor.com/docs/skills, /subagents, /hooks,
+/cloud-agent/automations
+
+## Fixture index
+
+| File           | Source URL                                      | Version       | Retrieved  | Expected path                    | Scope           |
+| -------------- | ----------------------------------------------- | ------------- | ---------- | -------------------------------- | --------------- |
+| skill.md       | https://cursor.com/docs/skills                  | 3.9+ (Jun 22) | 2026-07-17 | `.agents/skills/<name>/SKILL.md` | formatter-scope |
+| subagent.md    | https://cursor.com/docs/subagents               | 2.5+          | 2026-07-17 | `.cursor/agents/<name>.md`       | formatter-scope |
+| hooks.json     | https://cursor.com/docs/hooks                   | 3.11+         | 2026-07-17 | `.cursor/hooks.json`             | formatter-scope |
+| automations.md | https://cursor.com/docs/cloud-agent/automations | 3.8+          | 2026-07-17 | none (hosted cloud)              | out-of-scope    |
+
+## Scope notes
+
+### Skills (formatter-scope)
+
+Discovery locations (Cursor loads all):
+
+- `.agents/skills/` and `.cursor/skills/` (project)
+- `~/.agents/skills/` and `~/.cursor/skills/` (user)
+- Compat: `.claude/skills/`, `.codex/skills/` and home equivalents
+
+Skill = folder + `SKILL.md`. Optional dirs: `scripts/`, `references/`,
+`assets/`. Nested skill directories supported; identity comes from the folder
+holding `SKILL.md`. Nested project subdirectories scope skills to files inside
+that directory.
+
+Frontmatter:
+
+| Field                      | Required | Notes                                                          |
+| -------------------------- | -------- | -------------------------------------------------------------- |
+| `name`                     | yes      | Lowercase letters, numbers, hyphens; must match parent folder  |
+| `description`              | yes      | What the skill does and when to use it                         |
+| `paths`                    | no       | Glob patterns scoping skill to matching files (string or list) |
+| `disable-model-invocation` | no       | `true` = only via `/skill-name`                                |
+| `metadata`                 | no       | Arbitrary key-value                                            |
+
+Legacy `globs` accepted as fallback; new skills should use `paths`.
+
+### Subagents (formatter-scope)
+
+File locations:
+
+- `.cursor/agents/` (project, highest precedence)
+- `.claude/agents/`, `.codex/agents/` (project, compat)
+- `~/.cursor/agents/`, `~/.claude/agents/`, `~/.codex/agents/` (user)
+
+Frontmatter:
+
+| Field           | Required | Default   | Notes                                                       |
+| --------------- | -------- | --------- | ----------------------------------------------------------- |
+| `name`          | no       | filename  | Lowercase letters and hyphens                               |
+| `description`   | no       | -         | Delegation hint                                             |
+| `model`         | no       | `inherit` | `inherit` or model ID with optional `[id=value,...]` params |
+| `readonly`      | no       | `false`   | Restricted write permissions                                |
+| `is_background` | no       | `false`   | Background execution                                        |
+
+Model parameters: `fast`, `effort`, `context`. Example:
+`claude-opus-4-8[effort=high,context=300k]`. Since Cursor 2.5, subagents can
+launch child subagents (one nesting level).
+
+### Hooks (formatter-scope)
+
+Project hooks: `<project-root>/.cursor/hooks.json`. User: `~/.cursor/hooks.json`.
+Schema version 1. Priority: Enterprise -> Team -> Project -> User.
+
+Hook events:
+
+- Agent: `sessionStart`, `sessionEnd`, `preToolUse`, `postToolUse`,
+  `postToolUseFailure`, `subagentStart`, `subagentStop`,
+  `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`,
+  `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`,
+  `beforeSubmitPrompt`, `preCompact`, `stop`, `afterAgentResponse`,
+  `afterAgentThought`
+- Tab: `beforeTabFileRead`, `afterTabFileEdit`
+- App lifecycle: `workspaceOpen`
+
+Handler types: `command` (default), `prompt`. Per-script options: `command`,
+`type`, `timeout`, `loop_limit`, `failClosed`, `matcher`. Exit code 2 blocks.
+Cloud agents run command-based project hooks only (no `sessionStart`,
+`sessionEnd`, MCP, Tab, or `workspaceOpen`).
+
+Cursor supports loading hooks from Claude Code third-party format. Project
+hooks must use `.cursor/hooks/script.sh` paths (relative to project root).
+
+### Automations (out-of-scope)
+
+Automations are cloud-agent features triggered by schedule, source control
+(GitHub/GitLab/Bitbucket), Slack, webhook, Linear, Sentry, or PagerDuty.
+Configuration lives at cursor.com/automations or in the Agents Window. No
+project-local instruction file. `/automate` skill creates cloud automations.
+PromptScript must not add an automations formatter.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/automations.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/automations.md
@@ -1,0 +1,26 @@
+# Cursor Automations - Out of Scope
+
+Source: https://cursor.com/docs/cloud-agent/automations
+Retrieved: 2026-07-17
+
+## Why out of scope
+
+- Automations run cloud agents in the background on Cursor-owned VMs.
+- Triggers: schedule (cron), source control (GitHub/GitLab/Bitbucket push, PR,
+  review, label, CI completed, workflow run), Slack (message, reaction,
+  channel), webhook (private HTTP endpoint), Linear (issue, status, cycle),
+  Sentry (issue events), PagerDuty (incident events).
+- Configuration lives at https://cursor.com/automations or in the Agents
+  Window; no project-local instruction file.
+- `/automate` skill creates cloud automations from a local session.
+- Always runs in Max Mode; usage billed to team pool or creating user.
+
+## What PromptScript must not do
+
+- Add an `@automations` block.
+- Emit an automations configuration file into the project.
+- Add a Cursor automation adapter.
+
+## Reopen condition
+
+Reopen only if Cursor ships a versioned project-local automation schema.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/hooks.json
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/hooks.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": ".cursor/hooks/validate-shell.sh",
+        "matcher": "Shell"
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/format.sh"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/approve-network.sh",
+        "timeout": 30,
+        "matcher": "curl|wget|nc"
+      }
+    ],
+    "stop": [
+      {
+        "command": ".cursor/hooks/audit.sh",
+        "loop_limit": 10
+      }
+    ]
+  }
+}

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/skill.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/skill.md
@@ -1,0 +1,13 @@
+---
+name: react-component-patterns
+description: Conventions for writing React components in this codebase.
+paths:
+  - '**/*.tsx'
+  - 'packages/ui/**/*.ts'
+---
+
+# React component patterns
+
+Use functional components with hooks. Never use class components. Prefer
+co-located tests and CSS modules. Keep components under 200 lines; split
+larger UI into child components under the same folder.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/subagent.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/cursor/subagent.md
@@ -1,0 +1,21 @@
+---
+name: security-auditor
+description: Security specialist. Use when implementing auth, payments, or handling sensitive data.
+model: inherit
+readonly: true
+---
+
+You are a security expert auditing code for vulnerabilities.
+
+When invoked:
+
+1. Identify security-sensitive code paths
+2. Check for common vulnerabilities (injection, XSS, auth bypass)
+3. Verify secrets are not hardcoded
+4. Review input validation and sanitization
+
+Report findings by severity:
+
+- Critical (must fix before deploy)
+- High (fix soon)
+- Medium (address when possible)

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/INDEX.md
@@ -1,0 +1,47 @@
+# Factory AI Contracts
+
+Source: https://docs.factory.ai/cli/configuration/agents-md
+
+## Fixture index
+
+| File          | Source URL                                          | Version     | Retrieved  | Expected path                       | Scope           |
+| ------------- | --------------------------------------------------- | ----------- | ---------- | ----------------------------------- | --------------- |
+| agents-md.md  | https://docs.factory.ai/cli/configuration/agents-md | Factory CLI | 2026-07-17 | `AGENTS.md` (repo root, nested)     | formatter-scope |
+| user-level.md | https://docs.factory.ai/cli/configuration/agents-md | Factory CLI | 2026-07-17 | `~/.factory/AGENTS.md` (user-level) | out-of-scope    |
+
+## Scope notes
+
+### AGENTS.md (formatter-scope)
+
+Factory Droids look for `AGENTS.md` in this order (first match wins):
+
+1. `./AGENTS.md` in the current working directory
+2. The nearest parent directory up to the repo root
+3. Any `AGENTS.md` in sub-folders the agent is working inside
+4. Personal override: `~/.factory/AGENTS.md`
+
+Multiple files can coexist. The closer one to the file being edited takes
+precedence.
+
+Plain Markdown; headings provide semantic hints. Recommended sections: Build
+& Test, Architecture Overview, Security, Git Workflows, Conventions &
+Patterns. Aim for <= 150 lines.
+
+PromptScript Factory formatter already emits root `AGENTS.md`. Nested
+generation through build profiles is in scope (Task 19). Existing Factory
+filtering of unsupported frontmatter fields (including `license`) on generated
+and injected skills stays until a Factory fixture allows `license`.
+
+### User-level (out-of-scope)
+
+`~/.factory/AGENTS.md` is a personal override. PromptScript must NEVER write
+user-level files. Keep `~/.factory/` outside compiler output.
+
+### Specification mode
+
+`specModel` and `specReasoningEffort` are GA and already supported in
+`@agents`.
+
+### Custom droids
+
+`.factory/droids/<name>.md` are GA and already supported via `@agents`.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/agents-md.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/agents-md.md
@@ -1,0 +1,21 @@
+# Build & Test
+
+- Type-check and lint: `pnpm check`
+- Auto-fix style: `pnpm check:fix`
+- Run full test suite: `pnpm test --run --no-color`
+- Run a single test file: `pnpm test --run <path>.test.ts`
+- Start dev servers: `pnpm dev`
+- Build for production: `pnpm build` then `pnpm preview`
+
+# Architecture Overview
+
+The project is a monorepo. Frontend code lives in `client/`, backend code
+lives in `server/`, shared helpers belong in `src/`.
+
+# Git Workflow Essentials
+
+1. Branch from `main` with a descriptive name.
+2. Run `pnpm check` locally before committing.
+3. Force pushes allowed only on feature branches with
+   `git push --force-with-lease`. Never force-push `main`.
+4. Keep commits atomic; prefer checkpoints (`feat: ...`, `test: ...`).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/user-level.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/user-level.md
@@ -1,0 +1,25 @@
+# Factory AI User-Level AGENTS.md - Out of Scope
+
+Source: https://docs.factory.ai/cli/configuration/agents-md
+Retrieved: 2026-07-17
+
+## Contract
+
+`~/.factory/AGENTS.md` is the personal override AGENTS.md file. It is the
+last entry in the discovery hierarchy:
+
+1. `./AGENTS.md` in the current working directory
+2. The nearest parent directory up to the repo root
+3. Any `AGENTS.md` in sub-folders the agent is working inside
+4. Personal override: `~/.factory/AGENTS.md`
+
+## Why out of scope
+
+PromptScript must never write user-level files. The compiler scope is the
+project tree. `~/.factory/` is outside compiler output.
+
+## What PromptScript must not do
+
+- Emit `~/.factory/AGENTS.md`.
+- Emit any file under `~/.factory/`.
+- Add a Factory target option that writes to the home directory.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/INDEX.md
@@ -1,0 +1,60 @@
+# Gemini CLI Contracts
+
+Source: https://geminicli.com/docs/cli/skills/,
+https://geminicli.com/docs/cli/gemini-md/
+
+## Fixture index
+
+| File                | Source URL                                | Version    | Retrieved  | Expected path                                                        | Scope           |
+| ------------------- | ----------------------------------------- | ---------- | ---------- | -------------------------------------------------------------------- | --------------- |
+| skill.md            | https://geminicli.com/docs/cli/skills/    | Gemini CLI | 2026-07-17 | `.agents/skills/<name>/SKILL.md` or `.gemini/skills/<name>/SKILL.md` | formatter-scope |
+| gemini-md.md        | https://geminicli.com/docs/cli/gemini-md/ | Gemini CLI | 2026-07-17 | `GEMINI.md` (workspace local)                                        | formatter-scope |
+| agents-skills.md    | https://geminicli.com/docs/cli/skills/    | Gemini CLI | 2026-07-17 | alias precedence doc                                                 | formatter-scope |
+| runtime-commands.md | https://geminicli.com/docs/cli/skills/    | Gemini CLI | 2026-07-17 | none (runtime)                                                       | out-of-scope    |
+
+## Scope notes
+
+### Skills (formatter-scope)
+
+Discovery tiers (lowest to highest precedence):
+
+1. Built-in skills
+2. Extension skills
+3. User skills: `~/.gemini/skills/` or `~/.agents/skills/` alias
+4. Workspace skills: `.gemini/skills/` or `.agents/skills/` alias
+
+Within the same tier, `.agents/skills/` alias takes precedence over
+`.gemini/skills/`. The `.agents/skills/` alias is positioned as the
+interoperable cross-tool path.
+
+Skill = folder + `SKILL.md` following the Agent Skills open standard.
+Progressive disclosure: metadata at startup, body on activation, resources on
+demand.
+
+PromptScript action (Task 10): add target option `skillPath` with allowed
+values `agents` (`.agents/skills/`), `gemini` (`.gemini/skills/`), and `both`
+(only when explicitly requested). Use fixture-confirmed precedence to choose
+default. Command files stay under `.gemini/commands/`. Deduplicate content in
+`both` mode.
+
+### GEMINI.md (formatter-scope)
+
+Workspace-local context file. Global developer context at
+`~/.gemini/GEMINI.md` is user-level (out of scope).
+
+PromptScript Gemini formatter already emits `GEMINI.md`. Nested `GEMINI.md`
+support is planned (matrix `gemini.nested-memory` -> `planned` -> `supported`
+after Task 23/Task 19).
+
+### Runtime commands (out-of-scope)
+
+`/skills list`, `/skills link`, `/skills disable`, `/skills enable`,
+`/skills reload`, `gemini skills install/uninstall` are runtime commands.
+No instructions gap.
+
+### Transition to Antigravity CLI
+
+Announced June 18 2026 for unpaid tier and Google One users. Keep Gemini
+target stable. Add an explicit Antigravity compatibility mode only after
+Antigravity's project-local CLI file contract is confirmed (see
+`antigravity/`).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/agents-skills.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/agents-skills.md
@@ -1,0 +1,41 @@
+# Gemini CLI `.agents/skills/` Alias Precedence
+
+Source: https://geminicli.com/docs/cli/skills/
+Retrieved: 2026-07-17
+Version: Gemini CLI
+
+## Contract
+
+Within the same tier (user or workspace), the `.agents/skills/` alias takes
+precedence over the `.gemini/skills/` directory. The `.agents/skills/` alias
+is positioned as the interoperable cross-tool path.
+
+Discovery tiers (lowest to highest precedence):
+
+1. Built-in skills
+2. Extension skills
+3. User skills: `~/.gemini/skills/` or `~/.agents/skills/` alias
+4. Workspace skills: `.gemini/skills/` or `.agents/skills/` alias
+
+## PromptScript action (Task 10)
+
+Add target option `skillPath`:
+
+```yaml
+targets:
+  - gemini:
+      skillPath: agents
+```
+
+Allowed values:
+
+- `agents` -> `.agents/skills/`
+- `gemini` -> `.gemini/skills/`
+- `both` -> write to both paths only when explicitly requested; deduplicate
+  content
+
+Use fixture-confirmed precedence to choose default (`.agents/skills/` wins
+within a tier, but `.gemini/skills/` is the legacy default). Existing projects
+can select legacy `.gemini/skills/` via `skillPath: gemini`.
+
+No duplicate skill tree appears without `skillPath: both`.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/gemini-md.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/gemini-md.md
@@ -1,0 +1,25 @@
+# Gemini CLI GEMINI.md
+
+Source: https://geminicli.com/docs/cli/gemini-md/
+Retrieved: 2026-07-17
+Version: Gemini CLI (Antigravity CLI migration announced June 18 2026)
+
+## Contract
+
+Workspace-local context file. Gemini CLI reads `GEMINI.md` in the active
+directory. Global developer context lives at `~/.gemini/GEMINI.md`
+(user-level, out of compiler scope).
+
+Antigravity CLI reads both `GEMINI.md` and `AGENTS.md` in the active
+directory, so existing Gemini output remains valid when Antigravity is
+installed alongside it.
+
+## Expected path
+
+- Workspace local: `GEMINI.md`
+
+## PromptScript action
+
+- Existing Gemini formatter emits `GEMINI.md`. Keep stable.
+- Matrix `gemini.nested-memory`: `not-supported` -> `planned` (Task 8) ->
+  `supported` after nested generation tests pass (Task 19/Task 23).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/runtime-commands.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/runtime-commands.md
@@ -1,0 +1,19 @@
+# Gemini CLI Runtime Commands - Out of Scope
+
+Source: https://geminicli.com/docs/cli/skills/
+Retrieved: 2026-07-17
+
+## Why out of scope
+
+The following are runtime commands, not project-local instruction files:
+
+- `/skills list [all] [nodesc]`
+- `/skills link <path> [--scope user|workspace]`
+- `/skills disable <name>`
+- `/skills enable <name>`
+- `/skills reload` (or `/skills refresh`)
+- `gemini skills list --all`
+- `gemini skills install https://github.com/user/repo.git --consent`
+- `gemini skills uninstall my-skill --scope workspace`
+
+No instructions gap. PromptScript must not add a formatter adapter for these.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/skill.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/gemini/skill.md
@@ -1,0 +1,21 @@
+---
+name: pdf-processing
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+license: Apache-2.0
+metadata:
+  author: example-org
+  version: '1.0'
+---
+
+# PDF Processing
+
+Extract text and tables from PDF files, fill PDF forms, and merge multiple
+PDFs. Use when working with PDF documents or when the user mentions PDFs,
+forms, or document extraction.
+
+## Steps
+
+1. Load the PDF via the bundled script.
+2. Extract text and table regions.
+3. Fill form fields or merge sources as requested.
+4. Write the result to the requested output path.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/github/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/github/INDEX.md
@@ -1,0 +1,67 @@
+# GitHub Copilot Contracts
+
+Source: https://docs.github.com/en/copilot/reference/custom-agents-configuration,
+https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/create-custom-agents
+
+## Fixture index
+
+| File               | Source URL                                                               | Version                | Retrieved  | Expected path              | Scope           |
+| ------------------ | ------------------------------------------------------------------------ | ---------------------- | ---------- | -------------------------- | --------------- |
+| agent.md           | https://docs.github.com/en/copilot/reference/custom-agents-configuration | public preview 2026-07 | 2026-07-17 | `.github/agents/<name>.md` | formatter-scope |
+| agent-with-mcp.md  | https://docs.github.com/en/copilot/reference/custom-agents-configuration | public preview 2026-07 | 2026-07-17 | `.github/agents/<name>.md` | formatter-scope |
+| character-limit.md | https://docs.github.com/features/copilot/whats-new                       | removed June 2026      | 2026-07-17 | n/a (matrix correction)    | matrix-update   |
+
+## Scope notes
+
+### Custom agent filename
+
+GitHub accepts both `.md` and `.agent.md` suffixes. The filename (minus either
+suffix) is the deduplication key. Lowest level wins on conflicts (repo >
+org > enterprise). PromptScript retains `.md` unless a versioned migration
+requires the longer suffix.
+
+Two frontmatter subsets exist:
+
+- GitHub.com cloud agent: `name`, `description` (required), `target`,
+  `tools`, `model`, `disable-model-invocation`, `user-invocable`, `infer`
+  (retired), `mcp-servers`, `metadata`.
+- VS Code and other IDE agents: also support `argument-hint` and `handoffs`,
+  which the cloud agent ignores.
+
+PromptScript maps only fixture-confirmed fields and warns for fields GitHub
+cannot represent. Prompt-only `mode` (from Copilot prompt files) must NOT be
+added to generic `@agents` or custom agent files.
+
+### Frontmatter fields
+
+| Field                      | Type     | Required | Notes                                                                |
+| -------------------------- | -------- | -------- | -------------------------------------------------------------------- |
+| `name`                     | string   | no       | Defaults to filename without `.md` or `.agent.md`                    |
+| `description`              | string   | yes      | Purpose and capabilities                                             |
+| `target`                   | string   | no       | `vscode` or `github-copilot`; unset = both                           |
+| `tools`                    | list/str | no       | Tool aliases or `org/tool` MCP names; unset = all tools; `[]` = none |
+| `model`                    | string   | no       | Inherits default if unset                                            |
+| `disable-model-invocation` | boolean  | no       | `true` = manual select only; takes precedence over `infer`           |
+| `user-invocable`           | boolean  | no       | `false` = programmatic only; defaults `true`                         |
+| `infer`                    | boolean  | no       | Retired; use `disable-model-invocation` and `user-invocable`         |
+| `mcp-servers`              | object   | no       | Cloud agent only; not used in VS Code/IDE                            |
+| `metadata`                 | object   | no       | Cloud agent only; name/value string pairs                            |
+
+Prompt body max: 30,000 characters. Tool aliases are case-insensitive
+(`execute`/`shell`/`Bash`/`powershell`, `read`/`Read`/`NotebookRead`,
+`edit`/`Edit`/`MultiEdit`/`Write`/`NotebookEdit`, `search`/`Grep`/`Glob`,
+`agent`/`custom-agent`/`Task`, `web`/`WebSearch`/`WebFetch`,
+`todo`/`TodoWrite`).
+
+### Character limit (matrix correction)
+
+Repository custom instructions character limit was removed June 2026. The
+feature matrix entry `github.character-limit` moves from `planned` to
+`not-supported`.
+
+### Out of scope
+
+- GitHub organization code review runner controls (runtime config, not
+  instructions).
+- Copilot CLI runtime behavior (no project-local instruction contract beyond
+  `.github/copilot-instructions.md` and `.github/agents/`).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/github/agent-with-mcp.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/github/agent-with-mcp.md
@@ -1,0 +1,21 @@
+---
+name: my-custom-agent-with-mcp
+description: Custom agent description
+tools:
+  - tool-a
+  - tool-b
+  - custom-mcp/tool-1
+mcp-servers:
+  custom-mcp:
+    type: local
+    command: some-command
+    args:
+      - --arg1
+      - --arg2
+    tools:
+      - '*'
+    env:
+      ENV_VAR_NAME: ${{ secrets.COPILOT_MCP_ENV_VAR_VALUE }}
+---
+
+Prompt with suggestions for behavior and output.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/github/agent.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/github/agent.md
@@ -1,0 +1,14 @@
+---
+name: test-specialist
+description: Focuses on test coverage, quality, and testing best practices without modifying production code
+---
+
+You are a testing specialist focused on improving code quality through comprehensive testing. Your responsibilities:
+
+- Analyze existing tests and identify coverage gaps
+- Write unit tests, integration tests, and end-to-end tests following best practices
+- Review test quality and suggest improvements for maintainability
+- Ensure tests are isolated, deterministic, and well-documented
+- Focus only on test files and avoid modifying production code unless specifically requested
+
+Always include clear test descriptions and use appropriate testing patterns for the language and framework.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/github/character-limit.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/github/character-limit.md
@@ -1,0 +1,15 @@
+# GitHub Copilot Character Limit - Matrix Correction
+
+Repository custom instructions character limit was removed in June 2026.
+
+Source: https://github.com/features/copilot/whats-new
+Retrieved: 2026-07-17
+
+## Matrix action
+
+`packages/formatters/src/feature-matrix.ts`:
+
+- `github.character-limit`: `planned` -> `not-supported`
+
+No formatter output change required. The GitHub formatter already emits
+`.github/copilot-instructions.md` without enforcing a character cap.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/INDEX.md
@@ -1,0 +1,101 @@
+# Grok Build Contracts
+
+Source: https://docs.x.ai/build/overview,
+https://docs.x.ai/build/features/project-rules,
+https://docs.x.ai/build/features/skills-plugins-marketplaces
+
+## Fixture index
+
+| File             | Source URL                                                   | Version    | Retrieved  | Expected path                                       | Scope           |
+| ---------------- | ------------------------------------------------------------ | ---------- | ---------- | --------------------------------------------------- | --------------- |
+| agents-md.md     | https://docs.x.ai/build/features/project-rules               | Grok Build | 2026-07-17 | `AGENTS.md` (root, nested)                          | formatter-scope |
+| claude-compat.md | https://docs.x.ai/build/features/skills-plugins-marketplaces | Grok Build | 2026-07-17 | delegated to Claude formatter                       | formatter-scope |
+| skills.md        | https://docs.x.ai/build/features/skills-plugins-marketplaces | Grok Build | 2026-07-17 | `.grok/skills/<name>/SKILL.md` or `.claude/skills/` | formatter-scope |
+| plugins.md       | https://docs.x.ai/build/features/skills-plugins-marketplaces | Grok Build | 2026-07-17 | `.grok/plugins/` or `.claude/plugins/`              | out-of-scope    |
+| hooks.md         | https://docs.x.ai/build/features/skills-plugins-marketplaces | Grok Build | 2026-07-17 | `.grok/hooks/` or `.claude/hooks/`                  | out-of-scope    |
+
+## Scope notes
+
+### AGENTS.md (formatter-scope)
+
+Grok loads rules in this order, with deeper files taking precedence on
+conflicts:
+
+1. Global rules in `~/.grok/`
+2. Every directory from the repo root down to the working directory (or only
+   the working directory outside a git repo)
+
+Within each directory, Grok reads any of `AGENTS.md`, `Agents.md`,
+`AGENT.md`, `CLAUDE.md`, `Claude.md`, and `CLAUDE.local.md`, plus every
+`*.md` file in a `.grok/rules/` directory (`.claude/rules/` and
+`.cursor/rules/` are read for compatibility). Files ignored by `.gitignore`
+are skipped.
+
+A nested `AGENTS.md` scopes to its subtree. No size cap.
+
+PromptScript Grok formatter (Task 7) generates primary `AGENTS.md` through
+shared Markdown instruction logic. Versions:
+
+| Version     | Output                                                                             |
+| ----------- | ---------------------------------------------------------------------------------- |
+| `simple`    | Root `AGENTS.md` only                                                              |
+| `multifile` | `AGENTS.md`, `CLAUDE.md`, Claude rules and commands                                |
+| `full`      | `AGENTS.md`, `CLAUDE.md`, Claude rules, commands, skills, agents, and local memory |
+
+### Claude compatibility (formatter-scope)
+
+Grok is fully compatible with Claude Code with zero configuration. Grok
+automatically reads Claude Code marketplaces, plugins, skills, MCPs, agents,
+hooks, and instruction files (`CLAUDE.md`, `Claude.md`, `CLAUDE.local.md`,
+and `.claude/rules/`) alongside `.grok/`.
+
+PromptScript Grok formatter delegates compatible additional files to
+`ClaudeFormatter`. Tests compare delegated files byte-for-byte with Claude
+formatter output for the same AST and version. Report `.claude/skills` as
+Grok's skill base path only in versions that emit skills. Do NOT claim MCP,
+hooks, or plugins until their corresponding Claude outputs exist.
+
+Grok also reads the `AGENTS.md` family (`AGENTS.md`, `Agents.md`,
+`AGENT.md`) walked from cwd to repo root, and discovers user-level skills
+and commands from `~/.agents/skills/` and `~/.agents/commands/`.
+
+### Skills (formatter-scope)
+
+Grok discovers skills from:
+
+- `./.grok/skills/` (walked up to repo root)
+- `~/.grok/skills/` (user-level, out of scope)
+- Any enabled plugin's `skills/` directory
+- Extra paths under `[skills] paths` in `~/.grok/config.toml`
+- Compat: `.claude/skills/` (user-level)
+
+User-invocable skills also appear as slash commands.
+
+PromptScript Grok formatter delegates skill output to `ClaudeFormatter`
+(`.claude/skills/<name>/SKILL.md`) in versions that emit skills (`multifile`
+does not; `full` does). Do not duplicate skill trees.
+
+### Plugins (out-of-scope, blocked by Task 25)
+
+Plugins extend Grok with skills, agents, hooks, MCP servers, and LSP servers.
+Discovered from `./.grok/plugins/`, `~/.grok/plugins/`, marketplace installs,
+extra paths, and `--plugin-dir`. Plugin hooks receive `GROK_PLUGIN_ROOT` and
+`GROK_PLUGIN_DATA` env vars.
+
+PromptScript `@plugins` (Task 26) is blocked on project MCP definitions
+(Task 25). Grok plugin output deferred until then.
+
+### Hooks (out-of-scope until Task 15)
+
+Hooks run scripts on tool and session lifecycle events. Discovered from
+`~/.grok/hooks/`, project `.grok/hooks/` (requires `/hooks-trust`), and
+enabled plugins. See https://docs.x.ai/build/features/hooks for events,
+JSON format, and the script contract.
+
+PromptScript emits Grok hooks through Claude formatter delegation once
+`@hooks` lands (Task 15). Do not claim hooks output before then.
+
+### Subagents (runtime)
+
+Subagents spawn independent child sessions that handle tasks in parallel.
+Runtime feature, no instructions gap.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/agents-md.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/agents-md.md
@@ -1,0 +1,34 @@
+# Grok Build AGENTS.md
+
+Source: https://docs.x.ai/build/features/project-rules
+Retrieved: 2026-07-17
+Version: Grok Build (last updated July 4 2026)
+
+## Contract
+
+Grok loads rules in this order, with deeper files taking precedence on
+conflicts:
+
+1. Global rules in `~/.grok/`
+2. Every directory from the repo root down to the working directory (or only
+   the working directory outside a git repo)
+
+Within each directory, Grok reads any of `AGENTS.md`, `Agents.md`,
+`AGENT.md`, `CLAUDE.md`, `Claude.md`, and `CLAUDE.local.md`, plus every
+`*.md` file in a `.grok/rules/` directory (`.claude/rules/` and
+`.cursor/rules/` are read for compatibility). Files ignored by `.gitignore`
+are skipped.
+
+A nested `AGENTS.md` scopes to its subtree. No size cap. Short, specific
+instructions are followed more reliably than long ones.
+
+## Expected paths
+
+- Repo root: `AGENTS.md`
+- Nested package: `<package>/AGENTS.md` (scoped to subtree)
+
+## PromptScript action (Task 7)
+
+Generate primary `AGENTS.md` through shared Markdown instruction logic.
+Delegate `CLAUDE.md` and other Claude-compatible files to `ClaudeFormatter`
+in `multifile` and `full` versions.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/claude-compat.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/claude-compat.md
@@ -1,0 +1,33 @@
+# Grok Build Claude Code Compatibility
+
+Source: https://docs.x.ai/build/features/skills-plugins-marketplaces
+Retrieved: 2026-07-17
+Version: Grok Build (last updated July 4 2026)
+
+## Contract
+
+Grok is fully compatible with Claude Code with zero configuration needed.
+Grok automatically reads Claude Code marketplaces, plugins, skills, MCPs,
+agents, hooks, and instruction files (`CLAUDE.md`, `Claude.md`,
+`CLAUDE.local.md`, and `.claude/rules/`) alongside `.grok/`. No extra setup
+is needed.
+
+Grok also reads the `AGENTS.md` instruction-file family (`AGENTS.md`,
+`Agents.md`, `AGENT.md`) walked from cwd to repo root, and discovers
+user-level skills and commands from `~/.agents/skills/` and
+`~/.agents/commands/`.
+
+## PromptScript action (Task 7)
+
+- `simple` version: emit root `AGENTS.md` only.
+- `multifile` version: emit `AGENTS.md`, `CLAUDE.md`, Claude rules and
+  commands. Delegate to `ClaudeFormatter`.
+- `full` version: emit `AGENTS.md`, `CLAUDE.md`, Claude rules, commands,
+  skills, agents, and local memory. Delegate to `ClaudeFormatter`.
+- Tests compare delegated files byte-for-byte with Claude formatter output
+  for the same AST and version.
+- Report `.claude/skills` as Grok's skill base path only in versions that
+  emit skills.
+- Do NOT claim MCP, hooks, or plugins until their corresponding Claude
+  outputs exist.
+- Compiler skill injection must not create duplicate PromptScript skills.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/hooks.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/hooks.md
@@ -1,0 +1,26 @@
+# Grok Build Hooks - Out of Scope until Task 15
+
+Source: https://docs.x.ai/build/features/skills-plugins-marketplaces
+Retrieved: 2026-07-17
+
+## Contract
+
+Hooks run scripts on tool and session lifecycle events, such as before or
+after tool calls. Grok discovers hooks from:
+
+- `~/.grok/hooks/` (extra roots via `~/.grok/hooks-paths`)
+- Project `.grok/hooks/` (requires `/hooks-trust`)
+- Enabled plugins
+
+Plugin hooks additionally receive `GROK_PLUGIN_ROOT` and `GROK_PLUGIN_DATA`
+in their environment. For events, the JSON format, and the script contract,
+see https://docs.x.ai/build/features/hooks.
+
+## Why deferred
+
+PromptScript emits Grok hooks through Claude formatter delegation once the
+`@hooks` block lands (Task 15). Do not claim hooks output before then.
+
+## Reopen condition
+
+Implement in Task 15 alongside Claude and Codex hook adapters.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/plugins.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/plugins.md
@@ -1,0 +1,28 @@
+# Grok Build Plugins - Out of Scope (blocked by Task 25)
+
+Source: https://docs.x.ai/build/features/skills-plugins-marketplaces
+Retrieved: 2026-07-17
+
+## Contract
+
+Plugins extend Grok with additional skills, agents, hooks, MCP servers, and
+LSP servers. Grok loads plugins from:
+
+- `./.grok/plugins/`
+- `~/.grok/plugins/`
+- Marketplace installs under `~/.grok/plugins/marketplaces/`
+- Extra paths under `[plugins] paths` in `~/.grok/config.toml`
+- `--plugin-dir <PATH>` on the CLI
+
+Plugin hooks additionally receive `GROK_PLUGIN_ROOT` and `GROK_PLUGIN_DATA`
+in their environment.
+
+## Why out of scope
+
+PromptScript `@plugins` (Task 26) is blocked on project MCP definitions
+(Task 25). Grok plugin output is deferred until then.
+
+## Reopen condition
+
+Implement after Task 25 lands project MCP definitions and Task 26 adds the
+`@plugins` block.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/skills.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/grok/skills.md
@@ -1,0 +1,14 @@
+---
+name: code-style
+description: Project code style guidelines for Grok sessions.
+---
+
+## Code Style
+
+In this project, please follow these conventions:
+
+- Use 4-space indentation
+- Variable names use camelCase
+- Function names use snake_case
+- Every function needs a docstring
+- Lines should not exceed 100 characters

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/INDEX.md
@@ -1,0 +1,62 @@
+# Priority B Targets
+
+These platforms read `AGENTS.md` and have additional skills/MCP/subagent
+capabilities. PromptScript starts each with root `AGENTS.md` and adds native
+skill/agent paths only from a confirmed fixture (Task 27).
+
+## Family index
+
+| Target      | Source URL                                                         | Retrieved  | Expected path (initial) | Scope           |
+| ----------- | ------------------------------------------------------------------ | ---------- | ----------------------- | --------------- |
+| kimi        | https://moonshotai.github.io/kimi-cli/en/customization/skills.html | 2026-07-17 | `AGENTS.md`             | formatter-scope |
+| mimo        | https://github.com/XiaomiMiMo/MiMo-Code                            | 2026-07-17 | `AGENTS.md`             | formatter-scope |
+| deep-agents | https://docs.langchain.com/oss/python/deepagents/overview          | 2026-07-17 | `AGENTS.md` (memory)    | formatter-scope |
+| forgecode   | https://forgecode.dev/docs/skills/                                 | 2026-07-17 | `AGENTS.md`             | formatter-scope |
+
+## Per-target notes
+
+- **Kimi CLI** (Moonshot AI): AGENTS.md in repo. Skills via Agent Skills
+  open standard at `.kimi/skills/`, `.claude/skills/`, `.codex/skills/`
+  (brand group) and `.agents/skills/` (generic group). Flat `.md` skills
+  also recognized. Flow skills via `type: flow` frontmatter with Mermaid/D2
+  diagrams. MCP via plugins. `/skill:<name>` slash command. Built-in skills:
+  `kimi-cli-help`, `skill-creator`.
+- **MiMo Code** (Xiaomi): AGENTS.md in repo (confirmed - the MiMo-Code repo
+  itself has `AGENTS.md` and `CLAUDE.md` at root). Fork of OpenCode. Adds
+  persistent memory, intelligent context management, subagent orchestration,
+  goal-driven autonomous loops, compose workflows, self-improvement via
+  dream/distill. Skills via OpenCode/Antigravity `.agents/skills/` layout.
+  Config at `~/.config/mimocode/mimocode.jsonc` (user-level). MIT license.
+- **Deep Agents Code** (LangChain): AGENTS.md is the memory file format
+  (always loaded). Skills via Agent Skills open standard at
+  `<skill>/SKILL.md` with progressive disclosure. Subagents via `task` tool.
+  HITL via `interrupt_on`. Virtual filesystem with permission rules.
+  `deepagents` PyPI package. Project-local AGENTS.md is the memory contract;
+  skills live in the virtual filesystem.
+- **ForgeCode** (antinomyhq): Skills via `SKILL.md` at
+  `.forge/skills/<name>/SKILL.md` (project), `~/.agents/skills/<name>/SKILL.md`
+  (agents-shared), `~/forge/skills/<name>/SKILL.md` (global user).
+  Precedence: project > agents > global > built-in. Fully compatible with
+  Claude Code skills - `SKILL.md` format identical. `:skill` command lists
+  skills. AGENTS.md contract not explicitly documented on the skills page but
+  ForgeCode reads AGENTS.md as the cross-tool standard (confirm in Task 27
+  fixture).
+
+## PromptScript action (Task 27)
+
+For each verified target:
+
+- Start with root `AGENTS.md`.
+- Add native skill path only from a confirmed fixture.
+- Add native agent path only from a confirmed fixture.
+- Add hooks only through shared structured merge infrastructure (Task 15).
+- Expose headless, worktree, session, and HITL controls only when they are
+  stable project configuration, not runtime flags.
+- Keep unsupported capabilities as `planned` or `not-supported`.
+
+## Out of scope for Priority B
+
+- Runtime features: Kimi flow skill execution, MiMo dream/distill and Max
+  Mode, Deep Agents runtime steering, ForgeCode TermBench behavior.
+- Hosted/cloud features.
+- User-level configuration (`~/.config/mimocode/`, `~/forge/`, `~/.kimi/`).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/deep-agents/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/deep-agents/INDEX.md
@@ -1,0 +1,73 @@
+# Deep Agents Code (LangChain)
+
+Source: https://docs.langchain.com/oss/python/deepagents/overview,
+https://docs.langchain.com/oss/python/deepagents/skills
+Retrieved: 2026-07-17
+Version: `deepagents` PyPI package (current)
+
+## Contract
+
+Deep Agents is an "agent harness" - the same core tool calling loop as other
+agent frameworks, but with built-in capabilities for real tasks.
+
+### Memory (AGENTS.md)
+
+"Memory uses `AGENTS.md` files that you pass through the `memory` parameter
+when creating the agent. Unlike skills, memory files are always loaded, and
+the content is stored in the configured backend (`StateBackend`,
+`StoreBackend`, or `FilesystemBackend`)."
+
+The agent can update memory based on interactions and feedback. AGENTS.md is
+the memory contract - always-on context loaded at startup.
+
+### Skills
+
+Skills follow the Agent Skills open standard. Each skill is a directory with
+a `SKILL.md` file. Skills can include scripts, templates, reference docs,
+and supporting resources.
+
+Progressive disclosure: agent reads `SKILL.md` frontmatter at startup, then
+reads full skill content only when a task needs it.
+
+### Subagents
+
+Built-in `task` tool creates ephemeral subagents. Default `general-purpose`
+subagent enabled; custom subagents configurable. Each invocation creates a
+new agent instance with its own context. Single handoff - one final report.
+Subagents are stateless.
+
+### Steering (HITL)
+
+`interrupt_on` parameter pauses for approval on sensitive tool calls.
+Example: `interrupt_on={"edit_file": True}` pauses before every edit.
+
+### Execution environment
+
+- Tools (custom functions, LangChain tools, MCP servers)
+- Virtual filesystem with pluggable backends (in-memory, local disk,
+  LangGraph store, composite, custom)
+- Filesystem permissions (declarative read/write rules, first-match-wins)
+- Code execution (sandbox backends with `execute` tool, QuickJS
+  interpreters with `eval` tool)
+
+## Expected paths (initial)
+
+- `AGENTS.md` (root) - memory file, always loaded
+
+Native project-local skill directory contract for the `deepagents` PyPI
+package is not documented as a filesystem path; skills live in the virtual
+filesystem backend. PromptScript emits `AGENTS.md` only for the `deep-agents`
+target until a fixture confirms a project-local skill directory path.
+
+## Scope classification
+
+`formatter-scope` for `AGENTS.md`. Native skill path pending fixture
+confirmation in Task 27.
+
+## Out of scope
+
+- `interrupt_on` runtime configuration (runtime steering, not instructions).
+- Sandbox backend and interpreter configuration (runtime).
+- Virtual filesystem backend selection (runtime).
+- LangGraph store and LangSmith observability (runtime/hosted).
+- Managed Deep Agents (hosted deployment).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/forgecode/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/forgecode/INDEX.md
@@ -1,0 +1,63 @@
+# ForgeCode (antinomyhq)
+
+Source: https://forgecode.dev/docs/skills/,
+https://github.com/antinomyhq/forgecode
+Retrieved: 2026-07-17
+Version: ForgeCode (TermBench 2.0 #1, 81.8% accuracy)
+
+## Contract
+
+ForgeCode is an AI pair programmer supporting Claude, GPT, O Series, Grok,
+Deepseek, Gemini, and 300+ models.
+
+### Skills
+
+Skills live in three places:
+
+- **Project skills**: `.forge/skills/<skill-name>/SKILL.md` inside your
+  project, checked into version control and shared with your team.
+- **Agents skills**: `~/.agents/skills/<skill-name>/SKILL.md` on your
+  machine, shared with any agent tool that follows the common agents
+  convention.
+- **Global skills**: `~/forge/skills/<skill-name>/SKILL.md` on your machine,
+  available across every project.
+
+Precedence: project > agents > global > built-in.
+
+`SKILL.md` format is fully compatible with Claude Code - no conversion
+needed. Copy `.claude/skills` straight into `.forge/skills` and they work.
+
+`:skill` command lists all available skills with descriptions.
+
+### AGENTS.md
+
+ForgeCode reads `AGENTS.md` as the cross-tool standard. The skills page does
+not explicitly document the AGENTS.md path, but ForgeCode follows the common
+agents convention (it reads `~/.agents/skills/`). Task 27 must capture a
+fixture confirming the project-local AGENTS.md path before adding native
+agent output.
+
+### Agents
+
+ForgeCode supports custom agents (task management, 300+ models). Agent
+persona configurations live in
+https://github.com/antinomyhq/awesome-forge-agents. Project-local agent file
+contract is not documented on the skills page; Task 27 fixture must confirm
+the path before adding native agent output.
+
+## Expected paths (initial)
+
+- `AGENTS.md` (root) - instruction file (pending Task 27 fixture confirmation
+  of exact discovery rules)
+- `.forge/skills/<name>/SKILL.md` - native project skills (fixture-confirmed)
+
+## Scope classification
+
+`formatter-scope` for `AGENTS.md` and `.forge/skills/`.
+
+## Out of scope
+
+- User-level skill directories (`~/.agents/skills/`, `~/forge/skills/`).
+- Global Forge behavior, TermBench scoring (runtime).
+- Agent persona runtime selection.
+- Forge marketplace publishing.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/kimi/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/kimi/INDEX.md
@@ -1,0 +1,84 @@
+# Kimi CLI (Moonshot AI)
+
+Source: https://moonshotai.github.io/kimi-cli/en/customization/skills.html,
+https://github.com/MoonshotAI/kimi-cli
+Retrieved: 2026-07-17
+Version: Kimi Code CLI (current; rebuilt & upgraded version released)
+
+## Contract
+
+Kimi Code CLI supports Agent Skills (open standard) and AGENTS.md.
+
+### Skills
+
+Skill discovery (priority order, more specific scope wins):
+
+**Project > User > Extra > Built-in**
+
+User-level (candidate directories, two groups merged independently; brand
+group has higher specificity):
+
+- Brand group (mutually exclusive): `~/.kimi/skills/`, `~/.claude/skills/`,
+  `~/.codex/skills/`
+- Generic group (mutually exclusive): `~/.config/agents/skills/`
+  (recommended), `~/.agents/skills/`
+
+Project-level (relative to project root - nearest `.git` ancestor):
+
+- Brand group: `.kimi/skills/`, `.claude/skills/`, `.codex/skills/`
+- Generic group: `.agents/skills/`
+
+`merge_all_available_skills = true` (default) merges every brand directory
+that exists; same-name skills resolved by priority kimi > claude > codex.
+Set to `false` for first-match-only behaviour.
+
+`extra_skill_dirs` in config adds directories on top of discovery. `~` is
+expanded to `$HOME`; relative entries resolve against the project root.
+
+Flat `.md` skills: a single `.md` file placed directly in a skills directory
+is recognised as a skill. `name` defaults to the filename without `.md`. If a
+flat `.md` and a subdirectory share the same name in the same directory, the
+subdirectory wins.
+
+`SKILL.md` frontmatter:
+
+| Field           | Required | Notes                                                               |
+| --------------- | -------- | ------------------------------------------------------------------- |
+| `name`          | no       | 1-64 chars, lowercase letters/numbers/hyphens; defaults to dir name |
+| `description`   | no       | 1-1024 chars; "No description provided." if omitted                 |
+| `license`       | no       | License name or file reference                                      |
+| `compatibility` | no       | Up to 500 chars                                                     |
+| `metadata`      | no       | Additional key-value attributes                                     |
+
+Description resolution chain: frontmatter `description:` -> first non-empty
+body line (truncated at 240 chars) -> `"No description provided."`.
+
+`/skill:<name>` slash command loads a skill. `--skills-dir` flag adds skill
+directories. Flow skills use `type: flow` frontmatter with Mermaid or D2
+diagrams; invoked via `/flow:<name>`.
+
+Built-in skills: `kimi-cli-help`, `skill-creator`.
+
+### AGENTS.md
+
+Kimi CLI reads `AGENTS.md` as the cross-tool standard (the repo has its own
+`AGENTS.md` at https://github.com/MoonshotAI/kimi-cli/blob/main/AGENTS.md).
+
+## Expected paths (initial)
+
+- `AGENTS.md` (root) - instruction file
+- `.kimi/skills/<name>/SKILL.md` - native project skills (Task 27 fixture
+  confirmation)
+
+## Scope classification
+
+`formatter-scope` for `AGENTS.md`. Native skill path pending fixture
+confirmation in Task 27.
+
+## Out of scope
+
+- User-level skill directories (`~/.kimi/skills/`, `~/.claude/skills/`,
+  `~/.codex/skills/`, `~/.config/agents/skills/`, `~/.agents/skills/`).
+- Flow skill execution runtime (`/flow:<name>`).
+- `--skills-dir` flag and `extra_skill_dirs` config (runtime).
+- Plugin execution runtime.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/mimo/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/priority-b/mimo/INDEX.md
@@ -1,0 +1,62 @@
+# MiMo Code (Xiaomi)
+
+Source: https://github.com/XiaomiMiMo/MiMo-Code
+Retrieved: 2026-07-17
+Version: MiMo Code v0.1.6 (July 15 2026)
+
+## Contract
+
+MiMo Code is a fork of OpenCode. The MiMo-Code repository itself has both
+`AGENTS.md` and `CLAUDE.md` at the root, confirming AGENTS.md is read.
+
+MiMo Code keeps all core OpenCode capabilities (multiple providers, TUI, LSP,
+MCP, plugins) and adds persistent memory, intelligent context management,
+subagent orchestration, goal-driven autonomous loops, compose workflows, and
+self-improvement via dream/distill.
+
+### Configuration
+
+- Config: `~/.config/mimocode/mimocode.jsonc` or `mimocode.json`
+  (user-level, out of scope). Schema auto-injected at
+  `https://mimo.xiaomi.com/mimocode/config.json`.
+- TUI: `tui.json` (schema `https://mimo.xiaomi.com/mimocode/tui.json`).
+- Data directories (XDG, out of scope): `~/.local/share/mimocode/`,
+  `~/.local/state/mimocode/`, `~/.cache/mimocode/`.
+- `MIMOCODE_HOME` overrides all paths.
+
+### Skills
+
+MiMo Code (via OpenCode/Antigravity lineage) uses the `.agents/skills/`
+workspace project path (see `antigravity/skills-path.md`). Skills follow the
+Agent Skills open standard.
+
+### Permissions
+
+- `external_directory` permission prompts for paths outside the project
+  working directory. `/tmp/**` can be allowlisted in config.
+- `--dangerously-skip-permissions` (or `MIMOCODE_DANGEROUSLY_SKIP_PERMISSIONS=1`)
+  auto-approves everything in trusted/disposable environments.
+
+### Experimental
+
+- `experimental.maxMode` - parallel best-of-N reasoning with judge selection.
+
+## Expected paths (initial)
+
+- `AGENTS.md` (root) - instruction file
+- `.agents/skills/<name>/SKILL.md` - native project skills (Task 27 fixture
+  confirmation)
+
+## Scope classification
+
+`formatter-scope` for `AGENTS.md`. Native skill path pending fixture
+confirmation in Task 27. OpenCode compatibility means existing OpenCode
+formatter behavior is a useful reference.
+
+## Out of scope
+
+- User-level config (`~/.config/mimocode/`).
+- TUI preferences, runtime data, cache.
+- Max Mode, dream/distill, compose workflows (runtime).
+- Git worktree session features (runtime).
+- Permission rule configuration (runtime config, not instructions).

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/skill-md-spec/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/skill-md-spec/INDEX.md
@@ -1,0 +1,101 @@
+# SKILL.md Open Standard (agentskills.io)
+
+Source: https://agentskills.io/specification, https://agentskills.io/
+Retrieved: 2026-07-17
+Version: spec page last updated 2026-05-20
+
+## Directory structure
+
+```
+skill-name/
+├── SKILL.md          # Required: metadata + instructions
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+├── assets/           # Optional: templates, resources
+└── ...               # Any additional files or directories
+```
+
+## Frontmatter
+
+| Field           | Required | Constraints                                                                                                                            |
+| --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`          | yes      | Max 64 chars. Lowercase letters, numbers, hyphens only. No start/end hyphen. No consecutive hyphens. Must match parent directory name. |
+| `description`   | yes      | Max 1024 chars. Non-empty. What the skill does and when to use it.                                                                     |
+| `license`       | no       | License name or reference to a bundled license file.                                                                                   |
+| `compatibility` | no       | Max 500 chars. Environment requirements (product, system packages, network).                                                           |
+| `metadata`      | no       | Arbitrary key-value mapping (string -> string).                                                                                        |
+| `allowed-tools` | no       | Space-separated string of pre-approved tools. Experimental.                                                                            |
+
+## Name rules
+
+- 1-64 characters
+- unicode lowercase alphanumeric (`a-z`, `0-9`) and hyphens (`-`)
+- must not start or end with a hyphen
+- must not contain consecutive hyphens (`--`)
+- must match the parent directory name
+
+Invalid: `PDF-Processing` (uppercase), `-pdf` (leading hyphen),
+`pdf--processing` (consecutive hyphens).
+
+## Description rules
+
+- 1-1024 characters
+- describe both what the skill does and when to use it
+- include specific keywords that help agents identify relevant tasks
+
+Good: "Extracts text and tables from PDF files, fills PDF forms, and merges
+multiple PDFs. Use when working with PDF documents or when the user mentions
+PDFs, forms, or document extraction."
+
+Poor: "Helps with PDFs."
+
+## Body content
+
+No format restrictions. Recommended sections: step-by-step instructions,
+examples of inputs and outputs, common edge cases. Keep `SKILL.md` under 500
+lines. Move detailed reference material to separate files.
+
+## Optional directories
+
+- `scripts/` - executable code. Self-contained or clearly document dependencies.
+- `references/` - additional documentation loaded on demand.
+- `assets/` - static resources (templates, images, data files).
+
+## Progressive disclosure
+
+1. Metadata (~100 tokens): `name` and `description` loaded at startup.
+2. Instructions (< 5000 tokens recommended): full `SKILL.md` body loaded on activation.
+3. Resources (as needed): files in `scripts/`, `references/`, `assets/` loaded on demand.
+
+## File references
+
+Use relative paths from the skill root. Keep file references one level deep
+from `SKILL.md`.
+
+## Validation
+
+Use the `skills-ref` reference library: `skills-ref validate ./my-skill`.
+
+## PromptScript action (Task 9)
+
+- Add `license?: string` to inline skill extraction and SKILL.md frontmatter
+  where target schemas allow it.
+- Add `scripts?: string[]` and `references?: string[]` for inline PRS skills.
+- Resolve script and reference paths relative to the file declaring each
+  skill.
+- Load script content under `scripts/<basename>` and references under
+  `references/<basename>`.
+- Record source executable bits in `SkillResource` and propagate mode into
+  generated `FormatterOutput`.
+- Add `license` to skill replace semantics; add `scripts` and `references`
+  to append and deduplicate semantics.
+- Keep Factory filtering behavior until its contract fixture allows
+  `license`.
+- Preserve raw external frontmatter unchanged for permissive targets.
+
+## Adoption
+
+Adopted beyond Claude: Gemini CLI (`.gemini/skills/` + `.agents/skills/`
+alias), Cursor (via plugins and Customize), Codex (`.agents/skills/`,
+`skills.config`), Factory, OpenCode, Kimi CLI, ForgeCode, Deep Agents,
+Zed, and growing.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/skill-md-spec/full.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/skill-md-spec/full.md
@@ -1,0 +1,25 @@
+---
+name: pdf-processing
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+license: Apache-2.0
+compatibility: Requires Python 3.14+ and uv
+metadata:
+  author: example-org
+  version: '1.0'
+allowed-tools: Bash(git:*) Bash(jq:*) Read
+---
+
+# PDF Processing
+
+Extract text and tables from PDF files, fill PDF forms, and merge multiple
+PDFs. Use when working with PDF documents or when the user mentions PDFs,
+forms, or document extraction.
+
+## Steps
+
+1. Load the PDF via `scripts/extract.py`.
+2. Extract text and table regions.
+3. Fill form fields or merge sources as requested.
+4. Write the result to the requested output path.
+
+See [the reference guide](references/REFERENCE.md) for details.

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/skill-md-spec/minimal.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/skill-md-spec/minimal.md
@@ -1,0 +1,4 @@
+---
+name: skill-name
+description: A description of what this skill does and when to use it.
+---

--- a/packages/formatters/src/__tests__/platform-contracts.spec.ts
+++ b/packages/formatters/src/__tests__/platform-contracts.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, relative, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'platform-contracts'
+);
+
+/**
+ * Recursively find every INDEX.md under the fixture tree.
+ */
+function findAllIndexFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      results.push(...findAllIndexFiles(fullPath));
+    } else if (entry === 'INDEX.md') {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Extract a top-level "Field: value" from markdown content.
+ */
+function extractField(content: string, field: string): string | null {
+  const regex = new RegExp(`^${field}:\\s*(.+)$`, 'mi');
+  const match = content.match(regex);
+  return match ? match[1].trim() : null;
+}
+
+const VALID_SCOPES = ['formatter-scope', 'out-of-scope', 'rejected'];
+
+/**
+ * Determine the INDEX.md type:
+ * - 'family': has a markdown table with Source/Retrieved/Scope columns
+ * - 'target': has ## Scope classification section + ## Expected path section
+ * - 'spec': has Source/Retrieved but no Scope or Expected path (spec pages)
+ */
+function getIndexType(content: string): 'family' | 'target' | 'spec' {
+  if (/\|\s*Source/i.test(content) && /\|\s*Scope/i.test(content)) return 'family';
+  if (
+    /##\s+Scope classification/i.test(content) ||
+    /##\s+Expected path/i.test(content) ||
+    /##\s+Why rejected/i.test(content)
+  )
+    return 'target';
+  return 'spec';
+}
+
+/**
+ * Extract scope value from a target INDEX.md by searching the
+ * "## Scope classification" section for a valid scope keyword in backticks.
+ */
+function extractScopeFromSection(content: string): string | null {
+  const sectionMatch = content.match(/##\s+Scope classification[\s\S]*?(?=\n##\s|\n$|$)/i);
+  if (!sectionMatch) return null;
+  for (const scope of VALID_SCOPES) {
+    if (new RegExp(`\`${scope}\``, 'i').test(sectionMatch[0])) return scope;
+    if (new RegExp(`\\b${scope}\\b`, 'i').test(sectionMatch[0])) return scope;
+  }
+  return null;
+}
+
+const allIndexFiles = findAllIndexFiles(FIXTURES_DIR);
+
+describe('Platform contract fixture integrity', () => {
+  it('should find at least one INDEX.md in the fixture tree', () => {
+    expect(allIndexFiles.length).toBeGreaterThan(0);
+  });
+
+  it('should find INDEX.md for every expected platform directory', () => {
+    const expectedDirs = [
+      'claude',
+      'github',
+      'cursor',
+      'antigravity',
+      'codex',
+      'gemini',
+      'grok',
+      'factory',
+      'agents-md-spec',
+      'skill-md-spec',
+      'agents-md-only',
+      'agents-md-only/amazon-q',
+      'agents-md-only/warp',
+      'agents-md-only/zed',
+      'agents-md-only/aider',
+      'agents-md-only/jules',
+      'agents-md-only/devin',
+      'agents-md-only/phoenix',
+      'agents-md-only/swe-agent',
+      'priority-b',
+      'priority-b/kimi',
+      'priority-b/mimo',
+      'priority-b/deep-agents',
+      'priority-b/forgecode',
+    ];
+    for (const dir of expectedDirs) {
+      const indexPath = join(FIXTURES_DIR, dir, 'INDEX.md');
+      expect(existsSync(indexPath), `Missing INDEX.md: ${dir}/INDEX.md`).toBe(true);
+    }
+  });
+
+  describe.each(
+    allIndexFiles.map((filePath) => ({
+      filePath,
+      relPath: relative(FIXTURES_DIR, filePath),
+      dirName: basename(dirname(filePath)),
+      content: readFileSync(filePath, 'utf-8'),
+    }))
+  )('$relPath', ({ content, dirName, filePath }) => {
+    const indexType = getIndexType(content);
+    const isRejectedDir =
+      basename(dirname(filePath)) === 'phoenix' || basename(dirname(filePath)) === 'swe-agent';
+
+    it('should contain a Source URL or table column', () => {
+      if (indexType === 'family') {
+        expect(
+          /\|\s*Source/i.test(content),
+          `${dirName}/INDEX.md family index must have Source column`
+        ).toBe(true);
+      } else {
+        const source = extractField(content, 'Source');
+        expect(source, `${dirName}/INDEX.md must have a Source field`).not.toBeNull();
+        // Source must contain a URL, "web search", or "rejected" marker
+        expect(source!).toMatch(/https?:\/\/|web search|rejected/i);
+      }
+    });
+
+    it('should contain a Retrieved date', () => {
+      if (indexType === 'family') {
+        expect(
+          /\|\s*Retrieved/i.test(content),
+          `${dirName}/INDEX.md family index must have Retrieved column`
+        ).toBe(true);
+      } else {
+        const retrieved = extractField(content, 'Retrieved');
+        expect(retrieved, `${dirName}/INDEX.md must have a Retrieved date`).not.toBeNull();
+        expect(retrieved!).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    });
+
+    if (indexType === 'target') {
+      it('should contain a valid Scope classification', () => {
+        // First try top-level "Scope: value" field
+        let scope = extractField(content, 'Scope');
+        // Then try extracting from "## Scope classification" section
+        if (!scope) scope = extractScopeFromSection(content);
+        expect(scope, `${dirName}/INDEX.md must have a valid scope`).not.toBeNull();
+        expect(VALID_SCOPES).toContain(scope);
+      });
+
+      it('should contain an Expected path or rejected status', () => {
+        const hasExpectedPath = /##\s+Expected path/i.test(content);
+        const hasRejected = /##\s+Why rejected/i.test(content);
+        expect(
+          hasExpectedPath || hasRejected,
+          `${dirName}/INDEX.md must have "## Expected path" or "## Why rejected"`
+        ).toBe(true);
+      });
+    }
+
+    if (indexType === 'family') {
+      it('should have a Scope column in the table', () => {
+        expect(
+          /\|\s*Scope/i.test(content),
+          `${dirName}/INDEX.md family index must have Scope column`
+        ).toBe(true);
+      });
+
+      it('should have an Expected path column in the table', () => {
+        expect(
+          /\|\s*Expected path/i.test(content),
+          `${dirName}/INDEX.md family index must have Expected path column`
+        ).toBe(true);
+      });
+    }
+
+    // Spec pages (agents-md-spec, skill-md-spec) are not per-target contracts;
+    // they document open standards. Only Source + Retrieved are required.
+    if (indexType === 'spec') {
+      it('should contain a Version field', () => {
+        const version = extractField(content, 'Version');
+        expect(version, `${dirName}/INDEX.md spec page must have a Version field`).not.toBeNull();
+      });
+    }
+
+    it('should reference fixture files that exist on disk', () => {
+      const dir = dirname(filePath);
+      const files = readdirSync(dir).filter(
+        (f) => f !== 'INDEX.md' && f !== '.DS_Store' && !statSync(join(dir, f)).isDirectory()
+      );
+      for (const file of files) {
+        expect(existsSync(join(dir, file)), `Fixture file missing: ${file}`).toBe(true);
+      }
+    });
+
+    if (isRejectedDir) {
+      it('should document why it was rejected and reopen conditions', () => {
+        expect(content).toMatch(/##\s+Why rejected|##\s+.*Rejected/i);
+        expect(content).toMatch(/##\s+What PromptScript must not do|##\s+Reopen condition/i);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Add 65 fixture files covering all platform contracts with source URL, version, retrieval date, and expected project-local path. Includes platform-contracts.spec.ts integrity test.