### PR TITLE
fix(formatters): use .gemini/skills for auto-injected skill path

### DIFF
--- a/packages/core/src/target-catalog.ts
+++ b/packages/core/src/target-catalog.ts
@@ -155,7 +155,7 @@ export const TARGET_DEFINITIONS = {
     name: 'gemini',
     outputPath: 'GEMINI.md',
     family: 'base',
-    skillPath: { basePath: '.agents/skills', fileName: 'skill.md' },
+    skillPath: { basePath: '.gemini/skills', fileName: 'skill.md' },
     features: {
       defaultEnabled: false,
       defaultVersion: 'full',

--- a/packages/formatters/src/__tests__/skill-path-inventory.spec.ts
+++ b/packages/formatters/src/__tests__/skill-path-inventory.spec.ts
@@ -24,7 +24,7 @@ const EXPECTED_SKILL_PATHS: Record<string, { basePath: string | null; fileName: 
   cortex: { basePath: '.cortex/skills', fileName: 'SKILL.md' },
   crush: { basePath: '.crush/skills', fileName: 'SKILL.md' },
   factory: { basePath: '.factory/skills', fileName: 'SKILL.md' },
-  gemini: { basePath: '.agents/skills', fileName: 'skill.md' },
+  gemini: { basePath: '.gemini/skills', fileName: 'skill.md' },
   goose: { basePath: '.goose/skills', fileName: 'SKILL.md' },
   iflow: { basePath: '.iflow/skills', fileName: 'SKILL.md' },
   junie: { basePath: '.junie/skills', fileName: 'SKILL.md' },

--- a/packages/formatters/src/formatters/gemini.ts
+++ b/packages/formatters/src/formatters/gemini.ts
@@ -80,13 +80,17 @@ export class GeminiFormatter extends MarkdownInstructionFormatter {
   }
 
   /**
-   * Resolve the skill base path based on the `skillPath` target option.
-   * - `agents` (default): `.agents/skills/` (interoperable)
-   * - `gemini`: `.gemini/skills/` (legacy)
-   * - `both`: `.agents/skills/` (primary; `both` mode handled in format)
+   * Skill base path for auto-injected skills.
+   * Returns `.gemini/skills` to match the path used by generateSkillFile()
+   * (which derives from `this.config.dotDir`). This keeps the auto-injected
+   * PromptScript skill consistent with user-defined @skills blocks and
+   * avoids creating an unexpected `.agents/` directory.
+   *
+   * The `skillPath` target option (`agents` | `gemini` | `both`) is planned
+   * but not yet implemented; when it lands, this method should respect it.
    */
   override getSkillBasePath(): string | null {
-    return '.agents/skills';
+    return '.gemini/skills';
   }
 
   /**


### PR DESCRIPTION
## Problem

Fixes #312

When running `prs compile` with targets like `factory`, `github`, `gemini` (no `codex`), the auto-injected PromptScript skill was written to `.agents/skills/promptscript/skill.md` — creating an unexpected `.agents/` directory.

## Root Cause

`GeminiFormatter.getSkillBasePath()` returned `.agents/skills` (hardcoded), but `generateSkillFile()` used `.gemini/skills` (from `this.config.dotDir`). This inconsistency caused the auto-injected PromptScript skill to land in `.agents/` while user-defined @skills blocks went to `.gemini/skills/`.

## Fix

Changed `getSkillBasePath()` to return `.gemini/skills` — matching `generateSkillFile()` and the formatter's own `dotDir`. Now the auto-injected skill goes to `.gemini/skills/promptscript/skill.md`, consistent with user-defined skills. No `.agents/` directory is created unless a target that natively uses it (codex, cursor, amp, etc.) is configured.

The `skillPath` target option (`agents` | `gemini` | `both`) remains documented but unimplemented; it can be fully wired in a follow-up PR.

## Changes

- `packages/formatters/src/formatters/gemini.ts`: `getSkillBasePath()` returns `.gemini/skills`
- `packages/core/src/target-catalog.ts`: gemini `skillPath.basePath` updated to `.gemini/skills`
- `packages/formatters/src/__tests__/skill-path-inventory.spec.ts`: updated expected path

## Verification

All pipeline checks pass: format, lint, typecheck, test (1439 tests), prs validate, schema:check, skill:check, grammar:check.