### PR TITLE
docs(cli): replace duplicated config snippet with cross-link

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1108,39 +1108,15 @@ The CLI uses `promptscript.yaml` by default. Override with `--config`:
 id: my-project
 syntax: '1.4.0'
 
-# Input settings
 input:
   entry: .promptscript/project.prs
 
-# Registry configuration
-registry:
-  path: ./registry
-  # Or remote URL
-  # url: https://github.com/org/registry
-
-# Output targets
 targets:
-  - github:
-      output: .github/copilot-instructions.md
-  - claude:
-      output: CLAUDE.md
-  - cursor:
-      output: .cursor/rules/project.mdc
-  - antigravity:
-      output: .agent/rules/project.md
-
-# Validation settings
-validation:
-  rules:
-    empty-block: warning
-
-# Watch settings
-watch:
-  include:
-    - '.promptscript/**/*.prs'
-  exclude:
-    - '**/node_modules/**'
+  - github
+  - claude
 ```
+
+See the [Configuration Reference](./config.md) for every field, default, and advanced option (registry, builds, validation, watch, formatting, customConventions, universalDir). The JSON schema is the source of truth: <https://getpromptscript.dev/latest/schema/config.json>.
 
 ## Environment Variables
 


### PR DESCRIPTION
Trim the Configuration File section in the CLI reference to a minimal
example and link to the full Configuration Reference instead of
duplicating registry/validation/watch fields. Reduces drift between
the two pages.
