### PR TITLE
fix(formatters): render @context text as Context section

### DIFF
--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# promptscript-generated: 2026-05-30T23:22:42.935Z | source: .promptscript/project.prs | target: claude
+# promptscript-generated: 2026-07-23T16:03:24.538Z | source: .promptscript/project.prs | target: claude
 name: 'skill-creator'
 description: "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy."
 ---
@@ -387,6 +387,7 @@ Present the eval set to the user for review using the HTML template:
 
 1. Read the template from `assets/eval_review.html`
 2. Replace the placeholders:
+
    - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
    - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
    - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
@@ -502,6 +503,7 @@ Repeating one more time the core loop here for emphasis:
 - Draft or edit the skill
 - Run claude-with-access-to-the-skill on test prompts
 - With the user, evaluate the outputs:
+
   - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
   - Run quantitative evals
 

--- a/.claude/skills/skill-creator/agents/comparator.md
+++ b/.claude/skills/skill-creator/agents/comparator.md
@@ -1,6 +1,6 @@
 # Blind Comparator Agent
 
-<!-- PromptScript 2026-05-30T23:22:42.935Z | source: .promptscript/project.prs | target: claude - do not edit -->
+<!-- PromptScript 2026-07-23T16:03:24.538Z | source: .promptscript/project.prs | target: claude - do not edit -->
 
 Compare two outputs WITHOUT knowing which skill produced them.
 
@@ -41,18 +41,20 @@ You receive these parameters in your prompt:
 Based on the task, generate a rubric with two dimensions:
 
 **Content Rubric** (what the output contains):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
-|-----------|----------|----------------|---------------|
-| Correctness | Major errors | Minor errors | Fully correct |
-| Completeness | Missing key elements | Mostly complete | All elements present |
-| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+| Criterion    | 1 (Poor)                 | 3 (Acceptable)     | 5 (Excellent)        |
+| ------------ | ------------------------ | ------------------ | -------------------- |
+| Correctness  | Major errors             | Minor errors       | Fully correct        |
+| Completeness | Missing key elements     | Mostly complete    | All elements present |
+| Accuracy     | Significant inaccuracies | Minor inaccuracies | Accurate throughout  |
 
 **Structure Rubric** (how the output is organized):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
-|-----------|----------|----------------|---------------|
-| Organization | Disorganized | Reasonably organized | Clear, logical structure |
-| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
-| Usability | Difficult to use | Usable with effort | Easy to use |
+
+| Criterion    | 1 (Poor)            | 3 (Acceptable)       | 5 (Excellent)            |
+| ------------ | ------------------- | -------------------- | ------------------------ |
+| Organization | Disorganized        | Reasonably organized | Clear, logical structure |
+| Formatting   | Inconsistent/broken | Mostly consistent    | Professional, polished   |
+| Usability    | Difficult to use    | Usable with effort   | Easy to use              |
 
 Adapt criteria to the specific task. For example:
 

--- a/.factory/skills/promptscript/SKILL.md
+++ b/.factory/skills/promptscript/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# promptscript-generated: 2026-05-30T23:22:42.936Z | source: .promptscript/project.prs | target: factory
+# promptscript-generated: 2026-07-23T16:03:24.540Z | source: .promptscript/project.prs | target: factory
 name: promptscript
 description: >-
   PromptScript language expert for reading, writing, modifying, and
@@ -8,9 +8,9 @@ description: >-
   @restrictions, @shortcuts, @skills, or @agents, configuring
   promptscript.yaml, resolving compilation errors, understanding inheritance
   (@inherit) and composition (@use, @extend), or migrating AI instructions
-  to PromptScript. Also use when asked about compilation targets (GitHub
-  Copilot, Claude Code, Cursor, Antigravity, Factory AI, and 30+ other
-  AI coding agents).
+  to PromptScript. Also use when asked about the 48 built-in compilation
+  targets, including GitHub Copilot, Claude Code, Cursor, Antigravity,
+  Factory AI, and AGENTS.md-based platforms.
 user-invocable: true
 ---
 
@@ -497,9 +497,17 @@ prs skills list
 prs skills update
 ```
 
-### @extend (modify imported blocks)
+### @extend (modify existing or imported blocks)
 
-Requires an aliased @use:
+Use a direct path for inherited or local blocks:
+
+```
+@extend standards.testing {
+  coverage: 95
+}
+```
+
+Use an alias when targeting a specific imported block:
 
 ```
 @use @core/typescript as ts
@@ -508,6 +516,26 @@ Requires an aliased @use:
   testing: { coverage: 95 }
 }
 ```
+
+#### Replacing regular block fields
+
+Syntax `1.3.0` supports explicit replacement of complete regular block field values:
+
+```
+@meta { id: "project" syntax: "1.3.0" }
+
+@inherit ./company-base
+
+@extend standards {
+  testing!: ["Use Vitest"]
+  linting: ["Use ESLint"]
+}
+```
+
+`testing!` replaces the inherited value. Fields without `!` keep normal merge behavior.
+Replacement works after `@inherit` and `@use`, including aliases and nested target paths.
+A missing field is set. The modifier is rejected for `@skills`, which retain their dedicated
+merge and sealing semantics.
 
 #### Skill-aware @extend semantics
 
@@ -692,7 +720,7 @@ targets:
     version: frontmatter
   factory:
     version: full
-  windsurf:             # 31 additional agents supported
+  windsurf:             # 41 additional targets supported
     version: simple
   cline:
     version: simple
@@ -764,21 +792,28 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | Version | What it adds                                                                                                            |
 | ------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `1.0.0` | Core blocks (identity, context, standards, restrictions, knowledge, shortcuts, commands, guards, params, skills, local) |
-| `1.1.0` | Adds `@agents` (plus internal `@workflows`, `@prompts` - not user-facing)                                               |
+| `1.1.0` | Adds `@agents` and `@workflows`; reserves internal `@prompts`                                                           |
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
+| `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
+| `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
 
 ### Block Version Requirements
 
-| Block       | Minimum Syntax Version |
-| ----------- | ---------------------- |
-| `@agents`   | `1.1.0`                |
-| `@examples` | `1.2.0`                |
+| Block         | Minimum Syntax Version |
+| ------------- | ---------------------- |
+| `@agents`     | `1.1.0`                |
+| `@workflows`  | `1.1.0`                |
+| `@examples`   | `1.2.0`                |
+| `@hooks`      | `1.4.0`                |
+| `@mcpServers` | `1.4.0`                |
+| `@plugins`    | `1.4.0`                |
 
 All other built-in blocks are available from `1.0.0`.
+Regular block field replacement with `field!: value` requires syntax `1.3.0`.
 
 ### Validation Rules
 
-- **PS018 (`syntax-version-compat`)**: warns when blocks used in a file require a higher syntax version than declared. For example, `@agents` with `syntax: "1.0.0"` triggers PS018. Suggestion: run `prs validate --fix`.
+- **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
@@ -795,7 +830,7 @@ prs validate --fix          # Auto-fix syntax versions in .prs files
 prs upgrade                 # Upgrade all .prs files to the latest version
 ```
 
-`--fix` rewrites the `syntax: "..."` line in each file's `@meta` block to match the minimum version required by the blocks used. It only upgrades, never downgrades.
+`--fix` rewrites the `syntax: "..."` line in each file's `@meta` block to match the minimum version required by resolved blocks and syntax features. It follows inheritance, imports, and skill composition. It only upgrades, never downgrades.
 
 `prs upgrade` upgrades all files to the latest known syntax version regardless of what blocks they use.
 
@@ -803,10 +838,13 @@ prs upgrade                 # Upgrade all .prs files to the latest version
 
 ```
 prs init                    # Initialize project (auto-detects existing files)
+prs init --yes --targets claude factory
+prs init --dry-run          # Preview initialization
 prs init --auto-import      # Initialize + static import of existing files
 prs migrate                 # Interactive migration flow
 prs migrate --static        # Non-interactive static import
 prs migrate --llm           # Generate AI-assisted migration prompt
+prs migrate --static --dry-run
 prs compile                 # Compile to all targets
 prs compile --watch         # Watch mode
 prs compile --ignore-hashes # Skip integrity hash verification
@@ -816,7 +854,7 @@ prs validate --fix          # Auto-fix syntax version declarations
 prs validate --skip-policies # Skip policy engine evaluation
 prs upgrade                 # Upgrade all .prs files to latest syntax version
 prs import CLAUDE.md        # Import existing AI instructions
-prs import --dry-run        # Preview import conversion
+prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
 prs hooks install           # Install auto-compilation hooks for AI tools
@@ -840,34 +878,39 @@ prs registry list           # Show configured registries and aliases
 prs registry add <alias> <url>  # Add a registry alias
 ```
 
+`prs init --yes` requires explicit, detected, or user-configured targets. It does not invent
+default tools. For existing projects, `prs migrate` preserves `promptscript.yaml`, isolates static
+output under `.promptscript/migrated/`, leaves source instructions untouched, and performs no
+writes when no candidates are detected.
+
 ## Output Targets
 
-38+ supported targets. Key examples:
+48 supported targets. Key examples:
 
 | Target      | Main File                       | Skills                                             |
 | ----------- | ------------------------------- | -------------------------------------------------- |
 | GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md                         |
 | Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md                         |
-| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md                             |
-| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md                                 |
+| Cursor      | .cursor/rules/project.mdc       | .agents/skills/\*/SKILL.md                         |
+| Antigravity | .agent/rules/project.md         | -                                                  |
 | Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md, .factory/droids/\*.md |
 | OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md                       |
-| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md                         |
+| Gemini      | GEMINI.md                       | .agents/skills/\*/skill.md                         |
 | Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md                       |
-| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md                         |
-| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md                            |
+| Cline       | .clinerules                     | -                                                  |
+| Roo Code    | .roorules                       | -                                                  |
 | Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
-| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md                       |
-| + 26 more   |                                 | See full list in documentation                     |
+| Continue    | .continue/rules/project.md      | -                                                  |
+| + 36 more   |                                 | See full list in documentation                     |
 
 ### Formatter Documentation
 
 For detailed information about each formatter's output paths, supported features, quirks, and example outputs:
 
-- **Full formatter reference:** `docs/reference/formatters/` (7 dedicated pages + index of all 37)
+- **Full formatter reference:** `docs/reference/formatters/` (7 dedicated pages + index of all 48)
 - **llms-full.txt:** Available at the docs site root - contains all documentation in a single file for LLM consumption
 - **Dedicated pages exist for:** Claude Code, GitHub Copilot, Cursor, Antigravity, Factory AI, Gemini CLI, OpenCode
-- **All 37 formatters indexed at:** `docs/reference/formatters/index.md` with output paths, tier, and feature flags
+- **All 48 formatters indexed at:** `docs/reference/formatters/index.md` with output paths, tier, and feature flags
 
 ### Auto-Compilation Hooks
 
@@ -877,7 +920,6 @@ triggers compilation automatically when you edit `.prs` files:
 ```
 prs hooks install          # Auto-detect and install for all detected tools
 prs hooks install claude   # Install for a specific tool
-prs hooks install --all    # Install for all supported tools
 ```
 
 Hooks also protect generated files from direct edits — when an AI agent tries
@@ -904,7 +946,7 @@ The entry file uses `@use ./context`, `@use ./standards`, etc. to compose them.
 
 1. Missing @meta block - every .prs file needs `@meta` with `id` and `syntax`
 2. Multiple @inherit - only one per file; use `@use` for additional imports
-3. @extend without alias - requires prior `@use ... as alias`
+3. Extending an unknown path - target an inherited or local block, or use an imported alias
 4. Unquoted strings with special chars - quote strings containing `:`, `#`, `{`, `}`
 5. Forgetting to compile - `.prs` changes need `prs compile` to take effect
 6. Triple quotes inside triple quotes - not supported; describe content textually instead

--- a/.factory/skills/skill-creator/agents/comparator.md
+++ b/.factory/skills/skill-creator/agents/comparator.md
@@ -1,6 +1,6 @@
 # Blind Comparator Agent
 
-<!-- PromptScript 2026-05-30T23:22:42.937Z | source: .promptscript/project.prs | target: factory - do not edit -->
+<!-- PromptScript 2026-07-23T16:03:24.540Z | source: .promptscript/project.prs | target: factory - do not edit -->
 
 Compare two outputs WITHOUT knowing which skill produced them.
 
@@ -41,18 +41,20 @@ You receive these parameters in your prompt:
 Based on the task, generate a rubric with two dimensions:
 
 **Content Rubric** (what the output contains):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
-|-----------|----------|----------------|---------------|
-| Correctness | Major errors | Minor errors | Fully correct |
-| Completeness | Missing key elements | Mostly complete | All elements present |
-| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+| Criterion    | 1 (Poor)                 | 3 (Acceptable)     | 5 (Excellent)        |
+| ------------ | ------------------------ | ------------------ | -------------------- |
+| Correctness  | Major errors             | Minor errors       | Fully correct        |
+| Completeness | Missing key elements     | Mostly complete    | All elements present |
+| Accuracy     | Significant inaccuracies | Minor inaccuracies | Accurate throughout  |
 
 **Structure Rubric** (how the output is organized):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
-|-----------|----------|----------------|---------------|
-| Organization | Disorganized | Reasonably organized | Clear, logical structure |
-| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
-| Usability | Difficult to use | Usable with effort | Easy to use |
+
+| Criterion    | 1 (Poor)            | 3 (Acceptable)       | 5 (Excellent)            |
+| ------------ | ------------------- | -------------------- | ------------------------ |
+| Organization | Disorganized        | Reasonably organized | Clear, logical structure |
+| Formatting   | Inconsistent/broken | Mostly consistent    | Professional, polished   |
+| Usability    | Difficult to use    | Usable with effort   | Easy to use              |
 
 Adapt criteria to the specific task. For example:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Instructions
 
-<!-- PromptScript 2026-05-30T23:22:42.939Z | source: .promptscript/project.prs | target: github - do not edit -->
+<!-- PromptScript 2026-07-23T16:03:31.154Z | source: .promptscript/project.prs | target: github - do not edit -->
 
 ## project
 
@@ -90,6 +90,8 @@ The project is organized as a monorepo with these packages:
 - Framework: Vitest
 - Target >90% coverage for libraries
 - Use fixtures for parser tests
+- When refactoring formatter section methods (e.g. splitting context() into project() + techStack() + architecture()), add a test verifying that ALL input block content still appears in the output — not just the newly extracted subsections
+- Golden files are snapshots of correct behavior, not correct by definition — before regenerating golden files, verify the diff represents an intentional change, not a regression that golden files would lock in
 
 ### syntax-highlighting
 
@@ -179,6 +181,7 @@ After completing ANY code changes, run ALL steps in order:
 - Don't consider work complete until all CI checks pass (use `gh pr checks --watch`)
 - Don't commit directly to main - always use feature branches
 - Don't edit CHANGELOG.md manually - it is managed by release-please. Manual edits break release state tracking, preventing tag creation and GitHub releases.
+- Don't regenerate golden files without reviewing the diff — golden files lock in whatever behavior produced them, including regressions
 
 ## diagrams
 

--- a/.github/skills/promptscript/SKILL.md
+++ b/.github/skills/promptscript/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# promptscript-generated: 2026-05-30T23:22:42.939Z | source: .promptscript/project.prs | target: github
+# promptscript-generated: 2026-07-23T16:03:24.544Z | source: .promptscript/project.prs | target: github
 name: promptscript
 description: >-
   PromptScript language expert for reading, writing, modifying, and
@@ -8,9 +8,9 @@ description: >-
   @restrictions, @shortcuts, @skills, or @agents, configuring
   promptscript.yaml, resolving compilation errors, understanding inheritance
   (@inherit) and composition (@use, @extend), or migrating AI instructions
-  to PromptScript. Also use when asked about compilation targets (GitHub
-  Copilot, Claude Code, Cursor, Antigravity, Factory AI, and 30+ other
-  AI coding agents).
+  to PromptScript. Also use when asked about the 48 built-in compilation
+  targets, including GitHub Copilot, Claude Code, Cursor, Antigravity,
+  Factory AI, and AGENTS.md-based platforms.
 license: MIT
 metadata:
   author: PromptScript
@@ -526,9 +526,17 @@ prs skills list
 prs skills update
 ```
 
-### @extend (modify imported blocks)
+### @extend (modify existing or imported blocks)
 
-Requires an aliased @use:
+Use a direct path for inherited or local blocks:
+
+```
+@extend standards.testing {
+  coverage: 95
+}
+```
+
+Use an alias when targeting a specific imported block:
 
 ```
 @use @core/typescript as ts
@@ -537,6 +545,26 @@ Requires an aliased @use:
   testing: { coverage: 95 }
 }
 ```
+
+#### Replacing regular block fields
+
+Syntax `1.3.0` supports explicit replacement of complete regular block field values:
+
+```
+@meta { id: "project" syntax: "1.3.0" }
+
+@inherit ./company-base
+
+@extend standards {
+  testing!: ["Use Vitest"]
+  linting: ["Use ESLint"]
+}
+```
+
+`testing!` replaces the inherited value. Fields without `!` keep normal merge behavior.
+Replacement works after `@inherit` and `@use`, including aliases and nested target paths.
+A missing field is set. The modifier is rejected for `@skills`, which retain their dedicated
+merge and sealing semantics.
 
 #### Skill-aware @extend semantics
 
@@ -723,7 +751,7 @@ targets:
     version: frontmatter
   factory:
     version: full
-  windsurf:             # 31 additional agents supported
+  windsurf:             # 41 additional targets supported
     version: simple
   cline:
     version: simple
@@ -795,21 +823,28 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | Version | What it adds                                                                                                            |
 | ------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `1.0.0` | Core blocks (identity, context, standards, restrictions, knowledge, shortcuts, commands, guards, params, skills, local) |
-| `1.1.0` | Adds `@agents` (plus internal `@workflows`, `@prompts` - not user-facing)                                               |
+| `1.1.0` | Adds `@agents` and `@workflows`; reserves internal `@prompts`                                                           |
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
+| `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
+| `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
 
 ### Block Version Requirements
 
-| Block       | Minimum Syntax Version |
-| ----------- | ---------------------- |
-| `@agents`   | `1.1.0`                |
-| `@examples` | `1.2.0`                |
+| Block         | Minimum Syntax Version |
+| ------------- | ---------------------- |
+| `@agents`     | `1.1.0`                |
+| `@workflows`  | `1.1.0`                |
+| `@examples`   | `1.2.0`                |
+| `@hooks`      | `1.4.0`                |
+| `@mcpServers` | `1.4.0`                |
+| `@plugins`    | `1.4.0`                |
 
 All other built-in blocks are available from `1.0.0`.
+Regular block field replacement with `field!: value` requires syntax `1.3.0`.
 
 ### Validation Rules
 
-- **PS018 (`syntax-version-compat`)**: warns when blocks used in a file require a higher syntax version than declared. For example, `@agents` with `syntax: "1.0.0"` triggers PS018. Suggestion: run `prs validate --fix`.
+- **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
@@ -826,7 +861,7 @@ prs validate --fix          # Auto-fix syntax versions in .prs files
 prs upgrade                 # Upgrade all .prs files to the latest version
 ```
 
-`--fix` rewrites the `syntax: "..."` line in each file's `@meta` block to match the minimum version required by the blocks used. It only upgrades, never downgrades.
+`--fix` rewrites the `syntax: "..."` line in each file's `@meta` block to match the minimum version required by resolved blocks and syntax features. It follows inheritance, imports, and skill composition. It only upgrades, never downgrades.
 
 `prs upgrade` upgrades all files to the latest known syntax version regardless of what blocks they use.
 
@@ -834,10 +869,13 @@ prs upgrade                 # Upgrade all .prs files to the latest version
 
 ```
 prs init                    # Initialize project (auto-detects existing files)
+prs init --yes --targets claude factory
+prs init --dry-run          # Preview initialization
 prs init --auto-import      # Initialize + static import of existing files
 prs migrate                 # Interactive migration flow
 prs migrate --static        # Non-interactive static import
 prs migrate --llm           # Generate AI-assisted migration prompt
+prs migrate --static --dry-run
 prs compile                 # Compile to all targets
 prs compile --watch         # Watch mode
 prs compile --ignore-hashes # Skip integrity hash verification
@@ -847,7 +885,7 @@ prs validate --fix          # Auto-fix syntax version declarations
 prs validate --skip-policies # Skip policy engine evaluation
 prs upgrade                 # Upgrade all .prs files to latest syntax version
 prs import CLAUDE.md        # Import existing AI instructions
-prs import --dry-run        # Preview import conversion
+prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
 prs hooks install           # Install auto-compilation hooks for AI tools
@@ -871,34 +909,39 @@ prs registry list           # Show configured registries and aliases
 prs registry add <alias> <url>  # Add a registry alias
 ```
 
+`prs init --yes` requires explicit, detected, or user-configured targets. It does not invent
+default tools. For existing projects, `prs migrate` preserves `promptscript.yaml`, isolates static
+output under `.promptscript/migrated/`, leaves source instructions untouched, and performs no
+writes when no candidates are detected.
+
 ## Output Targets
 
-38+ supported targets. Key examples:
+48 supported targets. Key examples:
 
 | Target      | Main File                       | Skills                                             |
 | ----------- | ------------------------------- | -------------------------------------------------- |
 | GitHub      | .github/copilot-instructions.md | .github/skills/\*/SKILL.md                         |
 | Claude      | CLAUDE.md                       | .claude/skills/\*/SKILL.md                         |
-| Cursor      | .cursor/rules/project.mdc       | .cursor/commands/\*.md                             |
-| Antigravity | .agent/rules/project.md         | .agent/rules/\*.md                                 |
+| Cursor      | .cursor/rules/project.mdc       | .agents/skills/\*/SKILL.md                         |
+| Antigravity | .agent/rules/project.md         | -------------------------------------------------- |
 | Factory     | AGENTS.md                       | .factory/skills/\*/SKILL.md, .factory/droids/\*.md |
 | OpenCode    | OPENCODE.md                     | .opencode/skills/\*/SKILL.md                       |
-| Gemini      | GEMINI.md                       | .gemini/skills/\*/skill.md                         |
+| Gemini      | GEMINI.md                       | .agents/skills/\*/skill.md                         |
 | Windsurf    | .windsurf/rules/project.md      | .windsurf/skills/\*/SKILL.md                       |
-| Cline       | .clinerules                     | .agents/skills/\*/SKILL.md                         |
-| Roo Code    | .roorules                       | .roo/skills/\*/SKILL.md                            |
+| Cline       | .clinerules                     | -------------------------------------------------- |
+| Roo Code    | .roorules                       | -------------------------------------------------- |
 | Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
-| Continue    | .continue/rules/project.md      | .continue/skills/\*/SKILL.md                       |
-| + 26 more   |                                 | See full list in documentation                     |
+| Continue    | .continue/rules/project.md      | -------------------------------------------------- |
+| + 36 more   |                                 | See full list in documentation                     |
 
 ### Formatter Documentation
 
 For detailed information about each formatter's output paths, supported features, quirks, and example outputs:
 
-- **Full formatter reference:** `docs/reference/formatters/` (7 dedicated pages + index of all 37)
+- **Full formatter reference:** `docs/reference/formatters/` (7 dedicated pages + index of all 48)
 - **llms-full.txt:** Available at the docs site root - contains all documentation in a single file for LLM consumption
 - **Dedicated pages exist for:** Claude Code, GitHub Copilot, Cursor, Antigravity, Factory AI, Gemini CLI, OpenCode
-- **All 37 formatters indexed at:** `docs/reference/formatters/index.md` with output paths, tier, and feature flags
+- **All 48 formatters indexed at:** `docs/reference/formatters/index.md` with output paths, tier, and feature flags
 
 ### Auto-Compilation Hooks
 
@@ -908,7 +951,6 @@ triggers compilation automatically when you edit `.prs` files:
 ```
 prs hooks install          # Auto-detect and install for all detected tools
 prs hooks install claude   # Install for a specific tool
-prs hooks install --all    # Install for all supported tools
 ```
 
 Hooks also protect generated files from direct edits — when an AI agent tries
@@ -935,7 +977,7 @@ The entry file uses `@use ./context`, `@use ./standards`, etc. to compose them.
 
 1. Missing @meta block - every .prs file needs `@meta` with `id` and `syntax`
 2. Multiple @inherit - only one per file; use `@use` for additional imports
-3. @extend without alias - requires prior `@use ... as alias`
+3. Extending an unknown path - target an inherited or local block, or use an imported alias
 4. Unquoted strings with special chars - quote strings containing `:`, `#`, `{`, `}`
 5. Forgetting to compile - `.prs` changes need `prs compile` to take effect
 6. Triple quotes inside triple quotes - not supported; describe content textually instead

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# promptscript-generated: 2026-05-30T23:22:42.939Z | source: .promptscript/project.prs | target: github
+# promptscript-generated: 2026-07-23T16:03:24.544Z | source: .promptscript/project.prs | target: github
 name: skill-creator
 description: "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy."
 ---
@@ -387,6 +387,7 @@ Present the eval set to the user for review using the HTML template:
 
 1. Read the template from `assets/eval_review.html`
 2. Replace the placeholders:
+
    - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
    - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
    - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
@@ -502,6 +503,7 @@ Repeating one more time the core loop here for emphasis:
 - Draft or edit the skill
 - Run claude-with-access-to-the-skill on test prompts
 - With the user, evaluate the outputs:
+
   - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
   - Run quantitative evals
 

--- a/.github/skills/skill-creator/agents/comparator.md
+++ b/.github/skills/skill-creator/agents/comparator.md
@@ -1,6 +1,6 @@
 # Blind Comparator Agent
 
-<!-- PromptScript 2026-05-30T23:22:42.939Z | source: .promptscript/project.prs | target: github - do not edit -->
+<!-- PromptScript 2026-07-23T16:03:24.545Z | source: .promptscript/project.prs | target: github - do not edit -->
 
 Compare two outputs WITHOUT knowing which skill produced them.
 
@@ -41,18 +41,20 @@ You receive these parameters in your prompt:
 Based on the task, generate a rubric with two dimensions:
 
 **Content Rubric** (what the output contains):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
-|-----------|----------|----------------|---------------|
-| Correctness | Major errors | Minor errors | Fully correct |
-| Completeness | Missing key elements | Mostly complete | All elements present |
-| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+| Criterion    | 1 (Poor)                 | 3 (Acceptable)     | 5 (Excellent)        |
+| ------------ | ------------------------ | ------------------ | -------------------- |
+| Correctness  | Major errors             | Minor errors       | Fully correct        |
+| Completeness | Missing key elements     | Mostly complete    | All elements present |
+| Accuracy     | Significant inaccuracies | Minor inaccuracies | Accurate throughout  |
 
 **Structure Rubric** (how the output is organized):
-| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
-|-----------|----------|----------------|---------------|
-| Organization | Disorganized | Reasonably organized | Clear, logical structure |
-| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
-| Usability | Difficult to use | Usable with effort | Easy to use |
+
+| Criterion    | 1 (Poor)            | 3 (Acceptable)       | 5 (Excellent)            |
+| ------------ | ------------------- | -------------------- | ------------------------ |
+| Organization | Disorganized        | Reasonably organized | Clear, logical structure |
+| Formatting   | Inconsistent/broken | Mostly consistent    | Professional, polished   |
+| Usability    | Difficult to use    | Usable with effort   | Easy to use              |
 
 Adapt criteria to the specific task. For example:
 

--- a/.promptscript/restrictions.prs
+++ b/.promptscript/restrictions.prs
@@ -16,4 +16,5 @@
   - "Never consider work complete until all CI checks pass (use `gh pr checks --watch`)"
   - "Never commit directly to main - always use feature branches"
   - "Never edit CHANGELOG.md manually - it is managed by release-please. Manual edits break release state tracking, preventing tag creation and GitHub releases."
+  - "Never regenerate golden files without reviewing the diff — golden files lock in whatever behavior produced them, including regressions"
 }

--- a/.promptscript/standards.prs
+++ b/.promptscript/standards.prs
@@ -31,7 +31,9 @@
     "Follow AAA (Arrange, Act, Assert) pattern",
     "Framework: Vitest",
     "Target >90% coverage for libraries",
-    "Use fixtures for parser tests"
+    "Use fixtures for parser tests",
+    "When refactoring formatter section methods (e.g. splitting context() into project() + techStack() + architecture()), add a test verifying that ALL input block content still appears in the output — not just the newly extracted subsections",
+    "Golden files are snapshots of correct behavior, not correct by definition — before regenerating golden files, verify the diff represents an intentional change, not a regression that golden files would lock in"
   ]
 
   git: {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-<!-- PromptScript 2026-05-30T23:22:42.936Z | source: .promptscript/project.prs | target: factory - do not edit -->
+<!-- PromptScript 2026-07-23T16:03:31.151Z | source: .promptscript/project.prs | target: factory - do not edit -->
 
 ## Project
 
@@ -46,6 +46,8 @@ flowchart TB
 
 ## Conventions & Patterns
 
+### Graph First
+
 - Use code-review-graph MCP tools BEFORE Grep/Glob/Read when exploring the codebase
 - Exploring code: use semantic_search_nodes or query_graph instead of Grep
 - Understanding impact: use get_impact_radius instead of manually tracing imports
@@ -53,6 +55,9 @@ flowchart TB
 - Finding relationships: use query_graph with callers_of/callees_of/imports_of/tests_for
 - Architecture questions: use get_architecture_overview + list_communities
 - Fall back to Grep/Glob/Read only when the graph does not cover what you need
+
+### TypeScript
+
 - Strict mode enabled
 - Never use `any` type - use `unknown` with type guards
 - Use `unknown` with type guards instead of any
@@ -60,21 +65,38 @@ flowchart TB
 - Use `type` for unions and intersections
 - Named exports only, no default exports
 - Explicit return types on public functions
+
+### Naming Conventions
+
 - Files: `kebab-case.ts`
 - Classes: `PascalCase`
 - Interfaces: `PascalCase`
 - Functions: `camelCase`
 - Variables: `camelCase`
 - Constants: `UPPER_SNAKE_CASE`
+
+### Error Handling
+
 - Use custom error classes extending `PSError`
 - Always include location information
 - Provide actionable error messages
+
+### Testing
+
 - Test files: `*.spec.ts` next to source
 - Follow AAA (Arrange, Act, Assert) pattern
 - Framework: Vitest
 - Target >90% coverage for libraries
 - Use fixtures for parser tests
+- When refactoring formatter section methods (e.g. splitting context() into project() + techStack() + architecture()), add a test verifying that ALL input block content still appears in the output — not just the newly extracted subsections
+- Golden files are snapshots of correct behavior, not correct by definition — before regenerating golden files, verify the diff represents an intentional change, not a regression that golden files would lock in
+
+### Syntax Highlighting
+
 - keepInSync: when adding or changing block keywords (e.g. @knowledge, @guards), always update ALL THREE syntax highlighters: (1) Pygments lexer: docs_extensions/promptscript_lexer.py, (2) VS Code TextMate grammar: apps/vscode/syntaxes/promptscript.tmLanguage.json, (3) Playground Monaco language: packages/playground/src/utils/prs-language.ts
+
+### Workflow
+
 - branchStrategy: gitflow
 - newTask: When starting a new task while on main branch: 1. Create feature branch: git checkout -b feat/<task-name> or fix/<task-name> 2. Make changes with atomic commits (Conventional Commits format) 3. Run full verification pipeline before pushing 4. Push branch: git push -u origin <branch-name> 5. Create PR: gh pr create --fill 6. Monitor CI: gh pr checks --watch 7. If checks fail, fix issues and push again 8. Wait for all checks to pass before considering work complete
 - prMonitoring: use `gh pr checks --watch` to monitor CI status; do not consider work done until all checks pass
@@ -192,3 +214,4 @@ that file scanning cannot.
 - Don't consider work complete until all CI checks pass (use `gh pr checks --watch`)
 - Don't commit directly to main - always use feature branches
 - Don't edit CHANGELOG.md manually - it is managed by release-please. Manual edits break release state tracking, preventing tag creation and GitHub releases.
+- Don't regenerate golden files without reviewing the diff — golden files lock in whatever behavior produced them, including regressions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-<!-- PromptScript 2026-05-30T23:22:42.934Z | source: .promptscript/project.prs | target: claude - do not edit -->
+<!-- PromptScript 2026-07-23T16:03:31.147Z | source: .promptscript/project.prs | target: claude - do not edit -->
 
 ## Project
 
@@ -74,6 +74,8 @@ flowchart TB
 - Framework: Vitest
 - Target >90% coverage for libraries
 - Use fixtures for parser tests
+- When refactoring formatter section methods (e.g. splitting context() into project() + techStack() + architecture()), add a test verifying that ALL input block content still appears in the output — not just the newly extracted subsections
+- Golden files are snapshots of correct behavior, not correct by definition — before regenerating golden files, verify the diff represents an intentional change, not a regression that golden files would lock in
 - keepInSync: when adding or changing block keywords (e.g. @knowledge, @guards), always update ALL THREE syntax highlighters: (1) Pygments lexer: docs_extensions/promptscript_lexer.py, (2) VS Code TextMate grammar: apps/vscode/syntaxes/promptscript.tmLanguage.json, (3) Playground Monaco language: packages/playground/src/utils/prs-language.ts
 - branchStrategy: gitflow
 - newTask: When starting a new task while on main branch: 1. Create feature branch: git checkout -b feat/<task-name> or fix/<task-name> 2. Make changes with atomic commits (Conventional Commits format) 3. Run full verification pipeline before pushing 4. Push branch: git push -u origin <branch-name> 5. Create PR: gh pr create --fill 6. Monitor CI: gh pr checks --watch 7. If checks fail, fix issues and push again 8. Wait for all checks to pass before considering work complete
@@ -192,3 +194,4 @@ that file scanning cannot.
 - Don't consider work complete until all CI checks pass (use `gh pr checks --watch`)
 - Don't commit directly to main - always use feature branches
 - Don't edit CHANGELOG.md manually - it is managed by release-please. Manual edits break release state tracking, preventing tag creation and GitHub releases.
+- Don't regenerate golden files without reviewing the diff — golden files lock in whatever behavior produced them, including regressions

--- a/docs/__snapshots__/docs/examples/minimal.md/my-project_L26/claude.md
+++ b/docs/__snapshots__/docs/examples/minimal.md/my-project_L26/claude.md
@@ -5,6 +5,10 @@
 You are a helpful coding assistant for this project.
 Focus on clean, readable code.
 
+## Context
+
+This is a TypeScript project using modern best practices.
+
 ## Code Style
 
 - Use functional programming style

--- a/docs/__snapshots__/docs/examples/minimal.md/my-project_L26/github.md
+++ b/docs/__snapshots__/docs/examples/minimal.md/my-project_L26/github.md
@@ -5,6 +5,10 @@
 You are a helpful coding assistant for this project.
 Focus on clean, readable code.
 
+## Context
+
+This is a TypeScript project using modern best practices.
+
 ## code-standards
 
 ### code

--- a/docs/__snapshots__/docs/examples/team-setup.md/@team/frontend_L35/claude.md
+++ b/docs/__snapshots__/docs/examples/team-setup.md/@team/frontend_L35/claude.md
@@ -5,6 +5,22 @@
 You are a frontend developer on the Frontend team.
 You build modern, accessible web applications.
 
+## Context
+
+### Tech Stack
+
+  - React 18 with TypeScript
+  - Vite for development and building
+  - TailwindCSS for styling
+  - React Query for server state
+  - Vitest + Testing Library for tests
+
+  ### Architecture
+
+  - Feature-based folder structure
+  - Shared component library (@company/ui)
+  - API client generation from OpenAPI specs
+
 ## Code Style
 
 - Use TypeScript for all code

--- a/docs/__snapshots__/docs/examples/team-setup.md/@team/frontend_L35/github.md
+++ b/docs/__snapshots__/docs/examples/team-setup.md/@team/frontend_L35/github.md
@@ -5,6 +5,22 @@
 You are a frontend developer on the Frontend team.
 You build modern, accessible web applications.
 
+## Context
+
+### Tech Stack
+
+- React 18 with TypeScript
+- Vite for development and building
+- TailwindCSS for styling
+- React Query for server state
+- Vitest + Testing Library for tests
+
+### Architecture
+
+- Feature-based folder structure
+- Shared component library (@company/ui)
+- API client generation from OpenAPI specs
+
 ## code-standards
 
 ### code

--- a/docs/__snapshots__/docs/guides/migration.md/my-project_L496/claude.md
+++ b/docs/__snapshots__/docs/guides/migration.md/my-project_L496/claude.md
@@ -3,3 +3,7 @@
 ## Project
 
 Content from GitHub Copilot instructions...
+
+## Context
+
+Content from Claude instructions...

--- a/docs/__snapshots__/docs/guides/migration.md/my-project_L496/github.md
+++ b/docs/__snapshots__/docs/guides/migration.md/my-project_L496/github.md
@@ -3,3 +3,7 @@
 ## project
 
 Content from GitHub Copilot instructions...
+
+## Context
+
+Content from Claude instructions...

--- a/packages/formatters/src/__tests__/__golden__/adal/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/adal/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/amp/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/amp/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/antigravity.md
+++ b/packages/formatters/src/__tests__/__golden__/antigravity.md
@@ -43,6 +43,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Standards
 
 ### TypeScript

--- a/packages/formatters/src/__tests__/__golden__/antigravity/frontmatter.md
+++ b/packages/formatters/src/__tests__/__golden__/antigravity/frontmatter.md
@@ -51,6 +51,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Standards
 
 ### TypeScript

--- a/packages/formatters/src/__tests__/__golden__/antigravity/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/antigravity/simple.md
@@ -43,6 +43,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Standards
 
 ### TypeScript

--- a/packages/formatters/src/__tests__/__golden__/augment/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/augment/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/claude.md
+++ b/packages/formatters/src/__tests__/__golden__/claude.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/claude/full.md
+++ b/packages/formatters/src/__tests__/__golden__/claude/full.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/claude/multifile.md
+++ b/packages/formatters/src/__tests__/__golden__/claude/multifile.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/claude/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/claude/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/cline/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/cline/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/codebuddy/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/codebuddy/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/codex/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/codex/simple.md
@@ -39,6 +39,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/command-code/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/command-code/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/continue/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/continue/simple.md
@@ -46,6 +46,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/cortex/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/cortex/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/crush/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/crush/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/factory/full.md
+++ b/packages/formatters/src/__tests__/__golden__/factory/full.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Conventions & Patterns
 
 ### TypeScript

--- a/packages/formatters/src/__tests__/__golden__/factory/multifile.md
+++ b/packages/formatters/src/__tests__/__golden__/factory/multifile.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Conventions & Patterns
 
 ### TypeScript

--- a/packages/formatters/src/__tests__/__golden__/factory/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/factory/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Conventions & Patterns
 
 ### TypeScript

--- a/packages/formatters/src/__tests__/__golden__/gemini/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/gemini/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/github.md
+++ b/packages/formatters/src/__tests__/__golden__/github.md
@@ -43,6 +43,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## code-standards
 
 ### typescript

--- a/packages/formatters/src/__tests__/__golden__/github/full.md
+++ b/packages/formatters/src/__tests__/__golden__/github/full.md
@@ -43,6 +43,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## code-standards
 
 ### typescript

--- a/packages/formatters/src/__tests__/__golden__/github/multifile.md
+++ b/packages/formatters/src/__tests__/__golden__/github/multifile.md
@@ -43,6 +43,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## code-standards
 
 ### typescript

--- a/packages/formatters/src/__tests__/__golden__/github/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/github/simple.md
@@ -43,6 +43,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## code-standards
 
 ### typescript

--- a/packages/formatters/src/__tests__/__golden__/goose/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/goose/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/iflow/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/iflow/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/junie/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/junie/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/kilo/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/kilo/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/kiro/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/kiro/simple.md
@@ -45,6 +45,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/kode/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/kode/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/mcpjam/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/mcpjam/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/mistral-vibe/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/mistral-vibe/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/mux/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/mux/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/neovate/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/neovate/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/openclaw/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/openclaw/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/opencode/full.md
+++ b/packages/formatters/src/__tests__/__golden__/opencode/full.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/opencode/multifile.md
+++ b/packages/formatters/src/__tests__/__golden__/opencode/multifile.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/opencode/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/opencode/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/openhands/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/openhands/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/pi/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/pi/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/pochi/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/pochi/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/qoder/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/qoder/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/qwen-code/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/qwen-code/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/roo/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/roo/simple.md
@@ -41,6 +41,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/trae/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/trae/simple.md
@@ -45,6 +45,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/windsurf/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/windsurf/simple.md
@@ -45,6 +45,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__golden__/zencoder/simple.md
+++ b/packages/formatters/src/__tests__/__golden__/zencoder/simple.md
@@ -46,6 +46,15 @@ flowchart TB
   formatters --> core
 ```
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - Strict mode enabled

--- a/packages/formatters/src/__tests__/__snapshots__/snapshot.spec.ts.snap
+++ b/packages/formatters/src/__tests__/__snapshots__/snapshot.spec.ts.snap
@@ -44,6 +44,15 @@ flowchart TB
   formatters --> core
 \`\`\`
 
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
+
 ## Code Style
 
 - strictMode
@@ -337,6 +346,15 @@ flowchart TB
   validator --> core
   formatters --> core
 \`\`\`
+
+## Context
+
+### Key Libraries
+
+- Parser: Chevrotain
+- CLI: Commander.js
+- Testing: Vitest
+- Linting: ESLint + Prettier
 
 ## code-standards
 

--- a/packages/formatters/src/__tests__/cross-formatter-coverage.spec.ts
+++ b/packages/formatters/src/__tests__/cross-formatter-coverage.spec.ts
@@ -291,12 +291,13 @@ describe('@context → Context section (text content with @identity)', () => {
     )
   );
 
-  // Claude, GitHub, Factory should render @context text as a Context section
+  // Claude, GitHub, Factory, Antigravity should render @context text as a Context section
   // (excluding the Architecture section which is rendered separately)
   for (const { name, fmt } of [
     { name: 'claude', fmt: claude },
     { name: 'github', fmt: github },
     { name: 'factory', fmt: factory },
+    { name: 'antigravity', fmt: antigravity },
   ]) {
     it(`${name}: renders context section with remaining text after Architecture extraction`, () => {
       const result = fmt.format(ast);
@@ -325,6 +326,7 @@ describe('@context → Context section skipped when no @identity', () => {
     { name: 'claude', fmt: claude },
     { name: 'github', fmt: github },
     { name: 'factory', fmt: factory },
+    { name: 'antigravity', fmt: antigravity },
   ]) {
     it(`${name}: does not render Context section when @identity is absent (project fallback handles it)`, () => {
       const result = fmt.format(ast);

--- a/packages/formatters/src/__tests__/cross-formatter-coverage.spec.ts
+++ b/packages/formatters/src/__tests__/cross-formatter-coverage.spec.ts
@@ -52,6 +52,13 @@ const arr = (elements: Value[]): Block['content'] => ({
   loc: loc(),
 });
 
+const mixed = (textValue: string, properties: Record<string, Value>): Block['content'] => ({
+  type: 'MixedContent',
+  text: { type: 'TextContent', value: textValue, loc: loc() },
+  properties,
+  loc: loc(),
+});
+
 // ============================================================
 // Formatter instances
 // ============================================================
@@ -157,7 +164,7 @@ describe('@context MixedContent — @identity takes precedence over @context tex
     block('identity', text('You are an expert developer.')),
     block('context', {
       type: 'MixedContent',
-      text: { type: 'TextContent', value: 'This should NOT appear as project.', loc: loc() },
+      text: { type: 'TextContent', value: 'Context text for the project.', loc: loc() },
       properties: { languages: ['Go'] },
       loc: loc(),
     } as Block['content'])
@@ -167,7 +174,16 @@ describe('@context MixedContent — @identity takes precedence over @context tex
     it(`${name}: uses @identity not @context text when both exist`, () => {
       const result = fmt.format(ast);
       expect(result.content).toContain('expert developer');
-      expect(result.content).not.toContain('should NOT appear');
+      // @identity text should be in the Project section, not @context text
+      const projectMatch = result.content.match(/## [Pp]roject\n\n([\s\S]*?)(?=\n## |$)/);
+      if (projectMatch) {
+        expect(projectMatch[1]).toContain('expert developer');
+        expect(projectMatch[1]).not.toContain('Context text for the project');
+      } else {
+        // Formatters without a "## Project" heading (e.g. cursor, antigravity)
+        // embed identity text directly — just verify it is present
+        expect(result.content).toContain('expert developer');
+      }
     });
   }
 });
@@ -257,6 +273,66 @@ describe('@context → Architecture section', () => {
     it(`${name}: extracts architecture from @context text`, () => {
       const result = fmt.format(ast);
       expect(result.content, `${name} missing architecture`).toContain('flowchart');
+    });
+  }
+});
+
+describe('@context → Context section (text content with @identity)', () => {
+  const ast = program(
+    block('identity', text('You are an expert developer.')),
+    block(
+      'context',
+      mixed(
+        '## Architecture\n\n```mermaid\nflowchart LR\n  A --> B\n```\n\n## Key Libraries\n\n- Parser: Chevrotain\n- Testing: Vitest',
+        {
+          languages: ['TypeScript'],
+        }
+      )
+    )
+  );
+
+  // Claude, GitHub, Factory should render @context text as a Context section
+  // (excluding the Architecture section which is rendered separately)
+  for (const { name, fmt } of [
+    { name: 'claude', fmt: claude },
+    { name: 'github', fmt: github },
+    { name: 'factory', fmt: factory },
+  ]) {
+    it(`${name}: renders context section with remaining text after Architecture extraction`, () => {
+      const result = fmt.format(ast);
+      expect(result.content, `${name} missing Context section`).toContain('Key Libraries');
+      expect(result.content, `${name} missing context item`).toContain('Chevrotain');
+      // Architecture should still be rendered separately
+      expect(result.content, `${name} missing Architecture`).toContain('flowchart');
+    });
+  }
+});
+
+describe('@context → Context section skipped when no @identity', () => {
+  const ast = program(
+    block(
+      'context',
+      mixed(
+        '## Architecture\n\n```mermaid\nflowchart LR\n  A --> B\n```\n\n## Notes\n\nExtra info.',
+        {
+          languages: ['Go'],
+        }
+      )
+    )
+  );
+
+  for (const { name, fmt } of [
+    { name: 'claude', fmt: claude },
+    { name: 'github', fmt: github },
+    { name: 'factory', fmt: factory },
+  ]) {
+    it(`${name}: does not render Context section when @identity is absent (project fallback handles it)`, () => {
+      const result = fmt.format(ast);
+      // Architecture should still be extracted
+      expect(result.content).toContain('flowchart');
+      // "Notes" section should NOT appear as a separate Context section
+      // (it may appear in the project fallback for some formatters)
+      expect(result.content).not.toMatch(/## Context\n\n## Notes/);
     });
   }
 });

--- a/packages/formatters/src/__tests__/markdown-instruction-formatter.spec.ts
+++ b/packages/formatters/src/__tests__/markdown-instruction-formatter.spec.ts
@@ -231,6 +231,113 @@ describe('MarkdownInstructionFormatter', () => {
       expect(result.content).toContain('Node.js 20');
     });
 
+    it('should render context section from @context text when @identity exists', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'identity',
+            content: {
+              type: 'TextContent',
+              value: 'You are an expert developer.',
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+          {
+            type: 'Block',
+            name: 'context',
+            content: {
+              type: 'MixedContent',
+              text: {
+                type: 'TextContent',
+                value:
+                  '## Architecture\n\n```mermaid\nflowchart LR\n  A --> B\n```\n\n## Key Libraries\n\n- Parser: Chevrotain\n- Testing: Vitest',
+                loc: createLoc(),
+              },
+              properties: { languages: ['TypeScript'] },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast);
+      // Context section should contain remaining text after Architecture extraction
+      expect(result.content).toContain('## Context');
+      expect(result.content).toContain('Key Libraries');
+      expect(result.content).toContain('Chevrotain');
+      // Architecture should still be rendered separately
+      expect(result.content).toContain('flowchart');
+      // ## headings in context text should be downgraded to ###
+      expect(result.content).toContain('### Key Libraries');
+    });
+
+    it('should not render context section when @identity is absent', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'context',
+            content: {
+              type: 'MixedContent',
+              text: {
+                type: 'TextContent',
+                value:
+                  '## Architecture\n\n```mermaid\nflowchart LR\n  A --> B\n```\n\n## Notes\n\nExtra info.',
+                loc: createLoc(),
+              },
+              properties: { languages: ['Go'] },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast);
+      // Architecture should still be extracted
+      expect(result.content).toContain('flowchart');
+      // Should not have a Context section heading (project fallback handles the text)
+      expect(result.content).not.toMatch(/## Context/);
+    });
+
+    it('should not render context section when @context has no text', () => {
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'identity',
+            content: {
+              type: 'TextContent',
+              value: 'You are an expert developer.',
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+          {
+            type: 'Block',
+            name: 'context',
+            content: {
+              type: 'ObjectContent',
+              properties: { languages: ['TypeScript'], runtime: 'Node.js 20' },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+
+      const result = formatter.format(ast);
+      // Should have tech stack but not a Context section
+      expect(result.content).toContain('Tech Stack');
+      expect(result.content).not.toMatch(/## Context/);
+    });
+
     it('should extract restrictions from ArrayContent', () => {
       const ast: Program = {
         ...createMinimalProgram(),

--- a/packages/formatters/src/formatters/antigravity.ts
+++ b/packages/formatters/src/formatters/antigravity.ts
@@ -160,6 +160,10 @@ export class AntigravityFormatter extends BaseFormatter {
     const architecture = this.architecture(ast, renderer);
     if (architecture) sections.push(architecture);
 
+    // Add context section (remaining @context text after Architecture extraction)
+    const contextSection = this.contextSection(ast, renderer);
+    if (contextSection) sections.push(contextSection);
+
     // Add code standards
     const codeStandards = this.codeStandards(ast, renderer);
     if (codeStandards) sections.push(codeStandards);
@@ -596,6 +600,28 @@ ${this.stripAllIndent(content)}`;
     }
 
     return null;
+  }
+
+  private contextSection(ast: Program, _renderer: ConventionRenderer): string | null {
+    const identity = this.findBlock(ast, 'identity');
+    if (!identity) return null; // identity() fallback handles @context text
+
+    const contextBlock = this.findBlock(ast, 'context');
+    if (!contextBlock) return null;
+
+    const text = this.extractText(contextBlock.content);
+    if (!text) return null;
+
+    // Remove the "## Architecture" section with code block (rendered by architecture())
+    const archMatch = this.extractSectionWithCodeBlock(text, '## Architecture');
+    const remainingText = archMatch ? text.replace(archMatch, '').trim() : text.trim();
+    if (!remainingText) return null;
+
+    // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
+    const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
+    return `## Context
+
+${this.stripAllIndent(downgradedText)}`;
   }
 
   /**

--- a/packages/formatters/src/formatters/claude.ts
+++ b/packages/formatters/src/formatters/claude.ts
@@ -1016,6 +1016,7 @@ export class ClaudeFormatter extends BaseFormatter {
     this.addSection(sections, this.project(ast, renderer));
     this.addSection(sections, this.techStack(ast, renderer));
     this.addSection(sections, this.architecture(ast, renderer));
+    this.addSection(sections, this.contextSection(ast, renderer));
     this.addSection(sections, this.codeStandards(ast, renderer));
     this.addSection(sections, this.gitCommits(ast, renderer));
     this.addSection(sections, this.configFiles(ast, renderer));
@@ -1139,6 +1140,27 @@ export class ClaudeFormatter extends BaseFormatter {
     // Normalize for Prettier compatibility (strip code block indentation, etc.)
     const normalizedContent = this.normalizeMarkdownForPrettier(content);
     return renderer.renderSection('Architecture', normalizedContent.trim()) + '\n';
+  }
+
+  private contextSection(ast: Program, renderer: ConventionRenderer): string | null {
+    const identity = this.findBlock(ast, 'identity');
+    if (!identity) return null; // project() fallback handles @context text
+
+    const contextBlock = this.findBlock(ast, 'context');
+    if (!contextBlock) return null;
+
+    const text = this.extractText(contextBlock.content);
+    if (!text) return null;
+
+    // Remove the "## Architecture" section with code block (rendered by architecture())
+    const archMatch = this.extractSectionWithCodeBlock(text, '## Architecture');
+    const remainingText = archMatch ? text.replace(archMatch, '').trim() : text.trim();
+    if (!remainingText) return null;
+
+    // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
+    const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
+    const normalizedContent = this.normalizeMarkdownForPrettier(downgradedText);
+    return renderer.renderSection('Context', normalizedContent.trim()) + '\n';
   }
 
   private codeStandards(ast: Program, renderer: ConventionRenderer): string | null {

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -710,6 +710,7 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
     this.addSection(sections, this.project(ast, renderer));
     this.addSection(sections, this.techStack(ast, renderer));
     this.addSection(sections, this.architecture(ast, renderer));
+    this.addSection(sections, this.context(ast, renderer));
     this.addSection(sections, this.commands(ast, renderer));
     this.addSection(sections, this.postWork(ast, renderer));
   }

--- a/packages/formatters/src/formatters/github.ts
+++ b/packages/formatters/src/formatters/github.ts
@@ -988,6 +988,9 @@ export class GitHubFormatter extends BaseFormatter {
     const architecture = this.architecture(ast, renderer);
     if (architecture) sections.push(architecture);
 
+    const contextSection = this.contextSection(ast, renderer);
+    if (contextSection) sections.push(contextSection);
+
     const codeStandards = this.codeStandards(ast, renderer);
     if (codeStandards) sections.push(codeStandards);
 
@@ -1134,6 +1137,26 @@ export class GitHubFormatter extends BaseFormatter {
     const content = archMatch.replace('## Architecture', '').trim();
     // Apply stripAllIndent to normalize content for Prettier compatibility
     return renderer.renderSection('architecture', this.stripAllIndent(content));
+  }
+
+  private contextSection(ast: Program, renderer: ConventionRenderer): string | null {
+    const identity = this.findBlock(ast, 'identity');
+    if (!identity) return null; // project() fallback handles @context text
+
+    const contextBlock = this.findBlock(ast, 'context');
+    if (!contextBlock) return null;
+
+    const text = this.extractText(contextBlock.content);
+    if (!text) return null;
+
+    // Remove the "## Architecture" section with code block (rendered by architecture())
+    const archMatch = this.extractSectionWithCodeBlock(text, '## Architecture');
+    const remainingText = archMatch ? text.replace(archMatch, '').trim() : text.trim();
+    if (!remainingText) return null;
+
+    // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
+    const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
+    return renderer.renderSection('Context', this.stripAllIndent(downgradedText));
   }
 
   private codeStandards(ast: Program, renderer: ConventionRenderer): string | null {

--- a/packages/formatters/src/markdown-instruction-formatter.ts
+++ b/packages/formatters/src/markdown-instruction-formatter.ts
@@ -642,6 +642,7 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     this.addSection(sections, this.project(ast, renderer));
     this.addSection(sections, this.techStack(ast, renderer));
     this.addSection(sections, this.architecture(ast, renderer));
+    this.addSection(sections, this.context(ast, renderer));
     this.addSection(sections, this.codeStandards(ast, renderer));
     this.addSection(sections, this.gitCommits(ast, renderer));
     this.addSection(sections, this.configFiles(ast, renderer));
@@ -764,6 +765,37 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     const content = archMatch.replace('## Architecture', '');
     const normalizedContent = this.normalizeMarkdownForPrettier(content);
     return renderer.renderSection('Architecture', normalizedContent.trim()) + '\n';
+  }
+
+  /**
+   * Render @context block text content as a "## Context" section.
+   *
+   * The "## Architecture" subsection (with code block) is stripped because
+   * it is already rendered separately by {@link architecture}. Remaining
+   * "## " headings are downgraded to "### " to avoid clashing with the
+   * formatter's own h2 section headings. When no @identity block exists,
+   * the project() fallback already consumes the full @context text, so
+   * this method returns null to avoid duplication.
+   */
+  protected context(ast: Program, renderer: ConventionRenderer): string | null {
+    const identity = this.findBlock(ast, 'identity');
+    if (!identity) return null; // project() fallback handles @context text
+
+    const contextBlock = this.findBlock(ast, 'context');
+    if (!contextBlock) return null;
+
+    const text = this.extractText(contextBlock.content);
+    if (!text) return null;
+
+    // Remove the "## Architecture" section with code block (rendered by architecture())
+    const archMatch = this.extractSectionWithCodeBlock(text, '## Architecture');
+    const remainingText = archMatch ? text.replace(archMatch, '').trim() : text.trim();
+    if (!remainingText) return null;
+
+    // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
+    const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
+    const normalizedContent = this.normalizeMarkdownForPrettier(downgradedText);
+    return renderer.renderSection('Context', normalizedContent.trim()) + '\n';
   }
 
   protected codeStandards(ast: Program, renderer: ConventionRenderer): string | null {


### PR DESCRIPTION
## Fix

`@context` block text content was not rendered in AGENTS.md and other formatter outputs. This was a regression from the base class extraction (commit `1fbb71af6f`) which dropped the `context()` method.

### Changes

- Add `context()` method to `MarkdownInstructionFormatter` base class
- Wire into `addCommonSections` (affects all MIF-based formatters: Factory, Codex, Gemini, etc.)
- Add `contextSection()` to `ClaudeFormatter` and `GitHubFormatter` (override `addCommonSections` with private methods)
- Update `FactoryFormatter.addLeanSections` for split-rules mode

### Behavior

- `@context` text is rendered as a `## Context` section when `@identity` exists
- When no `@identity` exists, `project()` fallback handles `@context` text (no duplication)
- `## Architecture` subsection with code block is stripped (already rendered by `architecture()`)
- Remaining `## ` headings in `@context` text are downgraded to `### `` to prevent h2 collisions with formatter section headings

### Testing

- Updated 46 golden files, 2 snapshots, 6 docs example snapshots
- Updated cross-formatter-coverage test to verify `@identity` precedence
- Added dedicated tests for context section rendering and no-identity fallback

Closes #317