### PR TITLE
fix(cli): apply Prettier post-format in diff for compile parity

### DIFF
--- a/packages/cli/src/commands/__tests__/diff.spec.ts
+++ b/packages/cli/src/commands/__tests__/diff.spec.ts
@@ -11,6 +11,11 @@ const {
   mockReadFile,
   mockPagerWrite,
   mockPagerFlush,
+  mockIsVerbose,
+  mockIsDebug,
+  mockConsoleVerbose,
+  mockConsoleDebug,
+  mockConsoleWarn,
 } = vi.hoisted(() => {
   const mockStart = vi.fn().mockReturnThis();
   const mockSucceed = vi.fn().mockReturnThis();
@@ -30,6 +35,11 @@ const {
   const mockReadFile = vi.fn();
   const mockPagerWrite = vi.fn();
   const mockPagerFlush = vi.fn().mockResolvedValue(undefined);
+  const mockIsVerbose = vi.fn().mockReturnValue(false);
+  const mockIsDebug = vi.fn().mockReturnValue(false);
+  const mockConsoleVerbose = vi.fn();
+  const mockConsoleDebug = vi.fn();
+  const mockConsoleWarn = vi.fn();
   return {
     mockSucceed,
     mockFail,
@@ -41,16 +51,26 @@ const {
     mockReadFile,
     mockPagerWrite,
     mockPagerFlush,
+    mockIsVerbose,
+    mockIsDebug,
+    mockConsoleVerbose,
+    mockConsoleDebug,
+    mockConsoleWarn,
   };
 });
 
 vi.mock('../../output/console.js', () => ({
   createSpinner: vi.fn(() => mockSpinner),
+  isVerbose: mockIsVerbose,
+  isDebug: mockIsDebug,
   ConsoleOutput: {
     success: vi.fn(),
     error: vi.fn(),
     muted: vi.fn(),
     newline: vi.fn(),
+    verbose: mockConsoleVerbose,
+    debug: mockConsoleDebug,
+    warn: mockConsoleWarn,
   },
 }));
 
@@ -115,7 +135,7 @@ vi.mock('chalk', () => {
   };
 });
 
-import { diffCommand } from '../diff.js';
+import { diffCommand, createDiffLogger } from '../diff.js';
 import { ConsoleOutput } from '../../output/console.js';
 
 describe('diffCommand', () => {
@@ -124,6 +144,8 @@ describe('diffCommand', () => {
     process.exitCode = undefined;
     mockSpinner.text = '';
     mockPostFormatTransform.apply = false;
+    mockIsVerbose.mockReturnValue(false);
+    mockIsDebug.mockReturnValue(false);
   });
 
   it('should detect changes between compiled output and existing files', async () => {
@@ -289,5 +311,53 @@ describe('diffCommand', () => {
     expect(mockPagerWrite).toHaveBeenCalledWith(
       expect.stringContaining('All files are up to date')
     );
+  });
+});
+
+describe('createDiffLogger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsVerbose.mockReturnValue(false);
+    mockIsDebug.mockReturnValue(false);
+  });
+
+  it('verbose forwards to ConsoleOutput.verbose when --verbose or --debug is set', () => {
+    mockIsVerbose.mockReturnValue(true);
+    const logger = createDiffLogger();
+    logger.verbose('post-format note');
+    expect(mockConsoleVerbose).toHaveBeenCalledWith('post-format note');
+  });
+
+  it('verbose forwards when --debug is set even without --verbose', () => {
+    mockIsDebug.mockReturnValue(true);
+    const logger = createDiffLogger();
+    logger.verbose('post-format note');
+    expect(mockConsoleVerbose).toHaveBeenCalledWith('post-format note');
+  });
+
+  it('verbose is silent when neither --verbose nor --debug is set', () => {
+    const logger = createDiffLogger();
+    logger.verbose('post-format note');
+    expect(mockConsoleVerbose).not.toHaveBeenCalled();
+  });
+
+  it('debug forwards to ConsoleOutput.debug only when --debug is set', () => {
+    mockIsDebug.mockReturnValue(true);
+    const logger = createDiffLogger();
+    logger.debug('prettier rejected X');
+    expect(mockConsoleDebug).toHaveBeenCalledWith('prettier rejected X');
+  });
+
+  it('debug is silent when --debug is not set', () => {
+    mockIsVerbose.mockReturnValue(true);
+    const logger = createDiffLogger();
+    logger.debug('prettier rejected X');
+    expect(mockConsoleDebug).not.toHaveBeenCalled();
+  });
+
+  it('warn always forwards to ConsoleOutput.warn', () => {
+    const logger = createDiffLogger();
+    logger.warn('post-format warning');
+    expect(mockConsoleWarn).toHaveBeenCalledWith('post-format warning');
   });
 });

--- a/packages/cli/src/commands/__tests__/diff.spec.ts
+++ b/packages/cli/src/commands/__tests__/diff.spec.ts
@@ -83,6 +83,24 @@ vi.mock('../../output/pager.js', () => ({
   })),
 }));
 
+const { mockPostFormatWithPrettier, mockPostFormatTransform } = vi.hoisted(() => {
+  // postFormatWithPrettier mutates outputs in place. The default transform is
+  // a no-op so existing tests are unaffected; tests that exercise the
+  // post-format parity fix set mockPostFormatTransform.apply to true.
+  const mockPostFormatTransform = { apply: false };
+  const mockPostFormatWithPrettier = vi.fn(async (outputs: Map<string, { content: string }>) => {
+    if (!mockPostFormatTransform.apply) return;
+    for (const output of outputs.values()) {
+      output.content = `prettier-normalised\n${output.content}`;
+    }
+  });
+  return { mockPostFormatWithPrettier, mockPostFormatTransform };
+});
+
+vi.mock('../../prettier/post-format.js', () => ({
+  postFormatWithPrettier: mockPostFormatWithPrettier,
+}));
+
 vi.mock('chalk', () => {
   const identity = (s: string): string => s;
   return {
@@ -105,6 +123,7 @@ describe('diffCommand', () => {
     vi.clearAllMocks();
     process.exitCode = undefined;
     mockSpinner.text = '';
+    mockPostFormatTransform.apply = false;
   });
 
   it('should detect changes between compiled output and existing files', async () => {
@@ -232,5 +251,43 @@ describe('diffCommand', () => {
     expect(mockFail).toHaveBeenCalledWith('Error');
     expect(ConsoleOutput.error).toHaveBeenCalledWith('Config load failure');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('should apply Prettier post-format before comparing (issue #307 drift fix)', async () => {
+    // Arrange: disk content matches what compile writes AFTER prettier post-format.
+    // Without the post-format call, diff would compare raw formatter output
+    // (no "prettier-normalised" prefix) against the canonicalised disk file
+    // and falsely report a modification.
+    const prettierCanonicalised = 'prettier-normalised\nsame content';
+    mockLoadConfig.mockResolvedValue({
+      targets: ['github'],
+      validation: {},
+    });
+    mockResolveRegistryPath.mockResolvedValue({
+      path: './registry',
+      isRemote: false,
+      source: 'local',
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockCompile.mockResolvedValue({
+      success: true,
+      errors: [],
+      warnings: [],
+      outputs: new Map([
+        ['github', { path: '.github/copilot-instructions.md', content: 'same content' }],
+      ]),
+    });
+    mockReadFile.mockResolvedValue(prettierCanonicalised);
+    mockPostFormatTransform.apply = true;
+
+    // Act
+    await diffCommand({ noPager: true });
+
+    // Assert: post-format ran, and the canonicalised output matches disk → no drift
+    expect(mockPostFormatWithPrettier).toHaveBeenCalledTimes(1);
+    expect(mockSucceed).toHaveBeenCalledWith('Diff computed');
+    expect(mockPagerWrite).toHaveBeenCalledWith(
+      expect.stringContaining('All files are up to date')
+    );
   });
 });

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -31,7 +31,7 @@ function configureColors(options: DiffOptions): void {
  * Mirrors createCliLogger in compile.ts so diff and compile report Prettier
  * post-format warnings consistently.
  */
-function createDiffLogger(): Logger {
+export function createDiffLogger(): Logger {
   return {
     verbose: (message: string) => {
       if (isVerbose() || isDebug()) {

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -2,14 +2,15 @@ import { resolve } from 'path';
 import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import type { DiffOptions } from '../types.js';
-import type { PromptScriptConfig, TargetEntry, TargetConfig } from '@promptscript/core';
+import type { Logger, PromptScriptConfig, TargetEntry, TargetConfig } from '@promptscript/core';
 import type { FormatterOutput } from '@promptscript/compiler';
 import { loadConfig } from '../config/loader.js';
-import { createSpinner, ConsoleOutput } from '../output/console.js';
+import { createSpinner, ConsoleOutput, isVerbose, isDebug } from '../output/console.js';
 import { createPager, Pager } from '../output/pager.js';
 import { Compiler } from '@promptscript/compiler';
 import { resolveRegistryPath } from '../utils/registry-resolver.js';
 import { stripMarkers } from '../utils/markers.js';
+import { postFormatWithPrettier } from '../prettier/post-format.js';
 import chalk from 'chalk';
 
 /**
@@ -23,6 +24,29 @@ function configureColors(options: DiffOptions): void {
     chalk.level = 3; // Full color support
   }
   // Otherwise use chalk's auto-detection (respects NO_COLOR env var)
+}
+
+/**
+ * Logger that surfaces post-format diagnostics only when --verbose/--debug is set.
+ * Mirrors createCliLogger in compile.ts so diff and compile report Prettier
+ * post-format warnings consistently.
+ */
+function createDiffLogger(): Logger {
+  return {
+    verbose: (message: string) => {
+      if (isVerbose() || isDebug()) {
+        ConsoleOutput.verbose(message);
+      }
+    },
+    debug: (message: string) => {
+      if (isDebug()) {
+        ConsoleOutput.debug(message);
+      }
+    },
+    warn: (message: string) => {
+      ConsoleOutput.warn(message);
+    },
+  };
 }
 
 /**
@@ -157,6 +181,13 @@ export async function diffCommand(options: DiffOptions): Promise<void> {
       process.exitCode = 1;
       return;
     }
+
+    // Apply the same Prettier post-format pass as compile.ts so diff compares
+    // against the canonical form that compile --force actually writes to disk.
+    // Without this, Prettier-normalised markdown (list-continuation indent,
+    // YAML frontmatter quote style, etc.) on disk would always mismatch the
+    // raw formatter output, producing permanent false drift. See issue #307.
+    await postFormatWithPrettier(result.outputs, process.cwd(), createDiffLogger());
 
     spinner.succeed('Diff computed');
     ConsoleOutput.newline();


### PR DESCRIPTION
## Summary

`prs diff` skipped the `postFormatWithPrettier` pass that `prs compile` applies before writing output to disk. Disk files are Prettier-canonicalised (markdown list-continuation indent, YAML frontmatter quote style); raw formatter output is not. Comparing the two produced permanent false drift immediately after `compile --force`, even with no source change.

## Root cause

`packages/cli/src/commands/compile.ts` calls `postFormatWithPrettier(result.outputs, ...)` after compile and before writeOutputs. `packages/cli/src/commands/diff.ts` did not, so it compared disk content (Prettier-canonical) against raw compiler output (un-canonicalised).

`stripMarkers` only strips generation-marker comments; it does not touch indentation or frontmatter quote style, so the mismatch was not absorbed.

## Fix

Run the same `postFormatWithPrettier` pass in `diffCommand` after `compiler.compile` succeeds, before the compare loop. Adds a minimal `createDiffLogger` mirroring compile's logger so Prettier diagnostics surface under `--verbose`/`--debug`.

Fixes #307.

## Verification

- `pnpm run format`, `lint`, `typecheck`, `test` (1083 passing), `prs validate --strict`, `schema:check`, `skill:check`, `grammar:check` all green.
- New test `should apply Prettier post-format before comparing (issue #307 drift fix)` locks the call site and verifies disk content matching the canonicalised compile output reports no drift.