### PR TITLE
fix(resolver): disable interactive git credential prompts

### DIFF
--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -385,6 +385,18 @@ describe('GitRegistry', () => {
         expect.stringContaining('StrictHostKeyChecking=no')
       );
     });
+
+    it('should disable interactive credential prompts to prevent hangs', async () => {
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await registry.fetch('@company/base');
+
+      expect(mockGit.env).toHaveBeenCalledWith('GIT_TERMINAL_PROMPT', '0');
+      expect(mockGit.env).toHaveBeenCalledWith('GCM_INTERACTIVE', 'never');
+    });
   });
 
   describe('error handling', () => {

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -716,6 +716,13 @@ export class GitRegistry implements Registry {
 
     const git = simpleGit(options);
 
+    // Prevent interactive credential prompts from hanging indefinitely.
+    // Without these, git may invoke a GUI credential helper (e.g., GCM on
+    // Windows) or wait on stdin, blocking the process forever in a
+    // non-interactive CLI context. See issue #320.
+    git.env('GIT_TERMINAL_PROMPT', '0');
+    git.env('GCM_INTERACTIVE', 'never');
+
     if (this.auth?.type === 'token') {
       const token = this.resolveToken();
       if (token) {
@@ -1015,13 +1022,15 @@ export async function validateRemoteAccess(
   repoUrl: string,
   ref?: string
 ): Promise<RemoteValidation> {
-  const git = simpleGit();
+  const git = simpleGit().env('GIT_TERMINAL_PROMPT', '0').env('GCM_INTERACTIVE', 'never');
   try {
     const isCommit = ref !== undefined && /^[0-9a-f]{40}$/i.test(ref);
     if (isCommit) {
       const probeDir = await fs.mkdtemp(join(tmpdir(), 'promptscript-ref-'));
       try {
-        const probe = simpleGit(probeDir);
+        const probe = simpleGit(probeDir)
+          .env('GIT_TERMINAL_PROMPT', '0')
+          .env('GCM_INTERACTIVE', 'never');
         await probe.init();
         await probe.addRemote('origin', repoUrl);
         await probe.fetch(['origin', ref, '--depth=1']);


### PR DESCRIPTION
## Summary

`prs compile` hangs indefinitely on some machines (notably Windows) when a git clone encounters an auth challenge. The spinner keeps spinning, no output, process never completes.

## Root Cause

`GitRegistry.createGit()` and `validateRemoteAccess()` did not set `GIT_TERMINAL_PROMPT=0`. When git clone hits an auth challenge (GitHub rate limit, SSL cert issue, private repo), git invokes an interactive credential helper:

- **Windows**: Git Credential Manager (GCM) opens a GUI dialog, blocking the child process
- **Linux**: git waits on stdin that never arrives

The simple-git 60s `timeout.block` does not reliably kill the credential helper subprocess, so the hang persists indefinitely.

## Fix

Set `GIT_TERMINAL_PROMPT=0` and `GCM_INTERACTIVE=never` on all simple-git instances so git fails fast with an error instead of prompting in a non-interactive CLI context.

## Changed Files

- `packages/resolver/src/git-registry.ts` — set env vars in `createGit()` and `validateRemoteAccess()`
- `packages/resolver/src/__tests__/git-registry.spec.ts` — test verifying env vars are set

Fixes #320