### PR TITLE
feat(formatters): add portable hook working directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,8 @@ jobs:
             validate-types: {
               event: "post-tool-use"
               matcher: "Edit|Write"
-              command: ["pnpm", "run", "typecheck"]
+              command: ["python3", ".promptscript/scripts/validate.py"]
+              cwd: "project"
             }
           }
 
@@ -292,8 +293,8 @@ jobs:
           test ! -x .factory/skills/security-review/scripts/report.sh
           grep -q "issue-tracker" .factory/mcp.json
           grep -q "engineering" .factory/plugins.json
-          node -e "const h=require('./.factory/hooks.json');if(!h.hooks.PostToolUse)process.exit(1)"
-          node -e "const h=require('./.github/hooks/promptscript.json');const x=h.hooks.postToolUse?.[0];if(h.version!==1||!x?.bash||!x?.powershell)process.exit(1)"
+          node -e 'const h=require("./.factory/hooks.json");const x=h.hooks.PostToolUse?.[0]?.hooks?.[0];if(!x?.command?.startsWith("cd \"$FACTORY_PROJECT_DIR\" && python3"))process.exit(1)'
+          node -e "const h=require('./.github/hooks/promptscript.json');const x=h.hooks.postToolUse?.[0];if(h.version!==1||!x?.bash||!x?.powershell||x.cwd!=='.')process.exit(1)"
 
           chmod -x .factory/skills/security-review/scripts/check.sh
           chmod +x .factory/skills/security-review/scripts/report.sh

--- a/docs/__snapshots__/docs/reference/language.md/env-vars-example_L1945/claude.md
+++ b/docs/__snapshots__/docs/reference/language.md/env-vars-example_L1945/claude.md
@@ -1,6 +1,0 @@
-# CLAUDE.md
-
-## Project
-
-Running in ${NODE_ENV:-development} mode.
-API Key: ${API_KEY}

--- a/docs/__snapshots__/docs/reference/language.md/env-vars-example_L1945/cursor.mdc
+++ b/docs/__snapshots__/docs/reference/language.md/env-vars-example_L1945/cursor.mdc
@@ -1,7 +1,0 @@
----
-description: "Project-specific rules"
-alwaysApply: true
----
-
-Running in ${NODE_ENV:-development} mode.
-API Key: ${API_KEY}

--- a/docs/__snapshots__/docs/reference/language.md/env-vars-example_L1945/github.md
+++ b/docs/__snapshots__/docs/reference/language.md/env-vars-example_L1945/github.md
@@ -1,6 +1,0 @@
-# GitHub Copilot Instructions
-
-## project
-
-Running in ${NODE_ENV:-development} mode.
-API Key: ${API_KEY}

--- a/docs/__snapshots__/docs/reference/language.md/project_L1705/claude.md
+++ b/docs/__snapshots__/docs/reference/language.md/project_L1705/claude.md
@@ -1,1 +1,0 @@
-# CLAUDE.md

--- a/docs/__snapshots__/docs/reference/language.md/project_L1705/cursor.mdc
+++ b/docs/__snapshots__/docs/reference/language.md/project_L1705/cursor.mdc
@@ -1,6 +1,0 @@
----
-description: "Project-specific rules"
-alwaysApply: true
----
-
-You are working on the project.

--- a/docs/__snapshots__/docs/reference/language.md/project_L1705/github.md
+++ b/docs/__snapshots__/docs/reference/language.md/project_L1705/github.md
@@ -1,1 +1,0 @@
-# GitHub Copilot Instructions

--- a/docs/__snapshots__/docs/reference/language.md/template-example_L1624/claude.md
+++ b/docs/__snapshots__/docs/reference/language.md/template-example_L1624/claude.md
@@ -1,5 +1,0 @@
-# CLAUDE.md
-
-## Project
-
-You are working on {{projectName}}.

--- a/docs/__snapshots__/docs/reference/language.md/template-example_L1624/cursor.mdc
+++ b/docs/__snapshots__/docs/reference/language.md/template-example_L1624/cursor.mdc
@@ -1,6 +1,0 @@
----
-description: "Project-specific rules"
-alwaysApply: true
----
-
-You are working on {{projectName}}.

--- a/docs/__snapshots__/docs/reference/language.md/template-example_L1624/github.md
+++ b/docs/__snapshots__/docs/reference/language.md/template-example_L1624/github.md
@@ -1,5 +1,0 @@
-# GitHub Copilot Instructions
-
-## project
-
-You are working on {{projectName}}.

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -57,9 +57,10 @@ target set.
 | Codex          | `.codex/config.toml`              | Codex-native events and milliseconds |
 
 Hook files require `multifile` or `full` mode. `simple` mode reports `PS4002`
-because it cannot emit additional files. Target adapters also report `PS4002`
-when an event, matcher, `statusMessage`, or `continueOnFailure` value has no
-native equivalent.
+because it cannot emit additional files. Cursor emits hook files only in
+`full` mode; its other modes report `PS4002` and omit hooks. Target adapters
+also report `PS4002` when an event, matcher, `statusMessage`, or
+`continueOnFailure` value has no native equivalent.
 
 Factory and GitHub generated commands include a trailing
 `# promptscript-generated:<hook-id>` shell comment. PromptScript uses this
@@ -97,6 +98,21 @@ directories, and review inherited hooks as executable policy.
 Payload `cwd` describes where an event occurred. It does not configure the
 working directory of the hook command. `GITHUB_WORKSPACE` belongs to GitHub
 Actions and is not a portable GitHub Copilot hook variable.
+
+### Shell and Failure Behavior
+
+The `cd` wrapper emitted for Claude Code and Factory Droid targets a POSIX
+shell. Claude Code and Factory Droid hook payloads assume a POSIX environment.
+For Windows coverage, prefer the GitHub Copilot target: its native `cwd` field
+and separate `bash` and `powershell` payloads are cross-shell.
+
+`CLAUDE_PROJECT_DIR` and `FACTORY_PROJECT_DIR` are set by the respective tool
+when it runs the hook. If the variable is unset, the wrapper normally fails
+with a non-zero exit and the hook reports an error. On some shells, such as
+macOS `/bin/sh`, `cd ""` is a no-op instead: the command then runs in the
+session working directory, where a same-named script could execute in the
+wrong location. Rely on the tool setting the variable, and treat a missing
+variable as a hook error rather than a fallback to another directory.
 
 Contract references:
 

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -22,7 +22,8 @@ The `@hooks` block requires syntax `1.4.0`:
   validate-types: {
     event: "post-tool-use"
     matcher: "Edit|Write"
-    command: ["pnpm", "run", "typecheck"]
+    command: ["python3", ".promptscript/scripts/validate.py", "--strict"]
+    cwd: "project"
     timeoutMs: 120000
     statusMessage: "Checking TypeScript"
     continueOnFailure: false
@@ -68,13 +69,62 @@ user hook files remain untouched.
 Hook commands are arrays in PromptScript source:
 
 ```promptscript
-command: ["node", "./tools/validate-output.mjs", "--strict"]
+command: ["python3", ".promptscript/scripts/validate.py", "--strict"]
+cwd: "project"
 ```
 
-Shell interpolation is rejected in source. Factory shell-quotes command
-arguments, while GitHub emits separate `bash` and `powershell` commands.
-Commit hook programs to the repository and review inherited hooks as
-executable policy.
+`cwd: "project"` makes the project-root requirement explicit. A value such as
+`cwd: "tools/hooks"` resolves from project root. The location of the generated
+hook configuration does not determine command working directory.
+
+Shell interpolation is rejected in source. Target adapters preserve source
+argument boundaries when a platform requires one command string. Factory
+shell-quotes command arguments, while GitHub emits separate `bash` and
+`powershell` commands. Commit shared hook programs under
+`.promptscript/scripts/`, rather than duplicating them under target
+directories, and review inherited hooks as executable policy.
+
+### Project-Root Strategy by Target
+
+| Target         | Native project root              | Native `cwd` entry | Payload `cwd`  | PromptScript behavior                           |
+| -------------- | -------------------------------- | ------------------ | -------------- | ----------------------------------------------- |
+| Claude Code    | `CLAUDE_PROJECT_DIR` placeholder | No                 | Yes            | Emits a safely quoted `cd` wrapper              |
+| Factory Droid  | `FACTORY_PROJECT_DIR`            | No                 | Event-specific | Emits a safely quoted `cd` wrapper              |
+| GitHub Copilot | Repository root                  | Yes                | Yes            | Emits `cwd: "."` or the requested relative path |
+| Cursor         | No stable portable primitive     | No                 | Event-specific | Emits `PS4002` and uses the session directory   |
+| Codex          | No project-root variable         | No                 | Session `cwd`  | Emits `PS4002` and uses the session directory   |
+
+Payload `cwd` describes where an event occurred. It does not configure the
+working directory of the hook command. `GITHUB_WORKSPACE` belongs to GitHub
+Actions and is not a portable GitHub Copilot hook variable.
+
+Contract references:
+
+- [Claude Code hooks](https://code.claude.com/docs/en/hooks)
+- [Factory Droid hooks](https://docs.factory.ai/reference/hooks-reference)
+- [GitHub Copilot hooks](https://docs.github.com/en/copilot/reference/hooks-reference)
+- [Cursor hooks](https://cursor.com/docs/hooks)
+- [Codex hooks](https://developers.openai.com/codex/hooks)
+
+For example, the portable hook above generates this Factory command:
+
+```json
+{
+  "type": "command",
+  "command": "cd \"$FACTORY_PROJECT_DIR\" && python3 .promptscript/scripts/validate.py --strict # promptscript-generated:validate-types"
+}
+```
+
+The GitHub repository hook uses its native working-directory field:
+
+```json
+{
+  "type": "command",
+  "bash": "python3 .promptscript/scripts/validate.py --strict # promptscript-generated:validate-types",
+  "powershell": "& 'python3' '.promptscript/scripts/validate.py' '--strict' # promptscript-generated:validate-types",
+  "cwd": "."
+}
+```
 
 ## Workflows
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -26,6 +26,11 @@ Notes for compiled `@hooks` output:
 - **Cleanup** - removing `@hooks` deletes the obsolete generated hook file once every command in
   it carries the PromptScript ownership marker, and prunes managed directories left empty (such as
   `.github/hooks/`).
+- **Working directory** - for repository-local lifecycle commands, set `cwd: "project"` in the
+  language-level hook and keep shared scripts under `.promptscript/scripts/`. Generated hook file
+  location does not set command working directory. See
+  [Hooks and Workflows](../features/automation.md#project-root-strategy-by-target) for target
+  behavior and generated Factory and GitHub examples.
 
 There are two complementary behaviours:
 

--- a/docs/reference/formatters/cursor.md
+++ b/docs/reference/formatters/cursor.md
@@ -82,6 +82,7 @@ description: PromptScript output format for Cursor
 - `@shortcuts` with multi-line content become command files
 - The `.cursorrules` file (`legacy` mode) is deprecated; `.cursor/rules/*.mdc` is preferred
 - `full` mode adds commands, `.agents/skills/<name>/SKILL.md`, and `.cursor/agents/<name>.md`
+- `@hooks` emits `.cursor/hooks.json` only in `full` mode; other modes report `PS4002` and omit hooks
 - Supports `@file` and `@folder` context references in rules
 - Nested directory rules are supported
 

--- a/docs/reference/formatters/factory.md
+++ b/docs/reference/formatters/factory.md
@@ -149,4 +149,4 @@ project-root/
 ## Official Documentation
 
 - [Factory AI Documentation](https://docs.factory.ai/)
-- [Factory Hooks Reference](https://docs.factory.ai/harness/hooks)
+- [Factory Hooks Reference](https://docs.factory.ai/reference/hooks-reference)

--- a/docs/reference/formatters/index.md
+++ b/docs/reference/formatters/index.md
@@ -232,7 +232,8 @@ PromptScript emits `@mcpServers`, `@hooks`, and `@plugins` blocks (syntax 1.4.0+
 | Crush          | `.crush/mcp.json`                | -                                 | -                       |
 
 Hook files require `multifile` or `full` mode. In `simple` mode, formatters
-preserve single-file output and report a compatibility warning.
+preserve single-file output and report a compatibility warning. Cursor emits
+hook files only in `full` mode and reports `PS4002` in its other modes.
 
 Agent-level `mcpServers` references are emitted by Claude Code, Cursor, and Factory Droid.
 

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -1217,6 +1217,7 @@ target's native event system and configuration format.
     event: "pre-tool-use"
     matcher: "Edit|Write"
     command: ["prs", "hook", "pre-edit"]
+    cwd: "project"
     timeoutMs: 5000
     statusMessage: "Checking generated files"
     continueOnFailure: false
@@ -1239,20 +1240,26 @@ Portable events:
 
 Each hook entry is an object with:
 
-| Field               | Required | Type     | Description                                 |
-| ------------------- | -------- | -------- | ------------------------------------------- |
-| `event`             | Yes      | string   | Portable event name (see above)             |
-| `command`           | Yes      | string[] | Non-empty source argument array             |
-| `matcher`           | No       | string   | Target-native tool name matcher pattern     |
-| `timeoutMs`         | No       | number   | Timeout in ms (100-600000)                  |
-| `statusMessage`     | No       | string   | Status message shown during execution       |
-| `continueOnFailure` | No       | boolean  | Whether to continue if hook fails           |
-| `enabled`           | No       | boolean  | Whether the hook is enabled (default: true) |
+| Field               | Required | Type     | Description                                                  |
+| ------------------- | -------- | -------- | ------------------------------------------------------------ |
+| `event`             | Yes      | string   | Portable event name (see above)                              |
+| `command`           | Yes      | string[] | Non-empty source argument array                              |
+| `cwd`               | No       | string   | `"project"` or a forward-slash path relative to project root |
+| `matcher`           | No       | string   | Target-native tool name matcher pattern                      |
+| `timeoutMs`         | No       | number   | Timeout in ms (100-600000)                                   |
+| `statusMessage`     | No       | string   | Status message shown during execution                        |
+| `continueOnFailure` | No       | boolean  | Whether to continue if hook fails                            |
+| `enabled`           | No       | boolean  | Whether the hook is enabled (default: true)                  |
 
 Shell interpolation (`$()`, backticks, `${...}`) is forbidden in command arguments, and `command`
 must contain at least one argument - PS034 rejects empty arrays and hooks without an executable
-command are omitted from target output. Target adapters may serialize the array as one native
-command string, so verify argument quoting in generated hook configuration.
+command are omitted from target output. Target adapters preserve argument boundaries when they
+serialize the array as a native command string.
+
+`cwd: "project"` requests execution from the resolved PromptScript project root. Other `cwd` values
+must be portable relative paths and resolve from that root. Absolute paths, backslashes, empty path
+segments, `.` segments, and `..` traversal are rejected. Hook configuration location does not set
+the command working directory.
 
 `matcher` filters by tool name using the target's own vocabulary: Factory matches names like
 `Execute` or `Read`, GitHub Copilot matches its own tool names (and only on `preToolUse`,

--- a/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
+++ b/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Compiler } from '../compiler.js';
@@ -29,6 +30,7 @@ describe('Hook target smoke tests', () => {
     event: "pre-tool-use"
     matcher: "Edit|Write"
     command: ["python3", ".promptscript/scripts/validate.py"]
+    cwd: "project"
     timeoutMs: 30000
   }
 }
@@ -55,7 +57,7 @@ describe('Hook target smoke tests', () => {
               {
                 type: 'command',
                 command:
-                  'python3 .promptscript/scripts/validate.py # promptscript-generated:validate',
+                  'cd "$FACTORY_PROJECT_DIR" && python3 .promptscript/scripts/validate.py # promptscript-generated:validate',
                 timeout: 30,
               },
             ],
@@ -72,11 +74,111 @@ describe('Hook target smoke tests', () => {
             bash: 'python3 .promptscript/scripts/validate.py # promptscript-generated:validate',
             powershell:
               "& 'python3' '.promptscript/scripts/validate.py' # promptscript-generated:validate",
+            cwd: '.',
             matcher: 'Edit|Write',
             timeoutSec: 30,
           },
         ],
       },
     });
+  });
+
+  it('runs a repository-local script from project root when invoked from a nested directory', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript hook project '));
+    directories.push(directory);
+    const scriptDirectory = join(directory, '.promptscript', 'scripts');
+    const nestedDirectory = join(directory, 'packages', 'app');
+    mkdirSync(scriptDirectory, { recursive: true });
+    mkdirSync(nestedDirectory, { recursive: true });
+    const scriptPath = join(scriptDirectory, 'record-cwd.sh');
+    writeFileSync(scriptPath, '#!/bin/sh\npwd > .promptscript/hook-cwd.txt\n');
+    chmodSync(scriptPath, 0o755);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "hook-root-smoke"
+  syntax: "1.4.0"
+}
+
+@hooks {
+  record-cwd: {
+    event: "session-start"
+    command: ["sh", ".promptscript/scripts/record-cwd.sh"]
+    cwd: "project"
+  }
+}
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [{ name: 'factory', config: { version: 'full' } }],
+    });
+    const result = await compiler.compile(entryPath);
+    const hookFile = JSON.parse(result.outputs.get('.factory/hooks.json')!.content) as {
+      hooks: { SessionStart: Array<{ hooks: Array<{ command: string }> }> };
+    };
+
+    execFileSync('/bin/sh', ['-c', hookFile.hooks.SessionStart[0]!.hooks[0]!.command], {
+      cwd: nestedDirectory,
+      env: { ...process.env, FACTORY_PROJECT_DIR: directory },
+    });
+
+    expect(readFileSync(join(directory, '.promptscript', 'hook-cwd.txt'), 'utf-8').trim()).toBe(
+      directory
+    );
+  });
+
+  it('reports targets that cannot guarantee project-root execution', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-hooks-cwd-warnings-'));
+    directories.push(directory);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "hook-cwd-warnings"
+  syntax: "1.4.0"
+}
+
+@hooks {
+  validate: {
+    event: "post-tool-use"
+    command: ["python3", ".promptscript/scripts/check file.py", "--label=hello world"]
+    cwd: "project"
+  }
+}
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [
+        { name: 'claude', config: { version: 'full' } },
+        { name: 'cursor', config: { version: 'full' } },
+        { name: 'codex', config: { version: 'full' } },
+      ],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings.map((warning) => warning.message)).toEqual([
+      'Hook "validate" requests cwd "project", which cursor cannot guarantee and will ignore.',
+      'Hook "validate" requests cwd "project", which codex cannot guarantee and will ignore.',
+    ]);
+    const claude = JSON.parse(result.outputs.get('.claude/settings.json')!.content) as {
+      hooks: { PostToolUse: Array<{ hooks: Array<{ command: string }> }> };
+    };
+    expect(claude.hooks.PostToolUse[0]!.hooks[0]!.command).toBe(
+      "cd \"${CLAUDE_PROJECT_DIR}\" && python3 '.promptscript/scripts/check file.py' '--label=hello world'"
+    );
+    const cursor = JSON.parse(result.outputs.get('.cursor/hooks.json')!.content) as {
+      postEdit: Array<{ command: string }>;
+    };
+    expect(cursor.postEdit[0]!.command).toBe(
+      "python3 '.promptscript/scripts/check file.py' '--label=hello world'"
+    );
+    expect(result.outputs.get('.codex/config.toml')!.content).toContain(
+      'command = ["python3", ".promptscript/scripts/check file.py", "--label=hello world"]'
+    );
   });
 });

--- a/packages/formatters/src/__tests__/codex.spec.ts
+++ b/packages/formatters/src/__tests__/codex.spec.ts
@@ -680,6 +680,7 @@ describe('CodexFormatter', () => {
                 'my-hook': {
                   event: 'pre-tool-use',
                   command: ['echo', 'hello'],
+                  cwd: 'project',
                 },
               },
               loc: createLoc(),
@@ -697,6 +698,16 @@ describe('CodexFormatter', () => {
       );
       expect(configFile).toBeDefined();
       expect(configFile!.content).toContain('pre_tool_use');
+      expect(result.warnings).toEqual([
+        {
+          code: 'PS4002',
+          message:
+            'Hook "my-hook" requests cwd "project", which codex cannot guarantee and will ignore.',
+          suggestion:
+            'Review the generated codex hook because it will use the agent session working directory.',
+          location: createLoc(),
+        },
+      ]);
     });
 
     it('should skip agents with invalid names', () => {

--- a/packages/formatters/src/__tests__/cursor.spec.ts
+++ b/packages/formatters/src/__tests__/cursor.spec.ts
@@ -1425,6 +1425,75 @@ describe('CursorFormatter', () => {
       ]);
     });
 
+    it.each([undefined, 'modern', 'multifile', 'legacy', 'agents-md'])(
+      'should report PS4002 and omit hooks when @hooks block present in %s mode',
+      (version) => {
+        const ast: Program = {
+          type: 'Program',
+          uses: [],
+          extends: [],
+          loc: createLoc(),
+          blocks: [
+            {
+              type: 'Block',
+              name: 'hooks',
+              content: {
+                type: 'ObjectContent',
+                properties: {
+                  'my-hook': {
+                    event: 'pre-tool-use',
+                    command: ['echo', 'hello'],
+                  },
+                },
+                loc: createLoc(),
+              },
+              loc: createLoc(),
+            },
+          ],
+        };
+        const result = formatter.format(ast, version ? { version } : undefined);
+        const hooksFile = result.additionalFiles?.find((f) => f.path === '.cursor/hooks.json');
+        expect(hooksFile).toBeUndefined();
+        expect(result.warnings).toEqual([
+          {
+            code: 'PS4002',
+            message: `Cursor ${version ?? 'modern'} mode cannot emit @hooks and will omit them.`,
+            suggestion: "Use Cursor version 'full'.",
+            location: createLoc(),
+          },
+        ]);
+      }
+    );
+
+    it('should not warn when all hooks are disabled in non-full mode', () => {
+      const ast: Program = {
+        type: 'Program',
+        uses: [],
+        extends: [],
+        loc: createLoc(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'hooks',
+            content: {
+              type: 'ObjectContent',
+              properties: {
+                'my-hook': {
+                  event: 'pre-tool-use',
+                  command: ['echo', 'hello'],
+                  enabled: false,
+                },
+              },
+              loc: createLoc(),
+            },
+            loc: createLoc(),
+          },
+        ],
+      };
+      const result = formatter.format(ast);
+      expect(result.warnings).toBeUndefined();
+    });
+
     it('should emit mcp.json when @mcpServers block present', () => {
       const ast: Program = {
         type: 'Program',

--- a/packages/formatters/src/__tests__/cursor.spec.ts
+++ b/packages/formatters/src/__tests__/cursor.spec.ts
@@ -1399,6 +1399,7 @@ describe('CursorFormatter', () => {
                 'my-hook': {
                   event: 'pre-tool-use',
                   command: ['echo', 'hello'],
+                  cwd: 'project',
                 },
               },
               loc: createLoc(),
@@ -1412,6 +1413,16 @@ describe('CursorFormatter', () => {
       expect(hooksFile).toBeDefined();
       const parsed = JSON.parse(hooksFile!.content) as Record<string, unknown>;
       expect(parsed).toHaveProperty('preEdit');
+      expect(result.warnings).toEqual([
+        {
+          code: 'PS4002',
+          message:
+            'Hook "my-hook" requests cwd "project", which cursor cannot guarantee and will ignore.',
+          suggestion:
+            'Review the generated cursor hook because it will use the agent session working directory.',
+          location: createLoc(),
+        },
+      ]);
     });
 
     it('should emit mcp.json when @mcpServers block present', () => {

--- a/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/INDEX.md
+++ b/packages/formatters/src/__tests__/fixtures/platform-contracts/factory/INDEX.md
@@ -1,14 +1,14 @@
 # Factory AI Contracts
 
 Source: https://docs.factory.ai/cli/configuration/agents-md,
-https://docs.factory.ai/harness/hooks
+https://docs.factory.ai/reference/hooks-reference
 
 ## Fixture index
 
 | File          | Source URL                                          | Version     | Retrieved  | Expected path                       | Scope           |
 | ------------- | --------------------------------------------------- | ----------- | ---------- | ----------------------------------- | --------------- |
 | agents-md.md  | https://docs.factory.ai/cli/configuration/agents-md | Factory CLI | 2026-07-17 | `AGENTS.md` (repo root, nested)     | formatter-scope |
-| hooks.json    | https://docs.factory.ai/harness/hooks               | Factory CLI | 2026-07-30 | `.factory/hooks.json`               | formatter-scope |
+| hooks.json    | https://docs.factory.ai/reference/hooks-reference   | Factory CLI | 2026-07-30 | `.factory/hooks.json`               | formatter-scope |
 | user-level.md | https://docs.factory.ai/cli/configuration/agents-md | Factory CLI | 2026-07-17 | `~/.factory/AGENTS.md` (user-level) | out-of-scope    |
 
 ## Scope notes

--- a/packages/formatters/src/__tests__/hook-adapters.spec.ts
+++ b/packages/formatters/src/__tests__/hook-adapters.spec.ts
@@ -34,6 +34,7 @@ describe('hook-adapters', () => {
           event: 'pre-tool-use',
           matcher: 'Edit|Write',
           command: ['prs', 'hook', 'pre-edit'],
+          cwd: 'project',
           timeoutMs: 5000,
           statusMessage: 'Checking generated files',
           continueOnFailure: false,
@@ -46,6 +47,7 @@ describe('hook-adapters', () => {
       expect(hooks[0]!.event).toBe('pre-tool-use');
       expect(hooks[0]!.matcher).toBe('Edit|Write');
       expect(hooks[0]!.command).toEqual(['prs', 'hook', 'pre-edit']);
+      expect(hooks[0]!.cwd).toBe('project');
       expect(hooks[0]!.timeoutMs).toBe(5000);
       expect(hooks[0]!.statusMessage).toBe('Checking generated files');
       expect(hooks[0]!.continueOnFailure).toBe(false);
@@ -181,12 +183,12 @@ describe('hook-adapters', () => {
       expect(Object.keys(result)).toHaveLength(0);
     });
 
-    it('should join command arguments with spaces', () => {
+    it('should preserve command argument boundaries', () => {
       const hooks = extractHooks(
         makeHooksBlock({
           test: {
             event: 'pre-tool-use',
-            command: ['prs', 'hook', 'pre-edit'],
+            command: ['python3', 'scripts/check file.py', '--label=hello world'],
           },
         })
       );
@@ -195,7 +197,26 @@ describe('hook-adapters', () => {
       expect(preToolUse).toBeDefined();
       const entry = preToolUse![0] as Record<string, unknown>;
       const hookArr = entry['hooks'] as Record<string, unknown>[];
-      expect(hookArr[0]!['command']).toBe('prs hook pre-edit');
+      expect(hookArr[0]!['command']).toBe("python3 'scripts/check file.py' '--label=hello world'");
+    });
+
+    it('should execute project-relative hooks from the Claude project root', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          test: {
+            event: 'pre-tool-use',
+            command: ['python3', '.promptscript/scripts/check.py'],
+            cwd: 'tools/hook scripts',
+          },
+        })
+      );
+      const result = generateClaudeHooks(hooks);
+      const entry = (result['PreToolUse'] as Record<string, unknown>[])[0]!;
+      const hook = (entry['hooks'] as Record<string, unknown>[])[0]!;
+
+      expect(hook['command']).toBe(
+        'cd "${CLAUDE_PROJECT_DIR}"/\'tools/hook scripts\' && python3 .promptscript/scripts/check.py'
+      );
     });
   });
 
@@ -233,6 +254,21 @@ describe('hook-adapters', () => {
       expect(toml.trim()).toBe('');
     });
 
+    it('should preserve command argument boundaries for Codex', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          check: {
+            event: 'post-tool-use',
+            command: ['python3', 'scripts/check file.py', '--label=hello world'],
+          },
+        })
+      );
+
+      expect(generateCodexHooks(hooks)).toContain(
+        'command = ["python3", "scripts/check file.py", "--label=hello world"]'
+      );
+    });
+
     it('should include statusMessage in Claude hooks', () => {
       const hooks = extractHooks(
         makeHooksBlock({
@@ -259,7 +295,7 @@ describe('hook-adapters', () => {
           active: {
             event: 'pre-tool-use',
             matcher: 'Edit|Write',
-            command: ['prs', 'hook', 'pre-edit'],
+            command: ['python3', 'scripts/check file.py', '--label=hello world'],
             timeoutMs: 5000,
             statusMessage: 'Checking files',
             continueOnFailure: true,
@@ -276,7 +312,7 @@ describe('hook-adapters', () => {
         preEdit: [
           {
             matcher: 'Edit|Write',
-            command: 'prs hook pre-edit',
+            command: "python3 'scripts/check file.py' '--label=hello world'",
             timeout: 5,
             statusMessage: 'Checking files',
             continueOnFailure: true,
@@ -345,6 +381,33 @@ describe('hook-adapters', () => {
         ],
       });
     });
+
+    it('should execute Factory hooks from a project-relative working directory', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          rooted: {
+            event: 'pre-tool-use',
+            command: ['python3', '.promptscript/scripts/check.py'],
+            cwd: 'tools/hook scripts',
+          },
+        })
+      );
+
+      expect(generateFactoryHooks(hooks)).toEqual({
+        PreToolUse: [
+          {
+            matcher: '.*',
+            hooks: [
+              {
+                type: 'command',
+                command:
+                  'cd "$FACTORY_PROJECT_DIR"/\'tools/hook scripts\' && python3 .promptscript/scripts/check.py # promptscript-generated:rooted',
+              },
+            ],
+          },
+        ],
+      });
+    });
   });
 
   describe('generateGitHubHooks', () => {
@@ -355,6 +418,7 @@ describe('hook-adapters', () => {
             event: 'pre-tool-use',
             matcher: 'edit|create',
             command: ['prs', 'hook', 'pre-edit'],
+            cwd: 'project',
             timeoutMs: 5000,
           },
           stopped: {
@@ -376,6 +440,7 @@ describe('hook-adapters', () => {
             type: 'command',
             bash: 'prs hook pre-edit # promptscript-generated:active',
             powershell: "& 'prs' 'hook' 'pre-edit' # promptscript-generated:active",
+            cwd: '.',
             matcher: 'edit|create',
             timeoutSec: 5,
           },
@@ -407,6 +472,30 @@ describe('hook-adapters', () => {
             bash: "python3 'scripts/check file.py' 'it'\"'\"'s safe; echo' --% @name # promptscript-generated:quoted",
             powershell:
               "& 'python3' 'scripts/check file.py' 'it''s safe; echo' '--%' '@name' # promptscript-generated:quoted",
+          },
+        ],
+      });
+    });
+
+    it('should emit a project-relative GitHub working directory', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          rooted: {
+            event: 'pre-tool-use',
+            command: ['python3', '.promptscript/scripts/check.py'],
+            cwd: 'tools/hook scripts',
+          },
+        })
+      );
+
+      expect(generateGitHubHooks(hooks)).toEqual({
+        preToolUse: [
+          {
+            type: 'command',
+            bash: 'python3 .promptscript/scripts/check.py # promptscript-generated:rooted',
+            powershell:
+              "& 'python3' '.promptscript/scripts/check.py' # promptscript-generated:rooted",
+            cwd: 'tools/hook scripts',
           },
         ],
       });
@@ -468,5 +557,30 @@ describe('hook-adapters', () => {
         },
       ]);
     });
+
+    it.each(['cursor', 'codex'] as const)(
+      'warns when %s cannot guarantee a requested working directory',
+      (target) => {
+        const hooks = extractHooks(
+          makeHooksBlock({
+            rooted: {
+              event: 'post-tool-use',
+              command: ['python3', '.promptscript/scripts/check.py'],
+              cwd: 'project',
+              statusMessage: 'Checking',
+              continueOnFailure: true,
+            },
+          })
+        );
+
+        expect(getHookCompatibilityWarnings(hooks, target)).toEqual([
+          {
+            code: 'PS4002',
+            message: `Hook "rooted" requests cwd "project", which ${target} cannot guarantee and will ignore.`,
+            suggestion: `Review the generated ${target} hook because it will use the agent session working directory.`,
+          },
+        ]);
+      }
+    );
   });
 });

--- a/packages/formatters/src/formatters/codex.ts
+++ b/packages/formatters/src/formatters/codex.ts
@@ -4,7 +4,11 @@ import {
   type MarkdownAgentConfig,
 } from '../markdown-instruction-formatter.js';
 import type { FormatOptions, FormatterOutput, FormatterVersionMap } from '../types.js';
-import { extractHooks, generateCodexHooks } from '../hook-adapters.js';
+import {
+  extractHooks,
+  generateCodexHooks,
+  getHookCompatibilityWarnings,
+} from '../hook-adapters.js';
 import {
   findMcpServersBlock,
   extractMcpServers,
@@ -331,7 +335,14 @@ export class CodexFormatter extends MarkdownInstructionFormatter {
     // Emit .codex/config.toml when project config options or hooks are set
     const targetConfig = options?.targetConfig;
     const hooksBlock = ast.blocks.find((b) => b.name === 'hooks');
-    const hooksToml = hooksBlock ? generateCodexHooks(extractHooks(hooksBlock)) : '';
+    const hooks = hooksBlock ? extractHooks(hooksBlock) : [];
+    const hooksToml = generateCodexHooks(hooks);
+    const hookWarnings = hooksBlock
+      ? getHookCompatibilityWarnings(hooks, 'codex').map((warning) => ({
+          ...warning,
+          location: hooksBlock.loc,
+        }))
+      : [];
 
     if (
       (targetConfig &&
@@ -412,11 +423,19 @@ export class CodexFormatter extends MarkdownInstructionFormatter {
       );
       return {
         ...result,
+        ...(hookWarnings.length > 0
+          ? { warnings: [...(result.warnings ?? []), ...hookWarnings] }
+          : {}),
         additionalFiles: [...additionalFiles, ...extraFiles],
         managedOutputDirectories: [...(result.managedOutputDirectories ?? []), ...managedDirs],
       };
     }
 
-    return result;
+    return {
+      ...result,
+      ...(hookWarnings.length > 0
+        ? { warnings: [...(result.warnings ?? []), ...hookWarnings] }
+        : {}),
+    };
   }
 }

--- a/packages/formatters/src/formatters/cursor.ts
+++ b/packages/formatters/src/formatters/cursor.ts
@@ -160,23 +160,40 @@ export class CursorFormatter extends BaseFormatter {
 
     const version = this.resolveVersion(options?.version);
 
+    let output: FormatterOutput;
     if (version === 'legacy') {
-      return this.formatLegacy(ast, options);
+      output = this.formatLegacy(ast, options);
+    } else if (version === 'multifile') {
+      output = this.formatMultifile(ast, options);
+    } else if (version === 'agents-md') {
+      output = this.formatAgentsMd(ast, options);
+    } else if (version === 'full') {
+      // Full mode emits hooks and reports per-hook compatibility warnings.
+      output = this.formatFull(ast, options);
+    } else {
+      output = this.formatModern(ast, options);
     }
 
-    if (version === 'multifile') {
-      return this.formatMultifile(ast, options);
+    if (version !== 'full') {
+      const hooksBlock = this.findBlock(ast, 'hooks');
+      const hooks = hooksBlock ? extractHooks(hooksBlock) : [];
+      if (hooksBlock && hooks.some((hook) => hook.enabled !== false)) {
+        return {
+          ...output,
+          warnings: [
+            ...(output.warnings ?? []),
+            {
+              code: 'PS4002',
+              message: `Cursor ${version} mode cannot emit @hooks and will omit them.`,
+              suggestion: "Use Cursor version 'full'.",
+              location: hooksBlock.loc,
+            },
+          ],
+        };
+      }
     }
 
-    if (version === 'agents-md') {
-      return this.formatAgentsMd(ast, options);
-    }
-
-    if (version === 'full') {
-      return this.formatFull(ast, options);
-    }
-
-    return this.formatModern(ast, options);
+    return output;
   }
 
   /**

--- a/packages/formatters/src/formatters/cursor.ts
+++ b/packages/formatters/src/formatters/cursor.ts
@@ -2,7 +2,11 @@ import type { Block, Program, Value } from '@promptscript/core';
 import { BaseFormatter } from '../base-formatter.js';
 import { GlobCategorizer } from '../extractors/glob-categorizer.js';
 import type { FormatOptions, FormatterOutput } from '../types.js';
-import { extractHooks, generateCursorHooks } from '../hook-adapters.js';
+import {
+  extractHooks,
+  generateCursorHooks,
+  getHookCompatibilityWarnings,
+} from '../hook-adapters.js';
 import {
   findMcpServersBlock,
   extractMcpServers,
@@ -453,9 +457,14 @@ export class CursorFormatter extends BaseFormatter {
 
     // Generate hooks (.cursor/hooks.json) from @hooks block
     const hooksBlock = this.findBlock(ast, 'hooks');
+    let hookWarnings: FormatterOutput['warnings'];
     if (hooksBlock) {
       const hooks = extractHooks(hooksBlock);
       if (hooks.length > 0) {
+        hookWarnings = getHookCompatibilityWarnings(hooks, 'cursor').map((warning) => ({
+          ...warning,
+          location: hooksBlock.loc,
+        }));
         const cursorHooks = generateCursorHooks(hooks);
         if (Object.keys(cursorHooks).length > 0) {
           additionalFiles.push({
@@ -493,6 +502,9 @@ export class CursorFormatter extends BaseFormatter {
     return {
       ...result,
       additionalFiles: additionalFiles.length > 0 ? additionalFiles : undefined,
+      ...(hookWarnings && hookWarnings.length > 0
+        ? { warnings: [...(result.warnings ?? []), ...hookWarnings] }
+        : {}),
     };
   }
 

--- a/packages/formatters/src/hook-adapters.ts
+++ b/packages/formatters/src/hook-adapters.ts
@@ -26,6 +26,8 @@ export interface HookDefinition {
   matcher?: string;
   /** Command arguments (non-empty array). */
   command: string[];
+  /** Project-root or project-relative working directory. */
+  cwd?: string;
   /** Timeout in milliseconds. */
   timeoutMs?: number;
   /** Status message shown during execution. */
@@ -47,6 +49,10 @@ function quotePowerShellArgument(argument: string): string {
   return `'${argument.replace(/'/g, "''")}'`;
 }
 
+function serializePosixCommand(hook: HookDefinition, prefix = ''): string {
+  return `${prefix}${hook.command.map(quotePosixArgument).join(' ')}`;
+}
+
 function serializeOwnedCommand(
   hook: HookDefinition,
   quoteArgument: (argument: string) => string = quotePosixArgument,
@@ -54,6 +60,14 @@ function serializeOwnedCommand(
 ): string {
   const safeId = hook.id.replace(/[^A-Za-z0-9._-]/g, '-');
   return `${prefix}${hook.command.map(quoteArgument).join(' ')} ${HOOK_OWNERSHIP_MARKER}:${safeId}`;
+}
+
+function projectCwdPrefix(hook: HookDefinition, target: 'claude' | 'factory'): string {
+  if (!hook.cwd) return '';
+
+  const root = target === 'claude' ? '"${CLAUDE_PROJECT_DIR}"' : '"$FACTORY_PROJECT_DIR"';
+  const directory = hook.cwd === 'project' ? root : `${root}/${quotePosixArgument(hook.cwd)}`;
+  return `cd ${directory} && `;
 }
 
 /**
@@ -90,6 +104,9 @@ export function extractHooks(hooksBlock: {
 
     const matcher = obj['matcher'];
     if (typeof matcher === 'string') hook.matcher = matcher;
+
+    const cwd = obj['cwd'];
+    if (typeof cwd === 'string') hook.cwd = cwd;
 
     const timeoutMs = obj['timeoutMs'];
     if (typeof timeoutMs === 'number') hook.timeoutMs = timeoutMs;
@@ -219,7 +236,7 @@ export function generateClaudeHooks(hooks: HookDefinition[]): Record<string, unk
       hooks: [
         {
           type: 'command',
-          command: hook.command.join(' '),
+          command: serializePosixCommand(hook, projectCwdPrefix(hook, 'claude')),
           timeout: hook.timeoutMs ? convertTimeout(hook.timeoutMs, 'claude') : 10,
         },
       ],
@@ -252,7 +269,7 @@ export function generateCursorHooks(hooks: HookDefinition[]): Record<string, unk
 
     result[nativeEvent].push({
       matcher: hook.matcher ?? '.*',
-      command: hook.command.join(' '),
+      command: serializePosixCommand(hook),
       timeout: hook.timeoutMs ? convertTimeout(hook.timeoutMs, 'cursor') : 10,
       ...(hook.statusMessage ? { statusMessage: hook.statusMessage } : {}),
       ...(hook.continueOnFailure !== undefined
@@ -283,7 +300,11 @@ export function generateFactoryHooks(hooks: HookDefinition[]): Record<string, un
       hooks: [
         {
           type: 'command',
-          command: serializeOwnedCommand(hook),
+          command: serializeOwnedCommand(
+            hook,
+            quotePosixArgument,
+            projectCwdPrefix(hook, 'factory')
+          ),
           ...(hook.timeoutMs ? { timeout: convertTimeout(hook.timeoutMs, 'factory') } : {}),
         },
       ],
@@ -302,7 +323,7 @@ const GITHUB_MATCHER_EVENTS = new Set([
 
 export function getHookCompatibilityWarnings(
   hooks: HookDefinition[],
-  target: 'factory' | 'github'
+  target: 'claude' | 'cursor' | 'codex' | 'factory' | 'github'
 ): FormatterWarning[] {
   const warnings: FormatterWarning[] = [];
 
@@ -334,14 +355,22 @@ export function getHookCompatibilityWarnings(
       });
     }
 
-    if (hook.statusMessage) {
+    if (hook.cwd && (target === 'cursor' || target === 'codex')) {
+      warnings.push({
+        code: 'PS4002',
+        message: `Hook "${hook.id}" requests cwd "${hook.cwd}", which ${target} cannot guarantee and will ignore.`,
+        suggestion: `Review the generated ${target} hook because it will use the agent session working directory.`,
+      });
+    }
+
+    if (hook.statusMessage && (target === 'factory' || target === 'github')) {
       warnings.push({
         code: 'PS4002',
         message: `Hook "${hook.id}" uses statusMessage, which ${target} cannot represent and will omit.`,
       });
     }
 
-    if (hook.continueOnFailure !== undefined) {
+    if (hook.continueOnFailure !== undefined && (target === 'factory' || target === 'github')) {
       warnings.push({
         code: 'PS4002',
         message: `Hook "${hook.id}" uses continueOnFailure, which ${target} cannot represent and will omit.`,
@@ -369,6 +398,7 @@ export function generateGitHubHooks(hooks: HookDefinition[]): Record<string, unk
       type: 'command',
       bash: serializeOwnedCommand(hook),
       powershell: serializeOwnedCommand(hook, quotePowerShellArgument, '& '),
+      ...(hook.cwd ? { cwd: hook.cwd === 'project' ? '.' : hook.cwd } : {}),
       ...(hook.matcher && GITHUB_MATCHER_EVENTS.has(hook.event) ? { matcher: hook.matcher } : {}),
       ...(hook.timeoutMs ? { timeoutSec: convertTimeout(hook.timeoutMs, 'github') } : {}),
     });

--- a/packages/playground/src/components/ExampleGallery.tsx
+++ b/packages/playground/src/components/ExampleGallery.tsx
@@ -1114,7 +1114,8 @@ export const EXAMPLES: Example[] = [
   validate-changes: {
     event: "post-tool-use"
     matcher: "Edit|Write"
-    command: ["pnpm", "run", "typecheck"]
+    command: ["python3", ".promptscript/scripts/validate.py"]
+    cwd: "project"
     timeoutMs: 120000
     statusMessage: "Checking TypeScript"
   }

--- a/packages/playground/src/components/__tests__/ExampleGallery.spec.tsx
+++ b/packages/playground/src/components/__tests__/ExampleGallery.spec.tsx
@@ -46,13 +46,23 @@ describe('ExampleGallery — gallery examples compile', () => {
 
     expect(result.success).toBe(true);
     expect(JSON.parse(result.outputs.get('.factory/hooks.json')!.content)).toMatchObject({
-      hooks: { PostToolUse: expect.any(Array) },
+      hooks: {
+        PostToolUse: [
+          {
+            hooks: [
+              {
+                command: expect.stringContaining('cd "$FACTORY_PROJECT_DIR" && python3'),
+              },
+            ],
+          },
+        ],
+      },
     });
     expect(
       JSON.parse(result.outputs.get('.github/hooks/promptscript.json')!.content)
     ).toMatchObject({
       version: 1,
-      hooks: { postToolUse: expect.any(Array) },
+      hooks: { postToolUse: [{ cwd: '.' }] },
     });
   });
 });

--- a/packages/validator/src/__tests__/rules/valid-hooks.spec.ts
+++ b/packages/validator/src/__tests__/rules/valid-hooks.spec.ts
@@ -55,6 +55,7 @@ describe('PS034: valid-hooks', () => {
           event: 'pre-tool-use',
           matcher: 'Edit|Write',
           command: ['prs', 'hook', 'pre-edit'],
+          cwd: 'project',
           timeoutMs: 5000,
           statusMessage: 'Checking generated files',
           continueOnFailure: false,
@@ -63,6 +64,59 @@ describe('PS034: valid-hooks', () => {
       })
     );
     expect(messages).toHaveLength(0);
+  });
+
+  it('should accept a project-relative working directory', () => {
+    const messages = validate(
+      makeAst({
+        check: {
+          event: 'post-tool-use',
+          command: ['python3', 'check.py'],
+          cwd: 'tools/hook scripts',
+        },
+      })
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['.', 'dot'],
+    ['../outside', 'parent traversal'],
+    ['tools/../outside', 'nested parent traversal'],
+    ['/tmp/hooks', 'absolute POSIX'],
+    ['C:\\hooks', 'absolute Windows'],
+    ['C:/hooks', 'forward-slash Windows absolute'],
+    ['tools\\hooks', 'backslash'],
+  ])('should reject %s as a %s working directory', (cwd) => {
+    const messages = validate(
+      makeAst({
+        check: {
+          event: 'post-tool-use',
+          command: ['python3', 'check.py'],
+          cwd,
+        },
+      })
+    );
+
+    expect(messages.some((message) => message.message.includes('cwd must be "project"'))).toBe(
+      true
+    );
+  });
+
+  it('should reject a non-string working directory', () => {
+    const messages = validate(
+      makeAst({
+        check: {
+          event: 'post-tool-use',
+          command: ['python3', 'check.py'],
+          cwd: 42,
+        },
+      })
+    );
+
+    expect(messages.some((message) => message.message.includes('cwd must be a string'))).toBe(true);
   });
 
   it('should reject missing event field', () => {

--- a/packages/validator/src/rules/valid-hooks.ts
+++ b/packages/validator/src/rules/valid-hooks.ts
@@ -23,6 +23,7 @@ const MAX_TIMEOUT_MS = 600_000; // 10 minutes
  * - Hook IDs must be stable (from object keys, non-empty)
  * - `event` must be a valid portable event
  * - `command` must be a non-empty string array (no shell interpolation)
+ * - `cwd` must be "project" or a portable relative path
  * - `timeoutMs` must be in valid range
  * - `matcher` must be a string if present
  * - `statusMessage` must be a string if present
@@ -126,6 +127,25 @@ export const validHooks: ValidationRule = {
         }
       }
 
+      // Validate cwd
+      const cwd = hook['cwd'];
+      if (cwd !== undefined) {
+        if (typeof cwd !== 'string') {
+          ctx.report({
+            message: `Hook "${hookId}": cwd must be a string`,
+            location: hooksBlock.loc,
+            severity: 'error',
+          });
+        } else if (cwd !== 'project' && !isPortableRelativePath(cwd)) {
+          ctx.report({
+            message: `Hook "${hookId}": cwd must be "project" or a portable path relative to the project root`,
+            location: hooksBlock.loc,
+            suggestion: 'Use "project" or forward-slash path segments without "." or ".."',
+            severity: 'error',
+          });
+        }
+      }
+
       // Validate timeoutMs
       const timeoutMs = hook['timeoutMs'];
       if (timeoutMs !== undefined) {
@@ -186,3 +206,16 @@ export const validHooks: ValidationRule = {
     }
   },
 };
+
+function isPortableRelativePath(path: string): boolean {
+  if (!path || path.startsWith('/') || path.startsWith('\\') || path.includes('\\')) return false;
+  if (
+    /^[A-Za-z]:/.test(path) ||
+    path.includes('\0') ||
+    path.includes('\n') ||
+    path.includes('\r')
+  ) {
+    return false;
+  }
+  return path.split('/').every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}

--- a/packages/validator/src/rules/valid-hooks.ts
+++ b/packages/validator/src/rules/valid-hooks.ts
@@ -208,7 +208,7 @@ export const validHooks: ValidationRule = {
 };
 
 function isPortableRelativePath(path: string): boolean {
-  if (!path || path.startsWith('/') || path.startsWith('\\') || path.includes('\\')) return false;
+  if (!path || path.startsWith('/') || path.includes('\\')) return false;
   if (
     /^[A-Za-z]:/.test(path) ||
     path.includes('\0') ||


### PR DESCRIPTION
## Summary
- add validated `cwd: "project"` and project-relative hook working directories
- emit Claude and Factory project-root wrappers plus GitHub native `cwd`; warn for Cursor and Codex session-CWD fallback
- preserve shell argument boundaries and add docs, playground, runtime smoke, CI smoke, and coverage tests

## Validation
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:validate:check`
- `pnpm docs:build`

Stacked on #336.

Closes #334