### PR TITLE
docs(core): add verified issue implementation plans

### DIFF
--- a/docs/design/issue-plans/000-overview.md
+++ b/docs/design/issue-plans/000-overview.md
@@ -1,0 +1,106 @@
+# Open issue implementation plans
+
+Stan analizy: 2026-08-03. Bazowy commit: `eba37c6202e8`. Repozytorium: `mrwogu/promptscript`.
+
+## Zakres
+
+Strona Issues pokazuje 9 otwartych issue:
+
+- #330 `feat: unify block syntax across .prs blocks`
+- #331 `feat: support overriding generated section headers`
+- #343 `feat(hooks): support per-target commands and scripts`
+- #344 `feat(cli): safely migrate legacy Factory hooks during compile`
+- #345 `feat(hooks): add explicit terminal command lifecycle event`
+- #346 `fix(hooks): fail closed when project root is unavailable`
+- #347 `test(hooks): add cross-target integration fixture for merge and cleanup`
+- #348 `docs(validator): define canonical block shapes and diagnostics`
+- #349 `feat(language): add explicit override block semantics`
+
+Zamknięte #333 i #335 są traktowane jako wdrożoną bazę techniczną. Ich zakres jest już obecny w `hook-adapters.ts`, capability metadata, migracji Factory i testach smoke. Nie tworzymy dla nich nowych planów.
+
+## Decyzje łączne
+
+### Zależności
+
+```text
+#330 -> #331 -> #349
+
+#348 (niezależny kontrakt docs/validatora, wdrażany po #349 tylko dla ograniczenia churn)
+
+#346 -> #343 -> #345 -> #347
+#344 -----------------> #347
+```
+
+- #330 jest fundamentem dla jednego modelu treści, ale nie blokuje prac hookowych.
+- #331 korzysta z uniform block metadata z #330. Nie parsuje nagłówków zależnie od formattera.
+- #349 używa ordered operations z #330 i atomowej semantyki presentation metadata z #331.
+- #348 nie jest blokowane przez redesign #330 ani funkcje #331/#349. Rule i reference korzystają z compatibility adaptera, jeśli canonical AST nie jest jeszcze dostępny. W tej serii wdrażamy je po #349 tylko po to, aby uniknąć podwójnej migracji tych samych fixtures i docs.
+- #343, #345 i #346 zmieniają wspólną warstwę `hook-adapters.ts`; kolejność implementacji to #346, #343, #345, potem integracyjne #347. #344 może być rozwijane równolegle, ale #347 musi testować jego finalny kontrakt.
+
+### Nakładanie zakresu
+
+- #330 i #348: #330 zmienia parser/AST, #348 definiuje dokumentację i walidację. Nie dublować osobnych modeli shape.
+- #330 i #349: dodać jeden ordered declaration stream dla `@inherit`, top-level `@use`, blocków, `@extend` i `@override`. Inline `@use` pozostaje wpisem w ordered block body.
+- #331 i #348: contextual `@header` jest presentation entry; zwykłe fields `header` i `headers` pozostają domain data. #348 nie waliduje presentation semantics.
+- #343 i #345: per-target `matcher` pozostaje wspólnym miejscem dla target-native tool names. #345 rozszerza istniejący `HookTerminalCapability`; nie tworzy drugiego capability registry.
+- #344 i #347: migracja musi być serializowana compile-wide lockiem, odwracalna po błędzie i idempotentna. CLI fixture ma wymusić ten kontrakt.
+
+### Rozstrzygnięte konflikty
+
+1. **Unified grammar kontra kompatybilność.** #330 nie usuwa legacy syntax w jednym kroku. Parser normalizuje canonical i legacy formy do jednego AST, validator oznacza niejednoznaczne legacy formy, a migration notes opisują ewentualny codemod.
+   - `Block.body` i `Program.operations` są jedynym canonical source of truth.
+   - Parser i resolver zwracają `CanonicalProgram`. Publiczne wejścia nadal akceptują `LegacyProgram`, więc istniejące object literals pozostają type-compatible.
+   - `ProgramInput = LegacyProgram | CanonicalProgram` jest normalizowany dokładnie raz przez `createProgram`. To samo dotyczy `LegacyBlock | CanonicalBlock`.
+   - Cały canonical graph oraz `Block.content`, `Program.blocks`, `Program.uses` i `Program.extends` są deep-readonly i runtime deep-frozen przez factory. Mutacje legacy input pozostają legalne przed normalizacją; canonical outputs aktualizuje się wyłącznie immutable helperami.
+   - Resolver, validator, compiler, browser compiler, CLI i formattery nie mogą równolegle mutować canonical i compatibility views.
+   - Inline `@use` jest elementem `BlockBody.entries`, aby zachować pełną kolejność body.
+   - Shared merge engine przyjmuje jawny policy. Inheritance zachowuje child-wins, a `@use` zachowuje obecny import/source-wins.
+   - Pliki do syntax `1.5.x` bez `@override` wykonują blocks i `@extend` w legacy phase order, mimo że AST zachowuje source order. Syntax `1.6.0` albo presence `@override` włącza sequential operation mode wymagany przez #349. Lower version z override dostaje PS018, ale feature ma nadal jedno deterministic behavior. Upgrade diagnostics wykrywają `@extend` przed deklaracją targetu.
+2. **Nagłówek z przykładu #331 kontra spójność formatterów.** Canonical syntax to contextual `@header`, nie przeciążone domain fields ani formatter-specific parsing Markdown:
+
+   ```text
+   @standards {
+     @header "Coding Rules"
+     @header git-commits "Commit Rules"
+     code: ["Use strict TypeScript"]
+   }
+   ```
+
+   Początkowy `## Heading` w text-only block pozostaje kompatybilnym fallbackiem i jest konsumowany dokładnie raz. `@header` ma wyższy priorytet.
+   Zwykłe fields `header` i `headers` w built-in/custom blocks oraz nested domain fields, w tym `mcpServers.*.headers`, pozostają nietknięte.
+   Istniejący `KNOWN_SECTIONS` zostaje compatibility projection jednego rozszerzonego `SECTION_REGISTRY`, nie drugim registry.
+   `@extend` przenosi presentation patch osobno od body; root `@override` używa `BlockReplacement { body, presentation }`.
+
+3. **`@override` kontra sealed skills.** Override nie może zmienić ani usunąć sealed property. Root replacement `@override skills` jest odrzucany, jeśli narusza sealed state.
+   Root replacement zastępuje całe `BlockBody` razem z presentation metadata i inline uses. Brak metadata lub inline use w replacement oznacza ich usunięcie.
+4. **Automatyczna migracja Factory.** Compile-time migration działa tylko przy braku user-owned `.factory/hooks.json`, wykonuje się pod compile-wide lockiem i ma tryb warning-only przez flagę `--no-migrate-legacy-hooks`. Staged writes, backups i recovery journal gwarantują przywrócenie poprzednich dokumentów po błędzie lub przerwanym procesie.
+5. **Brak project root.** Nie ma fallbacku do process/session CWD dla wrapperów wymagających root. Environment-root i Git-root guards obejmują script oraz command resources wymagające `cwd`. `native-cwd` i `workspace-cwd` są osobnymi strategiami capability i generują jawne `PS4002`, gdy host nie gwarantuje repository root.
+6. **Browser parity.** Browser compiler używa tego samego canonical operation engine, merge policies i override validation co Node resolver. Same parity snapshots nie wystarczają.
+7. **Capability ownership.** Publiczne `PORTABLE_HOOK_EVENTS` i `HOOK_RUNTIME_CAPABILITIES` w core są jedynymi rejestrami portable events, statusu, root strategy, native event, terminal matcher i matcher enforcement. Validator i adaptery importują te dane zamiast utrzymywać równoległe listy.
+8. **Hook IR i locations.** Core jest właścicielem raw i validated hook IR, target overrides i lexical validatora. Canonical `ValueNode` zachowuje location każdego nested object field, array elementu i scalar value; raw `Value` pozostaje tylko compatibility projection.
+9. **Filesystem injection.** Locked output lifecycle używa jednego injected filesystem service. Project-wide compile lock jest nabywany raz przez outer command; `--all-builds` przekazuje token do wewnętrznych kompilacji bez ponownego lockowania. Dry-run nie tworzy locka i używa read-only stable snapshot check.
+
+## Wspólny kontrakt jakości
+
+- Każda zmiana ma test parsera, resolvera/validatora albo formattera odpowiednio do warstwy.
+- Hook tests sprawdzają Unix, PowerShell, ścieżki ze spacjami, ownership marker i brak duplikatów.
+- Docs przykłady muszą przejść compile/validation.
+- Nowe tokeny i directives synchronizują zawsze Pygments, VS Code TextMate i Playground Monaco. Zwykłe identifier fields nie wymagają specjalnej reguły highlightera.
+- `@extend` pozostaje kompatybilne. `field!` pozostaje kompatybilne.
+- Każdy compatibility test porównuje resolved AST oraz output przed i po migracji, nie tylko snapshot nowej ścieżki.
+- Cross-layer filesystem lifecycle jest testowany w CLI integration tests. Compiler tests pozostają in-memory.
+- Compatibility tests obejmują publiczne legacy AST object literals, custom block `@override`, legacy phase order i upgrade do sequential syntax `1.6.0`.
+- VS Code terminal best effort nie polega na ignorowanym matcher field. Generated payload-filter wrapper sprawdza `tool_name` przed uruchomieniem user resource.
+- Brak zmian w `CHANGELOG.md`; changelog obsługuje release tooling.
+
+## Kolejność wdrożenia
+
+1. #330: canonical block body, ordered operations, legacy adapter.
+2. #331: source-level presentation metadata, syntax `1.5.0` i formatter title resolution.
+3. #349: `@override`, syntax `1.6.0`, atomic path replacement.
+4. #348: shape matrix, canonical examples, validator diagnostics. Kolejność ogranicza churn, nie jest dependency.
+5. #346: fail-closed root wrappers.
+6. #343: per-target command/script resource override.
+7. #345: `pre-terminal-command` capability mapping i VS Code payload filter.
+8. #344: compile-time Factory migration.
+9. #347: cross-target integration fixture i CI coverage dla wszystkich hook-emitting output modes.

--- a/docs/design/issue-plans/000-overview.md
+++ b/docs/design/issue-plans/000-overview.md
@@ -48,13 +48,15 @@ Zamknięte #333 i #335 są traktowane jako wdrożoną bazę techniczną. Ich zak
 ### Rozstrzygnięte konflikty
 
 1. **Unified grammar kontra kompatybilność.** #330 nie usuwa legacy syntax w jednym kroku. Parser normalizuje canonical i legacy formy do jednego AST, validator oznacza niejednoznaczne legacy formy, a migration notes opisują ewentualny codemod.
-   - `Block.body` i `Program.operations` są jedynym canonical source of truth.
-   - Parser i resolver zwracają `CanonicalProgram`. Publiczne wejścia nadal akceptują `LegacyProgram`, więc istniejące object literals pozostają type-compatible.
-   - `ProgramInput = LegacyProgram | CanonicalProgram` jest normalizowany dokładnie raz przez `createProgram`. To samo dotyczy `LegacyBlock | CanonicalBlock`.
-   - Cały canonical graph oraz `Block.content`, `Program.blocks`, `Program.uses` i `Program.extends` są deep-readonly i runtime deep-frozen przez factory. Mutacje legacy input pozostają legalne przed normalizacją; canonical outputs aktualizuje się wyłącznie immutable helperami.
+   - `CanonicalBlock.body` i `CanonicalProgram.operations` są jedynym canonical source of truth.
+   - Existing exported `Program` i `Block` pozostają niezmienionymi mutable legacy input/output shapes. Istniejące imports, object literals i consumer mutation typecheckują jak wcześniej.
+   - Separate `CanonicalProgram` i `CanonicalBlock` są deep-readonly i nie rozszerzają mutable legacy interfaces. `ProgramInput = Program | CanonicalProgram` jest normalizowany dokładnie raz.
+   - Existing public parser entry point zachowuje `Program` return przez detached legacy projection. Nowy canonical entry point oraz resolver/compiler internals używają `CanonicalProgram`.
+   - Cały canonical graph oraz `CanonicalBlock.content`, `CanonicalProgram.blocks`, `CanonicalProgram.uses` i `CanonicalProgram.extends` są deep-readonly i runtime deep-frozen przez factory. Mutacje legacy input pozostają legalne przed normalizacją; canonical outputs aktualizuje się wyłącznie immutable helperami.
    - Resolver, validator, compiler, browser compiler, CLI i formattery nie mogą równolegle mutować canonical i compatibility views.
+   - Legacy custom formatter zawsze dostaje fresh detached `Program`; tylko explicit canonical formatter capability otrzymuje frozen `CanonicalProgram`.
    - Inline `@use` jest elementem `BlockBody.entries`, aby zachować pełną kolejność body.
-   - Shared merge engine przyjmuje jawny policy. Inheritance zachowuje child-wins, a `@use` zachowuje obecny import/source-wins.
+   - Shared merge engine przyjmuje jawny policy i `sourceLayerId`. Inheritance zachowuje child-wins, `@use` zachowuje obecny import/source-wins, a duplicate first-match semantics dotyczą dopiero kolejnych declarations w tym samym source layer.
    - Pliki do syntax `1.5.x` bez `@override` wykonują blocks i `@extend` w legacy phase order, mimo że AST zachowuje source order. Syntax `1.6.0` albo presence `@override` włącza sequential operation mode wymagany przez #349. Lower version z override dostaje PS018, ale feature ma nadal jedno deterministic behavior. Upgrade diagnostics wykrywają `@extend` przed deklaracją targetu.
 2. **Nagłówek z przykładu #331 kontra spójność formatterów.** Canonical syntax to contextual `@header`, nie przeciążone domain fields ani formatter-specific parsing Markdown:
 
@@ -66,19 +68,19 @@ Zamknięte #333 i #335 są traktowane jako wdrożoną bazę techniczną. Ich zak
    }
    ```
 
-   Początkowy `## Heading` w text-only block pozostaje kompatybilnym fallbackiem i jest konsumowany dokładnie raz. `@header` ma wyższy priorytet.
+   Początkowy `## Heading` staje się fallbackiem tylko dla syntax `1.5.0+` i registered primary ownera z `legacyHeadingFallback`; custom/unowned block oraz syntax do `1.4.x` zachowują heading jako body text. `@header` ma wyższy priorytet.
    Zwykłe fields `header` i `headers` w built-in/custom blocks oraz nested domain fields, w tym `mcpServers.*.headers`, pozostają nietknięte.
    Istniejący `KNOWN_SECTIONS` zostaje compatibility projection jednego rozszerzonego `SECTION_REGISTRY`, nie drugim registry.
    `@extend` przenosi presentation patch osobno od body; root `@override` używa `BlockReplacement { body, presentation }`.
 
 3. **`@override` kontra sealed skills.** Override nie może zmienić ani usunąć sealed property. Root replacement `@override skills` jest odrzucany, jeśli narusza sealed state.
    Root replacement zastępuje całe `BlockBody` razem z presentation metadata i inline uses. Brak metadata lub inline use w replacement oznacza ich usunięcie.
-4. **Automatyczna migracja Factory.** Compile-time migration działa tylko przy braku user-owned `.factory/hooks.json`, wykonuje się pod compile-wide lockiem i ma tryb warning-only przez flagę `--no-migrate-legacy-hooks`. Staged writes, backups i recovery journal gwarantują przywrócenie poprzednich dokumentów po błędzie lub przerwanym procesie.
+4. **Automatyczna migracja Factory.** Compile-time migration działa tylko wtedy, gdy `.factory/hooks.json` jest całkowicie absent, wykonuje się pod compile-wide lockiem i ma tryb warning-only przez flagę `--no-migrate-legacy-hooks`. Każdy existing canonical file, także PromptScript-owned, wyłącza auto-migration. Staged writes, backups i recovery journal zapewniają rollback po obsłużonym błędzie oraz guarded recovery po przerwaniu. Durable complete journal finalizuje new state; unknown post-crash edits nigdy nie są nadpisywane automatycznie i wymagają manual recovery.
 5. **Brak project root.** Nie ma fallbacku do process/session CWD dla wrapperów wymagających root. Environment-root i Git-root guards obejmują script oraz command resources wymagające `cwd`. `native-cwd` i `workspace-cwd` są osobnymi strategiami capability i generują jawne `PS4002`, gdy host nie gwarantuje repository root.
 6. **Browser parity.** Browser compiler używa tego samego canonical operation engine, merge policies i override validation co Node resolver. Same parity snapshots nie wystarczają.
 7. **Capability ownership.** Publiczne `PORTABLE_HOOK_EVENTS` i `HOOK_RUNTIME_CAPABILITIES` w core są jedynymi rejestrami portable events, statusu, root strategy, native event, terminal matcher i matcher enforcement. Validator i adaptery importują te dane zamiast utrzymywać równoległe listy.
 8. **Hook IR i locations.** Core jest właścicielem raw i validated hook IR, target overrides i lexical validatora. Canonical `ValueNode` zachowuje location każdego nested object field, array elementu i scalar value; raw `Value` pozostaje tylko compatibility projection.
-9. **Filesystem injection.** Locked output lifecycle używa jednego injected filesystem service. Project-wide compile lock jest nabywany raz przez outer command; `--all-builds` przekazuje token do wewnętrznych kompilacji bez ponownego lockowania. Dry-run nie tworzy locka i używa read-only stable snapshot check.
+9. **Filesystem injection.** Locked output lifecycle używa jednego injected filesystem service. PID/start/token są zakodowane w candidate filename, pełne lock metadata trafia do durable candidate, a atomic hard link publikuje candidate jako lock bez okna z pustym plikiem; project-wide lock jest nabywany raz przez outer command, a `--all-builds` przekazuje token do wewnętrznych kompilacji bez ponownego lockowania. Dry-run nie tworzy locka i używa read-only stable snapshot check. Symlink checks odrzucają pre-existing/detected escapes, ale nie obiecują ochrony przed malicious same-privilege ancestor-swap race bez handle-relative OS primitives.
 
 ## Wspólny kontrakt jakości
 

--- a/docs/design/issue-plans/330-unify-block-syntax.md
+++ b/docs/design/issue-plans/330-unify-block-syntax.md
@@ -1,0 +1,152 @@
+# Issue #330 - unify block syntax
+
+Issue: https://github.com/mrwogu/promptscript/issues/330
+
+## Cel
+
+Ujednolicić parser i AST bez wycinania obecnych form. Każdy block ma jeden model body, niezależnie od tego, czy zawiera tekst, mapę, listę, czy ich kombinację. Legacy syntax pozostaje parsowalny i jest normalizowany do canonical AST.
+
+## Stan obecny
+
+- `packages/parser/src/grammar/parser.ts:122` ma osobne `blockContent` i `extendBlockContent`.
+- `packages/parser/src/grammar/visitor.ts:468` klasyfikuje body jako `TextContent`, `ObjectContent`, `ArrayContent` albo `MixedContent`.
+- `packages/core/src/types/ast.ts:327` eksponuje union `BlockContent`.
+- `packages/resolver/src/inheritance.ts` i `imports.ts` mają duplikowane reguły merge dla shape.
+- `Program` przechowuje `blocks` i `extends` osobno, więc nie zachowuje kolejności wszystkich operacji.
+- Trzy highlightery mają częściowo niezależne listy directive/block.
+
+## Decyzja projektowa
+
+Wprowadzić canonical `BlockBody`:
+
+```ts
+interface BlockBody {
+  type: 'BlockBody';
+  shape: 'text' | 'object' | 'array' | 'mixed';
+  entries: BlockEntry[];
+}
+
+type BlockEntry = TextEntry | FieldEntry | ListEntry | InlineUseEntry;
+
+type ProgramOperation =
+  | InheritOperation
+  | UseOperation
+  | BlockOperation
+  | ExtendOperation
+  | OverrideOperation;
+```
+
+`FieldEntry` przechowuje nazwę i canonical `ValueNode`, `ListEntry` canonical element listy, `TextEntry` tekst, a `InlineUseEntry` pełną deklarację inline wraz z lokalizacją. Raw `Value` powstaje tylko w compatibility projection. Jeden `entries` array zachowuje kolejność `field -> @use -> text -> list`. `shape` jest wyliczany przez parser, nie podawany przez użytkownika.
+
+Contextual `@header` presentation directives z #331 trafiają do `Block.presentation`, a nie do body properties. Zwykłe fields `header` i `headers` pozostają domain data.
+
+`Block.body` i `Program.operations` są jedynym canonical source of truth. Cały canonical graph, w tym body, operations, presentation i nested `ValueNode`, jest `DeepReadonly` oraz runtime deep-frozen. `Program.operations` zachowuje kolejność `@inherit`, top-level `@use`, blocków, `@extend` i `@override`. Publiczne wejście pozostaje kompatybilne przez jawne typy `LegacyProgram`/`LegacyBlock` i union `ProgramInput`; istniejące object literals nie muszą od razu dodawać `body` ani `operations`. Parser zwraca `CanonicalProgram`, a compiler, resolver, browser compiler, validator i publiczne API normalizują legacy input dokładnie raz.
+
+Obecne `Block.content`, `Program.inherit`, `Program.uses`, `Program.blocks` i `Program.extends` pozostają przez jedną wersję jako deep-readonly compatibility projections. `BlockContent` pozostaje tymczasowym compatibility representation. `toLegacyBlockContent(body)` tworzy deep-frozen snapshot, a `getBlockProperties`, `getBlockText`, `getBlockItems` i `getInlineUses` czytają wyłącznie canonical body. Mutacje legacy input są legalne przed normalizacją; canonical output zmienia się wyłącznie przez immutable update helpers, które regenerują wszystkie snapshots.
+
+Source order i execution order to osobne kontrakty. AST zawsze zachowuje source order. Dla syntax do `1.5.x` bez `@override` resolver wykonuje kompatybilny phase policy: inheritance, top-level uses, blocks, inline composition, extends. Dzięki temu istniejący `@extend` zapisany przed deklaracją blocku nadal działa jak obecnie. Syntax `1.6.0` z #349 włącza sequential policy, w którym blocks, `@extend` i `@override` wykonują się w source order. Presence `@override` także wymusza sequential policy nawet przy niższej deklaracji, równolegle z PS018, ponieważ parsed feature musi mieć jedno deterministic behavior. Validator emituje migration diagnostic, gdy podniesienie wersji zmieni wynik, np. dla `@extend` przed target blockiem.
+
+Shared merge engine przyjmuje jawny `MergePolicy`:
+
+- inheritance: parent jako base, child wygrywa dla scalar i type mismatch;
+- top-level oraz inline `@use`: zachować obecną source/import-wins precedence;
+- `@extend`: zachować obecny additive merge oraz `field!`;
+- `@override`: complete replacement z #349.
+
+Powtórne zwykłe block declarations zachowują obecną semantykę: każdy `BlockOperation` dopisuje osobny block, compatibility `blocks` zachowuje duplicates i source order, a path lookup oraz formatter `findBlock` wybiera pierwszy matching block. Resolver nie łączy duplicates ukrycie. Validator może raportować istniejący ambiguity warning, ale nie zmienia wyniku. Ta reguła obowiązuje w `legacyPhased` i `sequential`.
+
+## Plan implementacji
+
+1. **Core AST**
+   - Dodać `BlockBody`, ordered entry types, `BlockPresentation`, `ProgramOperation` i discriminated operation kinds.
+   - Wprowadzić `LegacyProgram`, `LegacyBlock`, `CanonicalProgram`, `CanonicalBlock`, `ProgramInput` i `BlockInput`. Nie dodawać wymaganych canonical fields bezpośrednio do legacy public shape.
+   - Dodać canonical `Block.body`, `Program.operations` oraz helpery `getBlockProperties`, `getBlockText`, `getBlockItems` i `getInlineUses`.
+   - Oznaczyć compatibility arrays, nested values i content jako `DeepReadonly`, nie tylko płytkie `readonly`.
+   - Dodać AST factories `createBlock`, `createProgram`, `normalizeProgram` oraz immutable update helpers, które zawsze regenerują compatibility projections.
+   - Dodać canonical `ValueNode`/`ObjectFieldNode`/`ArrayElementNode` z location na każdym nested field, scalar i elemencie. `FieldEntry.value` i `ListEntry.value` używają `ValueNode`; `Value` pozostaje compatibility value projection dla istniejących API.
+   - Deep-freeze całe canonical nodes i compatibility snapshots w factory. Żaden publiczny canonical output nie udostępnia mutable nested arrays/maps.
+   - Zachować named exports i location na każdym nowym node.
+   - Oznaczyć `BlockContent` jako deprecated compatibility representation, bez usuwania go w pierwszym release.
+
+2. **Grammar i visitor**
+   - Zastąpić rozdzielne reguły `blockContent` i `extendBlockContent` jedną regułą ordered entries.
+   - Ujednolicić top-level visitor tak, aby wpisywał `@inherit`, `@use`, block i `@extend` do jednego `Program.operations` bez grupowania po typie. #349 dodaje do tego samego streamu `@override`.
+   - Zachować triple-quoted text, `field: value`, nested objects/arrays, dash-list i inline `@use`.
+   - Emitować inline `@use` jako `InlineUseEntry` w jego dokładnej pozycji, nie w bocznym array.
+   - Normalizować dash-list do `ListEntry`, zamiast specjalnego `@restrictions` parser branch.
+   - Emitować canonical `BlockBody`; compatibility view tworzyć wyłącznie przez AST factory.
+   - Zachować `field!` jako modifier w operation metadata.
+   - Zachować location nested object fields, array elements i standalone values podczas budowania `ValueNode`.
+   - Dodać test parse order dla top-level declarations oraz `field -> inline use -> text -> list`, mixed content, empty body, nested values i legacy syntax.
+
+3. **Resolver**
+   - Przenieść shape merge do jednego modułu używanego przez Node i browser resolver dla inheritance, `@use`, `@extend` i później `@override`.
+   - Merge ma działać na canonical entries z wymaganym `MergePolicy`, zachowując text concat, unique arrays i deep object merge.
+   - Zachować child-wins dla inheritance oraz obecną source/import-wins precedence dla `@use`, także dla scalar, `TextContent` i type mismatch.
+   - Zachować source order declarations podczas `@inherit`, top-level `@use`, aliasowanych `@use`, blocków i extensions. Grammar może nadal ograniczać legalne pozycje, ale visitor nie grupuje poprawnych deklaracji po typie.
+   - Dodać jawne `legacyPhased` i `sequential` execution policies. `legacyPhased` pozostaje defaultem do syntax `1.5.x` bez explicit override usage; `sequential` wybiera syntax `1.6.0` albo presence `@override`.
+   - Inline `@use` nadal używa dedicated skill composition semantics. Pozycja entry wyznacza fazę i ownership względem sąsiednich entries, ale nie zamienia inline use w generic body merge.
+   - Zachować duplicate `BlockOperation`s bez implicit merge. Path operations wybierają pierwszy matching block zgodnie z obecnym `findIndex`/`findBlock`.
+   - Usunąć duplikację `mergeBlockContent` z `inheritance.ts` i `imports.ts` po migracji callerów.
+   - Wydzielić browser-safe shared module bez Node filesystem APIs. `packages/browser-compiler/src/resolver.ts` nie utrzymuje drugiej implementacji merge/operation engine.
+
+4. **Migracja downstream**
+   - Zmigrować `packages/core/src/template.ts`, resolver skills/guards/composition, compiler, browser compiler, validator walker/policy/rules, CLI inspect/lock scanner oraz formatter extractors.
+   - Każdy direct `content.type`, `ast.blocks`, `ast.uses` i `ast.extends` ma używać canonical accessora albo jawnego compatibility boundary.
+   - Publiczne serialization i inspection APIs dokumentują, czy zwracają canonical AST, compatibility view, czy oba.
+   - Dodać temporary lint/search assertion blokujące nowe direct casts do `BlockContent` poza compatibility module.
+   - Utrzymać overloady przyjmujące `ProgramInput` dla publicznych validator/formatter/compiler entry points. Wewnętrzne funkcje po normalization przyjmują wyłącznie `CanonicalProgram`.
+   - Udokumentować, że mutacja legacy input przed wywołaniem API pozostaje wspierana, a canonical output jest immutable.
+
+5. **Validator**
+   - Dodać shape accessors i validation hooks, aby built-in rules nie castowały bezpośrednio `Record<string, Value>`.
+   - Custom blocks pozostają bez predefined schema.
+   - Legacy forms generują migration hint tylko wtedy, gdy shape jest niejednoznaczny.
+   - Dodać diagnostic dla syntax upgrade, jeśli legacy phase order i sequential order dają inny wynik.
+
+6. **Formatters**
+   - Migrować extractors na accessors zamiast bezpośredniej inspekcji `content.type`.
+   - Sprawdzić, że żadna treść nie znika przy przejściu Text/Object/Mixed.
+   - Nie zmieniać outputu dla obecnych canonical i legacy fixtures.
+
+7. **Highlightery i docs**
+   - #330 nie dodaje tokenu ani directive. Uruchomić istniejący sync check bez sztucznych reguł dla zwykłych fields.
+   - Przy późniejszym dodaniu `Override` przez #349 utrzymać zgodność `docs_extensions/promptscript_lexer.py`, `apps/vscode/syntaxes/promptscript.tmLanguage.json` i `packages/playground/src/utils/prs-language.ts`.
+   - Przepisać reference language na jeden model body, z sekcją legacy compatibility.
+   - Dodać canonical examples do docs, pełna macierz shape jest w #348.
+
+8. **Compatibility rollout**
+   - Wprowadzić feature flag/version gate dopiero dla syntax additions, nie dla istniejących form.
+   - Przez jedną wersję eksportować oba widoki AST.
+   - Udokumentować canonical source of truth oraz deprecated projections w public API.
+   - Usunąć compatibility view dopiero po aktualizacji public API, direct consumers, browser compiler i fixtures downstream.
+   - Nie wymagać `body`/`operations` od istniejących zewnętrznych object literals w pierwszym release.
+
+## Testy i weryfikacja
+
+- Core: legacy object literals nadal typecheckują; normalization generuje canonical AST; factory regeneruje deep-readonly compatibility views po każdej immutable transformacji.
+- Core: próba mutacji nested compatibility snapshot nie zmienia canonical body i jest blokowana typem oraz runtime deep freeze.
+- Core: próba mutacji canonical body, operations, presentation lub nested value jest blokowana typem i runtime deep freeze.
+- Parser: wszystkie kombinacje entry order i shape, w tym inline `@use` pomiędzy dwoma fields.
+- Parser: nested object/array/scalar locations są dokładne.
+- Resolver: inheritance, top-level i inline `@use`, aliases, nested paths, duplicate arrays, text deduplication oraz osobna scalar precedence dla inheritance i import.
+- Resolver: `@extend` przed target blockiem zachowuje obecny wynik do `1.5.x`; ten sam plik po upgrade do `1.6.0` dostaje migration diagnostic i deterministic sequential result.
+- Resolver/formatter: duplicate blocks pozostają osobnymi entries, path mutation i rendering zachowują first-match behavior.
+- Formatter: golden fixtures dla każdego built-in block i każdego targetu bazowego.
+- Downstream regression: template interpolation, validator walker, skills/guards, CLI inspect i lock scanner używają canonical accessors.
+- Browser compiler: ten sam shared merge/operation engine oraz parity tests dla canonical i legacy input.
+- Highlighter: `pnpm grammar:check`.
+- Docs examples: `pnpm prs validate --strict` oraz compile smoke.
+
+## Kryterium gotowości
+
+- Jeden canonical AST body dla built-in i custom blocks.
+- Jeden ordered program stream obejmuje wszystkie semantic declarations, a jeden ordered body stream obejmuje inline `@use`.
+- Compatibility fields są read-only projections i nie mogą rozjechać się z canonical AST.
+- Publiczne legacy AST object literals pozostają akceptowane przez jedną wersję przejściową.
+- Wszystkie obecne poprawne pliki nadal kompilują się bez ręcznej migracji.
+- Inheritance i `@use` zachowują swoją obecną, różną scalar precedence.
+- Ordered operations gotowe dla #349.
+- Brak shape-specific merge duplication w resolverze.
+- Node i browser resolver używają wspólnego operation engine.
+- Trzy highlightery i reference docs opisują ten sam model.

--- a/docs/design/issue-plans/330-unify-block-syntax.md
+++ b/docs/design/issue-plans/330-unify-block-syntax.md
@@ -38,11 +38,11 @@ type ProgramOperation =
 
 `FieldEntry` przechowuje nazwę i canonical `ValueNode`, `ListEntry` canonical element listy, `TextEntry` tekst, a `InlineUseEntry` pełną deklarację inline wraz z lokalizacją. Raw `Value` powstaje tylko w compatibility projection. Jeden `entries` array zachowuje kolejność `field -> @use -> text -> list`. `shape` jest wyliczany przez parser, nie podawany przez użytkownika.
 
-Contextual `@header` presentation directives z #331 trafiają do `Block.presentation`, a nie do body properties. Zwykłe fields `header` i `headers` pozostają domain data.
+Contextual `@header` presentation directives z #331 trafiają do `CanonicalBlock.presentation`, a nie do body properties. Zwykłe fields `header` i `headers` pozostają domain data.
 
-`Block.body` i `Program.operations` są jedynym canonical source of truth. Cały canonical graph, w tym body, operations, presentation i nested `ValueNode`, jest `DeepReadonly` oraz runtime deep-frozen. `Program.operations` zachowuje kolejność `@inherit`, top-level `@use`, blocków, `@extend` i `@override`. Publiczne wejście pozostaje kompatybilne przez jawne typy `LegacyProgram`/`LegacyBlock` i union `ProgramInput`; istniejące object literals nie muszą od razu dodawać `body` ani `operations`. Parser zwraca `CanonicalProgram`, a compiler, resolver, browser compiler, validator i publiczne API normalizują legacy input dokładnie raz.
+`CanonicalBlock.body` i `CanonicalProgram.operations` są jedynym canonical source of truth. Cały canonical graph, w tym body, operations, presentation i nested `ValueNode`, jest `DeepReadonly` oraz runtime deep-frozen. `CanonicalProgram.operations` zachowuje kolejność `@inherit`, top-level `@use`, blocków, `@extend` i `@override`. Existing exported names `Program` i `Block` pozostają niezmienionymi mutable legacy shapes. Separate `CanonicalProgram` i `CanonicalBlock` nie rozszerzają mutable interfaces, więc mogą mieć prawdziwie deep-readonly arrays bez naruszenia TypeScript assignability.
 
-Obecne `Block.content`, `Program.inherit`, `Program.uses`, `Program.blocks` i `Program.extends` pozostają przez jedną wersję jako deep-readonly compatibility projections. `BlockContent` pozostaje tymczasowym compatibility representation. `toLegacyBlockContent(body)` tworzy deep-frozen snapshot, a `getBlockProperties`, `getBlockText`, `getBlockItems` i `getInlineUses` czytają wyłącznie canonical body. Mutacje legacy input są legalne przed normalizacją; canonical output zmienia się wyłącznie przez immutable update helpers, które regenerują wszystkie snapshots.
+`ProgramInput = Program | CanonicalProgram` i `BlockInput = Block | CanonicalBlock` zachowują publiczne wejścia. Existing parser entry point nadal zwraca detached mutable `Program` projection; nowy `parseCanonical` oraz compiler/resolver internals zwracają `CanonicalProgram`. `CanonicalBlock.content`, `CanonicalProgram.inherit`, `CanonicalProgram.uses`, `CanonicalProgram.blocks` i `CanonicalProgram.extends` są deep-readonly projections, ale legacy projection jest osobnym clone, nie subtype relation. `BlockContent` pozostaje tymczasowym compatibility representation. `toLegacyProgram`/`toLegacyBlockContent` tworzą detached mutable legacy snapshots, a `getBlockProperties`, `getBlockText`, `getBlockItems` i `getInlineUses` czytają wyłącznie canonical body. Mutacje legacy input/output nie zmieniają canonical graph; canonical output zmienia się wyłącznie przez immutable update helpers.
 
 Source order i execution order to osobne kontrakty. AST zawsze zachowuje source order. Dla syntax do `1.5.x` bez `@override` resolver wykonuje kompatybilny phase policy: inheritance, top-level uses, blocks, inline composition, extends. Dzięki temu istniejący `@extend` zapisany przed deklaracją blocku nadal działa jak obecnie. Syntax `1.6.0` z #349 włącza sequential policy, w którym blocks, `@extend` i `@override` wykonują się w source order. Presence `@override` także wymusza sequential policy nawet przy niższej deklaracji, równolegle z PS018, ponieważ parsed feature musi mieć jedno deterministic behavior. Validator emituje migration diagnostic, gdy podniesienie wersji zmieni wynik, np. dla `@extend` przed target blockiem.
 
@@ -53,28 +53,32 @@ Shared merge engine przyjmuje jawny `MergePolicy`:
 - `@extend`: zachować obecny additive merge oraz `field!`;
 - `@override`: complete replacement z #349.
 
-Powtórne zwykłe block declarations zachowują obecną semantykę: każdy `BlockOperation` dopisuje osobny block, compatibility `blocks` zachowuje duplicates i source order, a path lookup oraz formatter `findBlock` wybiera pierwszy matching block. Resolver nie łączy duplicates ukrycie. Validator może raportować istniejący ambiguity warning, ale nie zmienia wyniku. Ta reguła obowiązuje w `legacyPhased` i `sequential`.
+Powtórne zwykłe block declarations zachowują obecną semantykę w obrębie jednego source layer: każdy kolejny `BlockOperation` dla tego samego key dopisuje osobny block, compatibility `blocks` zachowuje duplicates i source order, a path lookup oraz formatter `findBlock` wybiera pierwszy matching block. Resolver nie łączy same-layer duplicates ukrycie.
+
+Composition nie używa tej duplicate rule. Każda operation ma stable `sourceLayerId`. `@inherit` najpierw materializuje parent state, a pierwszy child block danego key mergeuje pierwszy inherited match przez inheritance policy; następne child declarations tego key są same-layer duplicates. `@use` mergeuje pierwszy imported match z pierwszym local match przez import policy, a kolejne imported duplicates pozostawia osobno. Dzięki temu parent/import nie zasłania child/source przez first-match lookup. Validator może raportować istniejący same-layer ambiguity warning, ale nie zmienia wyniku. Kontrakt działa tak samo w `legacyPhased` i `sequential`.
 
 ## Plan implementacji
 
 1. **Core AST**
    - Dodać `BlockBody`, ordered entry types, `BlockPresentation`, `ProgramOperation` i discriminated operation kinds.
-   - Wprowadzić `LegacyProgram`, `LegacyBlock`, `CanonicalProgram`, `CanonicalBlock`, `ProgramInput` i `BlockInput`. Nie dodawać wymaganych canonical fields bezpośrednio do legacy public shape.
-   - Dodać canonical `Block.body`, `Program.operations` oraz helpery `getBlockProperties`, `getBlockText`, `getBlockItems` i `getInlineUses`.
-   - Oznaczyć compatibility arrays, nested values i content jako `DeepReadonly`, nie tylko płytkie `readonly`.
-   - Dodać AST factories `createBlock`, `createProgram`, `normalizeProgram` oraz immutable update helpers, które zawsze regenerują compatibility projections.
+   - Zachować exported `Program` i `Block` dokładnie jako mutable legacy shapes, pod tymi samymi names i bez nowych required/readonly fields.
+   - Wprowadzić separate `CanonicalProgram`, `CanonicalBlock`, `ProgramInput = Program | CanonicalProgram` i `BlockInput = Block | CanonicalBlock`. Canonical interfaces nie rozszerzają mutable legacy interfaces.
+   - Dodać canonical `CanonicalBlock.body`, `CanonicalProgram.operations` oraz helpery `getBlockProperties`, `getBlockText`, `getBlockItems` i `getInlineUses`.
+   - Oznaczyć canonical compatibility arrays, nested values i content jako `DeepReadonly`, nie tylko płytkie `readonly`.
+   - Dodać AST factories `createBlock`, `createProgram`, `normalizeProgram`, `toLegacyProgram` oraz immutable update helpers. Legacy projection jest detached clone i nie może mutować canonical graph.
    - Dodać canonical `ValueNode`/`ObjectFieldNode`/`ArrayElementNode` z location na każdym nested field, scalar i elemencie. `FieldEntry.value` i `ListEntry.value` używają `ValueNode`; `Value` pozostaje compatibility value projection dla istniejących API.
-   - Deep-freeze całe canonical nodes i compatibility snapshots w factory. Żaden publiczny canonical output nie udostępnia mutable nested arrays/maps.
+   - Deep-freeze całe canonical nodes i canonical compatibility projections w factory. Detached legacy snapshots pozostają mutable i nie współdzielą references. Żaden publiczny canonical output nie udostępnia mutable nested arrays/maps.
    - Zachować named exports i location na każdym nowym node.
    - Oznaczyć `BlockContent` jako deprecated compatibility representation, bez usuwania go w pierwszym release.
 
 2. **Grammar i visitor**
    - Zastąpić rozdzielne reguły `blockContent` i `extendBlockContent` jedną regułą ordered entries.
-   - Ujednolicić top-level visitor tak, aby wpisywał `@inherit`, `@use`, block i `@extend` do jednego `Program.operations` bez grupowania po typie. #349 dodaje do tego samego streamu `@override`.
+   - Ujednolicić top-level visitor tak, aby wpisywał `@inherit`, `@use`, block i `@extend` do jednego `CanonicalProgram.operations` bez grupowania po typie. #349 dodaje do tego samego streamu `@override`.
    - Zachować triple-quoted text, `field: value`, nested objects/arrays, dash-list i inline `@use`.
    - Emitować inline `@use` jako `InlineUseEntry` w jego dokładnej pozycji, nie w bocznym array.
    - Normalizować dash-list do `ListEntry`, zamiast specjalnego `@restrictions` parser branch.
    - Emitować canonical `BlockBody`; compatibility view tworzyć wyłącznie przez AST factory.
+   - Zachować existing public parse function i `Program` return type przez `toLegacyProgram(parseCanonical(...))`. Dodać named `parseCanonical`; compiler, resolver i browser compiler używają go bez legacy round-trip.
    - Zachować `field!` jako modifier w operation metadata.
    - Zachować location nested object fields, array elements i standalone values podczas budowania `ValueNode`.
    - Dodać test parse order dla top-level declarations oraz `field -> inline use -> text -> list`, mixed content, empty body, nested values i legacy syntax.
@@ -82,11 +86,12 @@ Powtórne zwykłe block declarations zachowują obecną semantykę: każdy `Bloc
 3. **Resolver**
    - Przenieść shape merge do jednego modułu używanego przez Node i browser resolver dla inheritance, `@use`, `@extend` i później `@override`.
    - Merge ma działać na canonical entries z wymaganym `MergePolicy`, zachowując text concat, unique arrays i deep object merge.
+   - Każda operation przechowuje `sourceLayerId`. Composition mergeuje first matching block między layers, natomiast kolejne declarations tego samego key w jednym layer pozostają oddzielnymi duplicates.
    - Zachować child-wins dla inheritance oraz obecną source/import-wins precedence dla `@use`, także dla scalar, `TextContent` i type mismatch.
    - Zachować source order declarations podczas `@inherit`, top-level `@use`, aliasowanych `@use`, blocków i extensions. Grammar może nadal ograniczać legalne pozycje, ale visitor nie grupuje poprawnych deklaracji po typie.
    - Dodać jawne `legacyPhased` i `sequential` execution policies. `legacyPhased` pozostaje defaultem do syntax `1.5.x` bez explicit override usage; `sequential` wybiera syntax `1.6.0` albo presence `@override`.
    - Inline `@use` nadal używa dedicated skill composition semantics. Pozycja entry wyznacza fazę i ownership względem sąsiednich entries, ale nie zamienia inline use w generic body merge.
-   - Zachować duplicate `BlockOperation`s bez implicit merge. Path operations wybierają pierwszy matching block zgodnie z obecnym `findIndex`/`findBlock`.
+   - Zachować same-layer duplicate `BlockOperation`s bez implicit merge. Cross-layer composition używa jawnej policy powyżej. Path operations wybierają pierwszy matching block zgodnie z obecnym `findIndex`/`findBlock`.
    - Usunąć duplikację `mergeBlockContent` z `inheritance.ts` i `imports.ts` po migracji callerów.
    - Wydzielić browser-safe shared module bez Node filesystem APIs. `packages/browser-compiler/src/resolver.ts` nie utrzymuje drugiej implementacji merge/operation engine.
 
@@ -95,8 +100,10 @@ Powtórne zwykłe block declarations zachowują obecną semantykę: każdy `Bloc
    - Każdy direct `content.type`, `ast.blocks`, `ast.uses` i `ast.extends` ma używać canonical accessora albo jawnego compatibility boundary.
    - Publiczne serialization i inspection APIs dokumentują, czy zwracają canonical AST, compatibility view, czy oba.
    - Dodać temporary lint/search assertion blokujące nowe direct casts do `BlockContent` poza compatibility module.
-   - Utrzymać overloady przyjmujące `ProgramInput` dla publicznych validator/formatter/compiler entry points. Wewnętrzne funkcje po normalization przyjmują wyłącznie `CanonicalProgram`.
-   - Udokumentować, że mutacja legacy input przed wywołaniem API pozostaje wspierana, a canonical output jest immutable.
+   - Utrzymać publiczne validator/formatter/compiler entry points przyjmujące `ProgramInput`. Wewnętrzne funkcje po normalization przyjmują wyłącznie `CanonicalProgram`.
+   - Zachować istniejący publiczny `Formatter.format(ast: Program)` contract dla custom formatterów. Formatter adapter zawsze przekazuje mu fresh detached `toLegacyProgram(canonical)` clone.
+   - Dodać opt-in `CanonicalFormatter.formatCanonical(ast: CanonicalProgram)` dla built-in formatterów. Adapter używa canonical entry point tylko po explicit capability check; frozen canonical graph nigdy nie trafia do legacy formatter method.
+   - Udokumentować, że mutacja legacy input i legacy parser output pozostaje wspierana, ale detached legacy output nie mutuje canonical graph. Canonical output jest immutable.
 
 5. **Validator**
    - Dodać shape accessors i validation hooks, aby built-in rules nie castowały bezpośrednio `Record<string, Value>`.
@@ -117,22 +124,25 @@ Powtórne zwykłe block declarations zachowują obecną semantykę: każdy `Bloc
 
 8. **Compatibility rollout**
    - Wprowadzić feature flag/version gate dopiero dla syntax additions, nie dla istniejących form.
-   - Przez jedną wersję eksportować oba widoki AST.
+   - Przez jedną wersję eksportować mutable legacy i separate immutable canonical widok AST.
    - Udokumentować canonical source of truth oraz deprecated projections w public API.
    - Usunąć compatibility view dopiero po aktualizacji public API, direct consumers, browser compiler i fixtures downstream.
    - Nie wymagać `body`/`operations` od istniejących zewnętrznych object literals w pierwszym release.
 
 ## Testy i weryfikacja
 
-- Core: legacy object literals nadal typecheckują; normalization generuje canonical AST; factory regeneruje deep-readonly compatibility views po każdej immutable transformacji.
-- Core: próba mutacji nested compatibility snapshot nie zmienia canonical body i jest blokowana typem oraz runtime deep freeze.
+- Core: object literals typed/imported jako existing `Program` i `Block` nadal typecheckują bez canonical fields; normalization generuje canonical AST; factory regeneruje deep-readonly canonical projections po każdej immutable transformacji.
+- Public consumer fixture: osobny TypeScript project importuje `Program`/`Block` z package root, buduje i mutuje pre-#330 literals oraz parser output, po czym przechodzi typecheck bez casts.
+- Core: mutacja detached legacy parser output nie zmienia canonical body; próba mutacji canonical projection jest blokowana typem oraz runtime deep freeze.
 - Core: próba mutacji canonical body, operations, presentation lub nested value jest blokowana typem i runtime deep freeze.
 - Parser: wszystkie kombinacje entry order i shape, w tym inline `@use` pomiędzy dwoma fields.
 - Parser: nested object/array/scalar locations są dokładne.
 - Resolver: inheritance, top-level i inline `@use`, aliases, nested paths, duplicate arrays, text deduplication oraz osobna scalar precedence dla inheritance i import.
+- Resolver: parent/child oraz import/local same-key blocks mergeują między source layers zgodnie z policy; drugi same-key block w jednym pliku pozostaje duplicate i nie zasłania first composed result.
 - Resolver: `@extend` przed target blockiem zachowuje obecny wynik do `1.5.x`; ten sam plik po upgrade do `1.6.0` dostaje migration diagnostic i deterministic sequential result.
 - Resolver/formatter: duplicate blocks pozostają osobnymi entries, path mutation i rendering zachowują first-match behavior.
 - Formatter: golden fixtures dla każdego built-in block i każdego targetu bazowego.
+- Formatter compatibility: legacy custom formatter może mutować otrzymany detached `Program` bez throw i bez zmiany canonical graph; built-in formatter dostaje frozen `CanonicalProgram`.
 - Downstream regression: template interpolation, validator walker, skills/guards, CLI inspect i lock scanner używają canonical accessors.
 - Browser compiler: ten sam shared merge/operation engine oraz parity tests dla canonical i legacy input.
 - Highlighter: `pnpm grammar:check`.
@@ -142,7 +152,7 @@ Powtórne zwykłe block declarations zachowują obecną semantykę: każdy `Bloc
 
 - Jeden canonical AST body dla built-in i custom blocks.
 - Jeden ordered program stream obejmuje wszystkie semantic declarations, a jeden ordered body stream obejmuje inline `@use`.
-- Compatibility fields są read-only projections i nie mogą rozjechać się z canonical AST.
+- Canonical compatibility fields są read-only projections i nie mogą rozjechać się z canonical AST; mutable legacy projection jest detached.
 - Publiczne legacy AST object literals pozostają akceptowane przez jedną wersję przejściową.
 - Wszystkie obecne poprawne pliki nadal kompilują się bez ręcznej migracji.
 - Inheritance i `@use` zachowują swoją obecną, różną scalar precedence.

--- a/docs/design/issue-plans/331-section-header-overrides.md
+++ b/docs/design/issue-plans/331-section-header-overrides.md
@@ -1,0 +1,137 @@
+# Issue #331 - override generated section headers
+
+Issue: https://github.com/mrwogu/promptscript/issues/331
+
+## Cel
+
+Pozwolić zmienić tytuł sekcji generowanej przez formatter bez forka formattera. Domyślne nazwy i obecny output pozostają bez zmian.
+
+## Stan obecny
+
+- `packages/formatters/src/markdown-instruction-formatter.ts:95` ma `MarkdownFormatterConfig.sectionNames`, ale jest to konfiguracja formattera, nie źródło `.prs`.
+- `getSectionName` jest używane przez część sekcji, lecz `Project`, `Tech Stack`, `Architecture`, `Context` i inne ścieżki mają tytuły inline.
+- `addCommonSections` definiuje wspólną kolejność sekcji.
+- Formatter-specific implementations mogą mieć własne nagłówki; trzeba objąć także targets spoza `MarkdownInstructionFormatter`.
+- Obecny przykład z `## Coding Rules` w `@standards` jest free-form text i nie daje stabilnej semantyki dla wszystkich targetów.
+
+## Decyzja składniowa
+
+Canonical form:
+
+```text
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  code: ["Use strict TypeScript"]
+}
+```
+
+- `@header "..."` zastępuje primary section title dla danego built-in block.
+- `@header <section-key> "..."` nazywa derived section, gdy block generuje więcej niż jedną sekcję.
+- Canonical public section keys używają kebab-case IDs z `SECTION_REGISTRY`, np. `git-commits`. Existing formatter config keys, np. `gitCommits`, są compatibility aliases mapowanymi jawnie w tym samym registry.
+- `@header` jest contextual presentation entry w ordered body, nie zwykłym property i nie globalnym lexer keywordem.
+- Zwykłe fields `header` i `headers` pozostają domain data w każdym built-in i custom blocku. Nested fields, w tym `mcpServers.<name>.headers`, nigdy nie są presentation metadata.
+- Dla text-only block pierwszy heading `## ...` na początku tekstu pozostaje legacy fallbackiem. Gdy występuje obok `@header`, wygrywa `@header`.
+- Legacy fallback konsumuje dokładnie pierwszy heading line z body i emituje go raz jako resolved title. Pozostały text body zachowuje byte-equivalent content poza usuniętą linią headinga i jednym bezpośrednim newline. Heading poza początkiem body pozostaje zwykłą treścią.
+- Priorytet: source override > formatter config `sectionNames` > built-in default.
+
+## Plan implementacji
+
+1. **AST i normalizacja**
+   - Użyć `BlockPresentation` wprowadzonego w #330; #331 jest właścicielem semantyki i validation tego typu.
+   - Dodać canonical `PresentationEntry` do ordered `BlockEntry`: explicit primary, explicit derived albo legacy heading entry, każdy z title i exact location.
+   - `PresentationEntry` nie wpływa na `BlockBody.shape`; shape jest wyliczany tylko z text/field/list entries.
+   - `PresentationEntry` w ordered body jest jedynym parsed source. `Block.presentation` i operation `presentationPatch` są mandatory derived, deep-readonly projections regenerowane przez AST factory po każdej transformacji. Konsumenci nie mogą mutować ani niezależnie serializować obu form.
+   - Grammar rozpoznaje `@header` entry wewnątrz dowolnego block body przez contextual identifier gate. Nie dodawać globalnego `Header` tokenu; zwykłe `header`/`headers` fields i custom names pozostają legalne.
+   - Przenieść `SectionContract` i `SECTION_REGISTRY` do browser-safe core, ponieważ validator i formatters muszą czytać ten sam owner/key contract. `packages/formatters/src/section-registry.ts` re-exportuje core registry i compatibility helpers.
+   - Visitor zachowuje entry, a validator importuje core `SECTION_REGISTRY` i pozwala presentation semantics tylko dla owner blocków. Custom block z `@header` dostaje unknown contextual directive diagnostic.
+   - Zachować location dla directive, section key, title i legacy headinga. Diagnostics nie mogą wskazywać całego blocku.
+   - Walidować: title musi być niepustym stringiem; optional key musi istnieć w `SECTION_REGISTRY` i należeć do owner blocku.
+   - Nie interpretować dowolnych `##` wewnątrz tekstu jako override, aby nie niszczyć treści dokumentu.
+   - Normalizer zastępuje consumed heading line canonical `LegacyPresentationEntry` w tej samej pozycji, a pozostały text zapisuje jako sąsiedni `TextEntry`. Dzięki temu body nie renderuje headinga drugi raz, ale factory nadal może regenerować `Block.presentation.legacyHeader` wyłącznie z canonical entries.
+
+2. **Syntax versioning**
+   - Dodać `SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE` i syntax `1.5.0`.
+   - Parser zapisuje feature usage na exact location contextual `@header`. Legacy początkowy `## Heading` nie wymaga nowej wersji.
+   - Wydzielić browser-safe `collectSyntaxCompatibilityIssues(ast)` w core. Node i browser resolver uruchamiają collector dla każdego root, inherited, imported i inline-composed AST bezpośrednio po parse i propagują issues w `ResolvedAST`, także gdy późniejsza resolution failuje.
+   - PS018 pozostaje jedynym właścicielem message, configured severity/off policy i fix suggestion. Parser nadaje usage stabilne ID. Compiler deduplikuje collected oraz direct-validator issue przez `usage.id`, z compatibility fallback `file + (offset ?? line:column) + feature`.
+   - Plik z `@header` i syntax niższym niż `1.5.0` dostaje PS018 na directive location. Warning policy nie zmienia semantics; issue nie może zostać utracone przez późniejszy resolver error.
+   - `prs validate --fix` używa collected usage nawet po resolver error i podnosi deklarację do minimum `1.5.0`.
+   - Dodać monotonic registry test i zachować usage record przez destructive resolver passes.
+
+3. **Centralny resolver tytułów**
+   - Rozszerzyć istniejący contract do jednego core `SECTION_REGISTRY`, używanego przez validator, section parity i title resolution.
+   - Zachować formatter `KNOWN_SECTIONS` jako deprecated, generated compatibility projection `SECTION_REGISTRY.map(...)`. Nie utrzymywać drugiej ręcznej listy.
+   - Dodać `SectionTitleResolver` w `packages/formatters/src`, przyjmujący AST, section key, formatter config i entry z `SECTION_REGISTRY`.
+   - Registry przechowuje default title, primary owner block, ordered fallback owner blocks, source blocks oraz informację, czy key jest primary czy derived dla danego ownera.
+   - Każdy entry ma canonical kebab-case `id` i optional legacy formatter config aliases. Resolver normalizuje aliases do ID przed owner lookup.
+   - Ustalić source precedence dla sekcji złożonych:
+     - `Project`: `identity`, potem `context`;
+     - `Tech Stack`: `context`, potem `standards`;
+     - `Commands`: `shortcuts`, potem derived `knowledge.commands`;
+     - `Architecture` i `Context`: `context`;
+     - standards subsections: odpowiedni `@header <section-key>` z `standards`.
+   - Dla każdego section key pierwszy owner posiadający explicit source override wygrywa. Brak override we wszystkich ownerach przechodzi do formatter config, potem default.
+   - Przenieść wszystkie human-readable titles do `SectionNameKey`, w tym inline `Project`, `Tech Stack`, `Architecture`, `Context`, `Commands`, `Documentation`, `Diagrams`, `Knowledge`, `Examples`, `Required Context`, `Restrictions` i tytuły subsection generowane przez formatter-specific paths.
+   - Zastąpić inline literals w `addCommonSections` i metodach derived sections resolverem.
+   - Dodać adapter API dla formatterów, które nie dziedziczą po `MarkdownInstructionFormatter`.
+   - Dodać inventory test, który sprawdza wszystkie formatter paths emitujące human-readable heading. Nowy hardcoded heading wymaga entry w registry albo jawnego komentarza, że jest user content.
+
+4. **Semantyka bloków**
+   - Zdefiniować primary section, derived keys i owner precedence dla każdego built-in block.
+   - `@header "..."` działa wyłącznie dla primary section danego blocku. `@header <section-key> "..."` działa wyłącznie dla key zarejestrowanego dla tego blocku.
+   - Gdy block generuje kilka sekcji, derived entries działają niezależnie; brak wpisu używa default.
+   - Duplicate primary albo ten sam derived key w jednym body jest validation error. Kolejne explicit patches z inheritance/use/extend rozstrzyga merge policy.
+   - Inheritance: parent presentation jest base, child explicit `@header` wygrywa per section key.
+   - Top-level i inline `@use`: zachować source/import-wins policy z #330 per section key.
+   - `BlockOperation` i `ExtendOperation` przechowują `presentationPatch` obok body. `@extend` używa last-explicit-wins per section key, bez konkatenacji.
+   - Explicit `@header` ma wyższy rank niż legacy heading niezależnie od operation layer. Dwa explicit candidates rozstrzyga operation policy powyżej; dwa legacy candidates również. Incoming legacy heading nie nadpisuje istniejącego explicit `@header`.
+   - #349 używa `BlockReplacement { body, presentation }`. Root `@override` zastępuje oba atomowo; brak metadata usuwa wcześniejsze metadata.
+   - Root `@override` resetuje poprzedni rank wraz z całym presentation state, więc replacement legacy heading jest skuteczny, jeśli replacement nie zawiera explicit `@header`.
+   - Nested `@override` nie adresuje presentation metadata. Pełne presentation replacement jest dostępne przez root block replacement; scoped title update używa `@extend` z `@header`.
+   - Empty/whitespace header jest błędem, nie fallbackiem.
+
+5. **Formattery**
+   - Zaktualizować wszystkie formattery i common renderer.
+   - Sprawdzić osobne implementations w Claude, GitHub, Factory i pozostałych targetach, które kopiują `project`, `architecture`, `context`, `commands`, `postWork` albo knowledge extraction zamiast dziedziczyć common path.
+   - Override zmienia tylko human-readable title. Nie zmienia JSON/TOML/YAML keys, filenames, frontmatter property names ani native protocol fields.
+   - Dla targetów wieloplikowych registry wskazuje, które nagłówki w plikach dodatkowych są user-visible sections. Nazwa pliku nie wynika z override.
+   - Zachować target-specific heading syntax; override jest tylko tekstem tytułu, nie surowym Markdown.
+
+6. **Docs i tooling**
+   - Dodać jedną sekcję reference z canonical syntax i mapą section keys.
+   - Udokumentować owner i fallback owner każdego section key, zwłaszcza `Project`, `Tech Stack` i `Commands`.
+   - Pokazać przykład językowy, angielski i title z Unicode.
+   - `header` i `headers` pozostają zwykłymi identifier fields. `@header` jest contextual directive bez osobnego parser tokenu.
+   - Zaktualizować Pygments, VS Code TextMate i Playground Monaco dla `@header`; rozszerzyć `grammar:check` o contextual directive parity.
+   - Opisać legacy `##` fallback i ograniczenie do headinga początkowego.
+
+## Testy i weryfikacja
+
+- AST: extraction contextual `@header`, loc, inheritance i `@use`.
+- Syntax: `1.5.0` accepts `@header`; lower version reports exact directive even when later resolution fails; legacy heading remains available.
+- Transitive syntax: lower-version parent, import i inline skill z `@header` raportują własny source location przed composition.
+- Syntax diagnostics: PS018 pojawia się raz, zachowuje configured severity/off policy i pozostaje fixable po resolver error.
+- Legacy heading: consumed raz, brak duplicated heading, remainder body bez utraty treści.
+- Scope regression: built-in/custom `header`/`headers` fields i nested `mcpServers.*.headers` pozostają domain data.
+- Validator: unknown/unowned key, empty/non-string title i duplicate key.
+- Formatter: override i default dla każdego common section key.
+- Composite sections: owner precedence dla `Project`, `Tech Stack` i `Commands`, także gdy oba source blocks istnieją.
+- Merge precedence: inheritance child-wins, use source/import-wins, extend last-explicit-wins, root override complete replacement.
+- Presentation rank: explicit zawsze wygrywa z legacy w inheritance/use/extend; same-rank conflicts używają operation policy; root override resetuje rank.
+- Key compatibility: canonical `git-commits` i legacy formatter config alias `gitCommits` rozwiązują ten sam registry entry.
+- Cross-formatter: Claude, Factory, Copilot, Cursor i formatter bez Markdown base.
+- Structured outputs: JSON/TOML/YAML keys, filenames i protocol fields pozostają identyczne.
+- Regression: cała treść blocku nadal występuje, nie tylko zmieniony header.
+- Inventory: brak hardcoded human-readable title omijającego registry.
+- Registry compatibility: `KNOWN_SECTIONS` jest generowane z `SECTION_REGISTRY`, a section parity i title defaults nie mogą się rozjechać.
+- Golden diff: zaakceptować tylko intentional title changes.
+
+## Kryterium gotowości
+
+- Jeden source-level contract działa dla wszystkich formatterów.
+- Contextual metadata nie przechwytuje built-in, custom ani nested domain fields.
+- Każda sekcja złożona ma deterministycznego ownera i fallback precedence.
+- Brak hardcoded title path omijających resolver.
+- Stary `.prs` bez metadata generuje identyczne nagłówki.
+- `@header` nie zanieczyszcza danych domenowych blocku; zwykłe `header`/`headers` pozostają nietknięte.

--- a/docs/design/issue-plans/331-section-header-overrides.md
+++ b/docs/design/issue-plans/331-section-header-overrides.md
@@ -31,8 +31,9 @@ Canonical form:
 - Canonical public section keys używają kebab-case IDs z `SECTION_REGISTRY`, np. `git-commits`. Existing formatter config keys, np. `gitCommits`, są compatibility aliases mapowanymi jawnie w tym samym registry.
 - `@header` jest contextual presentation entry w ordered body, nie zwykłym property i nie globalnym lexer keywordem.
 - Zwykłe fields `header` i `headers` pozostają domain data w każdym built-in i custom blocku. Nested fields, w tym `mcpServers.<name>.headers`, nigdy nie są presentation metadata.
-- Dla text-only block pierwszy heading `## ...` na początku tekstu pozostaje legacy fallbackiem. Gdy występuje obok `@header`, wygrywa `@header`.
-- Legacy fallback konsumuje dokładnie pierwszy heading line z body i emituje go raz jako resolved title. Pozostały text body zachowuje byte-equivalent content poza usuniętą linią headinga i jednym bezpośrednim newline. Heading poza początkiem body pozostaje zwykłą treścią.
+- Dla syntax `1.5.0+` pierwszy heading `## ...` na początku text-only blocku może działać jako fallback tylko wtedy, gdy block jest registered primary-section owner z `legacyHeadingFallback: true`. Custom i nieuprawnione built-in blocks zachowują heading jako body text. Gdy fallback występuje obok `@header`, wygrywa `@header`.
+- Dla syntax do `1.4.x` heading pozostaje zwykłą body treścią i existing output jest byte-compatible. Nie konsumować go ani nie zmieniać generated default title.
+- W `1.5.0+` fallback konsumuje dokładnie pierwszy heading line z body i emituje go raz jako resolved title. Pozostały text body zachowuje byte-equivalent content poza usuniętą linią headinga i jednym bezpośrednim newline. Heading poza początkiem body pozostaje zwykłą treścią.
 - Priorytet: source override > formatter config `sectionNames` > built-in default.
 
 ## Plan implementacji
@@ -41,18 +42,19 @@ Canonical form:
    - Użyć `BlockPresentation` wprowadzonego w #330; #331 jest właścicielem semantyki i validation tego typu.
    - Dodać canonical `PresentationEntry` do ordered `BlockEntry`: explicit primary, explicit derived albo legacy heading entry, każdy z title i exact location.
    - `PresentationEntry` nie wpływa na `BlockBody.shape`; shape jest wyliczany tylko z text/field/list entries.
-   - `PresentationEntry` w ordered body jest jedynym parsed source. `Block.presentation` i operation `presentationPatch` są mandatory derived, deep-readonly projections regenerowane przez AST factory po każdej transformacji. Konsumenci nie mogą mutować ani niezależnie serializować obu form.
+   - `PresentationEntry` w ordered body jest jedynym parsed source. `CanonicalBlock.presentation` i operation `presentationPatch` są mandatory derived, deep-readonly projections regenerowane przez AST factory po każdej transformacji. Konsumenci nie mogą mutować ani niezależnie serializować obu form.
    - Grammar rozpoznaje `@header` entry wewnątrz dowolnego block body przez contextual identifier gate. Nie dodawać globalnego `Header` tokenu; zwykłe `header`/`headers` fields i custom names pozostają legalne.
    - Przenieść `SectionContract` i `SECTION_REGISTRY` do browser-safe core, ponieważ validator i formatters muszą czytać ten sam owner/key contract. `packages/formatters/src/section-registry.ts` re-exportuje core registry i compatibility helpers.
    - Visitor zachowuje entry, a validator importuje core `SECTION_REGISTRY` i pozwala presentation semantics tylko dla owner blocków. Custom block z `@header` dostaje unknown contextual directive diagnostic.
    - Zachować location dla directive, section key, title i legacy headinga. Diagnostics nie mogą wskazywać całego blocku.
    - Walidować: title musi być niepustym stringiem; optional key musi istnieć w `SECTION_REGISTRY` i należeć do owner blocku.
    - Nie interpretować dowolnych `##` wewnątrz tekstu jako override, aby nie niszczyć treści dokumentu.
-   - Normalizer zastępuje consumed heading line canonical `LegacyPresentationEntry` w tej samej pozycji, a pozostały text zapisuje jako sąsiedni `TextEntry`. Dzięki temu body nie renderuje headinga drugi raz, ale factory nadal może regenerować `Block.presentation.legacyHeader` wyłącznie z canonical entries.
+   - Normalizer tworzy `LegacyPresentationEntry` wyłącznie dla syntax `1.5.0+` i ownera, którego primary registry entry ma `legacyHeadingFallback: true`. Zastępuje consumed heading line w tej samej pozycji, a pozostały text zapisuje jako sąsiedni `TextEntry`.
+   - Dla syntax do `1.4.x` normalizer zachowuje cały heading w `TextEntry` i nie tworzy presentation projection. Dzięki temu stary output pozostaje identyczny.
 
 2. **Syntax versioning**
    - Dodać `SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE` i syntax `1.5.0`.
-   - Parser zapisuje feature usage na exact location contextual `@header`. Legacy początkowy `## Heading` nie wymaga nowej wersji.
+   - Parser zapisuje feature usage na exact location contextual `@header`. Legacy heading fallback aktywuje się dopiero dla deklaracji `1.5.0+`; niższa wersja zachowuje heading jako text i nie emituje PS018 za sam heading.
    - Wydzielić browser-safe `collectSyntaxCompatibilityIssues(ast)` w core. Node i browser resolver uruchamiają collector dla każdego root, inherited, imported i inline-composed AST bezpośrednio po parse i propagują issues w `ResolvedAST`, także gdy późniejsza resolution failuje.
    - PS018 pozostaje jedynym właścicielem message, configured severity/off policy i fix suggestion. Parser nadaje usage stabilne ID. Compiler deduplikuje collected oraz direct-validator issue przez `usage.id`, z compatibility fallback `file + (offset ?? line:column) + feature`.
    - Plik z `@header` i syntax niższym niż `1.5.0` dostaje PS018 na directive location. Warning policy nie zmienia semantics; issue nie może zostać utracone przez późniejszy resolver error.
@@ -63,12 +65,12 @@ Canonical form:
    - Rozszerzyć istniejący contract do jednego core `SECTION_REGISTRY`, używanego przez validator, section parity i title resolution.
    - Zachować formatter `KNOWN_SECTIONS` jako deprecated, generated compatibility projection `SECTION_REGISTRY.map(...)`. Nie utrzymywać drugiej ręcznej listy.
    - Dodać `SectionTitleResolver` w `packages/formatters/src`, przyjmujący AST, section key, formatter config i entry z `SECTION_REGISTRY`.
-   - Registry przechowuje default title, primary owner block, ordered fallback owner blocks, source blocks oraz informację, czy key jest primary czy derived dla danego ownera.
+   - Registry przechowuje default title, primary owner block, ordered fallback owner blocks, source blocks, `legacyHeadingFallback` oraz informację, czy key jest primary czy derived dla danego ownera.
    - Każdy entry ma canonical kebab-case `id` i optional legacy formatter config aliases. Resolver normalizuje aliases do ID przed owner lookup.
    - Ustalić source precedence dla sekcji złożonych:
      - `Project`: `identity`, potem `context`;
      - `Tech Stack`: `context`, potem `standards`;
-     - `Commands`: `shortcuts`, potem derived `knowledge.commands`;
+     - `Commands`: `shortcuts`, potem `commands`, potem derived `knowledge.commands`;
      - `Architecture` i `Context`: `context`;
      - standards subsections: odpowiedni `@header <section-key>` z `standards`.
    - Dla każdego section key pierwszy owner posiadający explicit source override wygrywa. Brak override we wszystkich ownerach przechodzi do formatter config, potem default.
@@ -112,11 +114,11 @@ Canonical form:
 - Syntax: `1.5.0` accepts `@header`; lower version reports exact directive even when later resolution fails; legacy heading remains available.
 - Transitive syntax: lower-version parent, import i inline skill z `@header` raportują własny source location przed composition.
 - Syntax diagnostics: PS018 pojawia się raz, zachowuje configured severity/off policy i pozostaje fixable po resolver error.
-- Legacy heading: consumed raz, brak duplicated heading, remainder body bez utraty treści.
+- Legacy heading: syntax do `1.4.x` zachowuje byte-compatible output; `1.5.0+` registered owner konsumuje fallback raz, bez duplicated heading i utraty remainder body; custom/unowned block zachowuje heading jako text.
 - Scope regression: built-in/custom `header`/`headers` fields i nested `mcpServers.*.headers` pozostają domain data.
 - Validator: unknown/unowned key, empty/non-string title i duplicate key.
 - Formatter: override i default dla każdego common section key.
-- Composite sections: owner precedence dla `Project`, `Tech Stack` i `Commands`, także gdy oba source blocks istnieją.
+- Composite sections: owner precedence dla `Project`, `Tech Stack` i `Commands`; Commands fixture zawiera jednocześnie `shortcuts`, `commands` i `knowledge.commands`.
 - Merge precedence: inheritance child-wins, use source/import-wins, extend last-explicit-wins, root override complete replacement.
 - Presentation rank: explicit zawsze wygrywa z legacy w inheritance/use/extend; same-rank conflicts używają operation policy; root override resetuje rank.
 - Key compatibility: canonical `git-commits` i legacy formatter config alias `gitCommits` rozwiązują ten sam registry entry.
@@ -133,5 +135,5 @@ Canonical form:
 - Contextual metadata nie przechwytuje built-in, custom ani nested domain fields.
 - Każda sekcja złożona ma deterministycznego ownera i fallback precedence.
 - Brak hardcoded title path omijających resolver.
-- Stary `.prs` bez metadata generuje identyczne nagłówki.
+- Stary `.prs` z syntax do `1.4.x` generuje identyczne nagłówki i body. Nowe fallback semantics są opt-in przez syntax `1.5.0+`.
 - `@header` nie zanieczyszcza danych domenowych blocku; zwykłe `header`/`headers` pozostają nietknięte.

--- a/docs/design/issue-plans/343-per-target-hook-commands.md
+++ b/docs/design/issue-plans/343-per-target-hook-commands.md
@@ -1,0 +1,129 @@
+# Issue #343 - per-target commands and scripts
+
+Issue: https://github.com/mrwogu/promptscript/issues/343
+
+## Cel
+
+Pozwolić target override wybrać własny `command` albo `script`, bez kopiowania całego hooka i bez utraty portable defaults.
+
+```promptscript
+@hooks {
+  validate: {
+    event: "post-tool-use"
+    script: {
+      path: ".promptscript/scripts/validate.py"
+      interpreter: "python3"
+    }
+    targets: {
+      factory: {
+        command: ["node", ".promptscript/scripts/factory.mjs"]
+      }
+      vscode: {
+        script: {
+          path: ".promptscript/scripts/vscode.py"
+          interpreter: "python3"
+        }
+      }
+    }
+  }
+}
+```
+
+## Stan obecny
+
+- `HookDefinition` i `HookTargetOverride` są w `packages/formatters/src/hook-adapters.ts:32`.
+- `extractHooks` nie odczytuje `command` ani `script` w target override.
+- `applyHookTargetOverrides` robi płaski spread, więc resource override wymaga rozszerzenia typów i walidacji.
+- `valid-hooks.ts:240` ma osobną listę target fields.
+- Wszystkie target serializers korzystają z effective hook, więc zmiana może być centralna.
+
+## Decyzje
+
+- Target override może mieć najwyżej jedno z `command` i `script`.
+- Gdy nie ma żadnego, dziedziczy portable resource.
+- Target override nie może usunąć resource przez `null`, pusty command ani pusty script.
+- `command` zachowuje `string[]` i argument boundaries. Nigdy nie jest parsowany jako shell string.
+- `script` przechodzi ten sam safe path/interpreter contract co portable script.
+- Walidacja target script ma dwa etapy: AST/schema validation oraz filesystem containment validation po wybraniu effective resource.
+- Existing `matcher` remains optional target-native matcher override, także dla #345.
+- Disabled override (`enabled: false`) suppresses target output, jak obecnie.
+
+## Plan implementacji
+
+1. **Core hook model**
+   - Przenieść portable hook IR z `packages/formatters/src/hook-adapters.ts` do browser-safe modułu w core.
+   - Rozdzielić raw i validated IR: `RawHookDefinition`/`RawHookTargetOverride` zachowują unknown i malformed `ValueNode`; `HookDefinition`/`HookTargetOverride`/`HookResource` zawierają wyłącznie zwalidowane dane.
+   - Dodać pure conversion `validateHookDefinition(raw): HookValidationResult`, zwracające validated hook albo diagnostics bez silent filtering.
+   - Formatters re-exportują deprecated type aliases przez jedną wersję, aby nie łamać publicznych importów.
+   - Rozszerzyć core `HookTargetOverride` o `command?: string[]` i `script?: HookScriptDefinition`.
+   - Wydzielić pure `validateHookResource` w core, aby validator, compiler, browser compiler i target override używały jednej lexical/schema logiki bez dependency na formatters.
+   - `applyHookTargetOverrides` wykonać explicit merge: scalar fields override, resource wybierany atomowo. Zwrócić także origin metadata `portable | target:<name>` i source location effective resource.
+   - Nie mutować source hook ani nested targets.
+
+2. **Parser/extractor**
+   - Przenieść extractor do core hook IR. Formatters używają tego samego exported API.
+   - `extractRawHooks` zachowuje target command arrays, script objects, unknown target entries i malformed resource candidates wraz z `ValueNode.loc`.
+   - Validator wywołuje `validateHookDefinition`; compiler filesystem validator i formatters dostają tylko `HookDefinition[]`.
+   - Effective hook zawiera wyłącznie validated resource; serializer nie filtruje malformed values jako normalnego flow.
+
+3. **AST i semantic validator**
+   - Dodać fields do `TARGET_OVERRIDE_FIELDS`.
+   - Reject both fields, missing/empty command, non-string args, shell interpolation, unsafe script path, unsupported interpreter i malformed script args.
+   - Dla override script komunikat ma zawierać target i hook ID.
+   - Reuse exact portable lexical path policy: `.promptscript/scripts/`, no absolute/traversal/backslash.
+   - Czytać location z canonical `ObjectFieldNode`/`ValueNode` z #330. Diagnostic wskazuje location pola `targets.<target>.command` albo `targets.<target>.script`, nie tylko location całego `@hooks`.
+
+4. **Compiler filesystem validator**
+   - Rozszerzyć `packages/compiler/src/hook-script-validator.ts`, aby iterował portable script oraz każdy enabled target override script, nie tylko `hook.script`.
+   - Dla każdego kandydata wykonać `lstat`, `realpath`, file-type check i containment pod real `.promptscript/scripts/`.
+   - Symlink escape, missing file i non-file raportują hook ID, target/origin, path i source location.
+   - Jeden invalid target override zatrzymuje cały compile przed formatter output. Pozostałe poprawne targety nie maskują błędu.
+
+5. **Browser filesystem validator**
+   - Rozszerzyć `packages/browser-compiler/src/hook-script-validator.ts` o ten sam iteration/effective-resource contract.
+   - Rozszerzyć `VirtualFileSystem` o typed entries `file | directory | symlink`, `lstat`, `realpath` i deterministic symlink resolution z cycle detection. Existing `Map<string, string>` constructor nadal tworzy regular file entries dla compatibility.
+   - Rozszerzyć publiczny `BrowserCompileInput`/`compile()` o `Record<string, string | VirtualFileEntry> | Map<string, string | VirtualFileEntry>` oraz convenience builders `file()`, `directory()`, `symlink()`. Existing `Record<string, string>` i `Map<string, string>` pozostają source-compatible.
+   - Dodać named exports `VirtualFileEntry`, `VirtualFileKind`, `file`, `directory` i `symlink` z `@promptscript/browser-compiler` package entrypoint. Bez deep importów.
+   - Zachować `toMap(): Map<string, string>` i `toObject(): Record<string, string>` jako deprecated regular-file-only projections. Jeśli VFS zawiera directory lub symlink, te metody rzucają actionable error zamiast gubić typ wpisu.
+   - Dodać lossless `toEntryMap()` i `toEntryObject()` dla typed entries. `clone()` i `merge()` zawsze zachowują entry kind, symlink target i file content; merge używa obecnej other-wins path precedence.
+   - Normalizować VFS path i wymagać containment pod project `.promptscript/scripts/` dla portable oraz target scripts.
+   - Browser validator odrzuca symlink escape, dangling link, cycle, directory i unknown entry type. Adapter bez typed metadata może dostarczyć tylko regular files; nie może oznaczyć opaque entry jako bezpiecznej.
+   - Parity tests porównują hook ID, target, error code i exact source location między Node i browser dla regular file, missing file, directory, symlink escape, dangling symlink i cycle.
+
+6. **Serializers**
+   - Przepiąć wszystkie `generate*Hooks` na effective resource.
+   - Sprawdzić Factory, GitHub, VS Code, Claude, Cursor, Codex, Gemini, Windsurf i Grok.
+   - Dla targetów z osobnym Unix/Windows commandem utrzymać oba warianty.
+   - Ownership marker nadal jest final tokenem dla generated command.
+   - Native serializers nie mogą flattenować command arrays w sposób zmieniający quoting.
+   - Command override z `cwd` używa root strategy i fail-closed guards z #346. Serializer nie może ominąć guard tylko dlatego, że resource nie jest script.
+
+7. **Docs**
+   - Dodać per-target override examples do `docs/reference/language.md` i automation guide.
+   - Zdefiniować inheritance order: target override resource > portable resource; other portable properties unchanged.
+   - Opisać, że override `enabled: false` emituje zero entry.
+
+## Testy i weryfikacja
+
+- AST validator: exactly-one, empty command, shell interpolation, invalid path/interpreter, valid fallback i precise target field location.
+- Node filesystem validator: valid target script, missing file, directory, traversal i symlink escape dla portable oraz każdego override.
+- Browser validator: target script VFS containment, regular file, missing path, directory, symlink escape, dangling symlink, cycle i Node parity.
+- Browser convenience API: typed VFS entries przechodzą przez publiczne `compile()`, nie tylko internal validator.
+- Browser input compatibility: typed Record i Map działają identycznie; istniejące string-only Record/Map zachowują wynik.
+- Browser package API: consumer fixture importuje wszystkie typed VFS types/builders z package root, kompiluje TypeScript i wykonuje Record oraz Map input przez publiczne `compile()`.
+- VFS compatibility: legacy exports działają dla regular files i failują jawnie dla typed-only entries; lossless exports, clone i merge zachowują wszystkie entry metadata.
+- Public API: stare imports typów hooków z formatters nadal działają przez deprecated re-exports.
+- Raw/validated boundary: malformed resource pozostaje w raw IR z location, nie dociera do filesystem validatora ani serializerów.
+- Extractor: command/script inheritance and target override parsing.
+- Adapter unit tests for every target family.
+- Factory/GitHub/VS Code snapshots with spaces and special characters in args/path.
+- Unix/PowerShell command generation and ownership marker.
+- Integration compile with target overrides plus repeated compile/cleanup fixture from #347.
+
+## Kryterium gotowości
+
+- One hook source can select different safe resources per target.
+- Missing override resource falls back predictably.
+- Invalid override fails validation before output generation.
+- Portable i target scripts przechodzą ten sam two-stage safety contract w Node i browser compilerze.
+- No target serializer duplicates override merge logic.

--- a/docs/design/issue-plans/343-per-target-hook-commands.md
+++ b/docs/design/issue-plans/343-per-target-hook-commands.md
@@ -25,6 +25,7 @@ Pozwolić target override wybrać własny `command` albo `script`, bez kopiowani
         }
       }
     }
+    cwd: "project"
   }
 }
 ```
@@ -74,13 +75,16 @@ Pozwolić target override wybrać własny `command` albo `script`, bez kopiowani
    - Czytać location z canonical `ObjectFieldNode`/`ValueNode` z #330. Diagnostic wskazuje location pola `targets.<target>.command` albo `targets.<target>.script`, nie tylko location całego `@hooks`.
 
 4. **Compiler filesystem validator**
-   - Rozszerzyć `packages/compiler/src/hook-script-validator.ts`, aby iterował portable script oraz każdy enabled target override script, nie tylko `hook.script`.
+   - Compiler buduje `SelectedHookRuntimeTargets` z loaded formatterów, output versions i nested emission contexts, np. VS Code przez GitHub formatter tylko przy `targets.vscode`.
+   - Rozszerzyć `packages/compiler/src/hook-script-validator.ts`, aby iterował portable script używany przez selected targets oraz każdy enabled selected target override script, nie tylko `hook.script`.
+   - Lexical/schema validator nadal sprawdza wszystkie declared overrides. Filesystem existence/realpath validation nie blokuje compile przez poprawny, lecz unselected target resource.
    - Dla każdego kandydata wykonać `lstat`, `realpath`, file-type check i containment pod real `.promptscript/scripts/`.
    - Symlink escape, missing file i non-file raportują hook ID, target/origin, path i source location.
    - Jeden invalid target override zatrzymuje cały compile przed formatter output. Pozostałe poprawne targety nie maskują błędu.
 
 5. **Browser filesystem validator**
    - Rozszerzyć `packages/browser-compiler/src/hook-script-validator.ts` o ten sam iteration/effective-resource contract.
+   - Browser compiler przekazuje ten sam `SelectedHookRuntimeTargets` derived z requested formatterów/versions; selection semantics muszą być identyczne z Node.
    - Rozszerzyć `VirtualFileSystem` o typed entries `file | directory | symlink`, `lstat`, `realpath` i deterministic symlink resolution z cycle detection. Existing `Map<string, string>` constructor nadal tworzy regular file entries dla compatibility.
    - Rozszerzyć publiczny `BrowserCompileInput`/`compile()` o `Record<string, string | VirtualFileEntry> | Map<string, string | VirtualFileEntry>` oraz convenience builders `file()`, `directory()`, `symlink()`. Existing `Record<string, string>` i `Map<string, string>` pozostają source-compatible.
    - Dodać named exports `VirtualFileEntry`, `VirtualFileKind`, `file`, `directory` i `symlink` z `@promptscript/browser-compiler` package entrypoint. Bez deep importów.
@@ -106,7 +110,8 @@ Pozwolić target override wybrać własny `command` albo `script`, bez kopiowani
 ## Testy i weryfikacja
 
 - AST validator: exactly-one, empty command, shell interpolation, invalid path/interpreter, valid fallback i precise target field location.
-- Node filesystem validator: valid target script, missing file, directory, traversal i symlink escape dla portable oraz każdego override.
+- Node filesystem validator: valid target script, missing file, directory, traversal i symlink escape dla portable oraz każdego selected override.
+- Target selection: invalid filesystem resource w unselected target nie blokuje outputu; wybranie tego targetu failuje przed formatter output.
 - Browser validator: target script VFS containment, regular file, missing path, directory, symlink escape, dangling symlink, cycle i Node parity.
 - Browser convenience API: typed VFS entries przechodzą przez publiczne `compile()`, nie tylko internal validator.
 - Browser input compatibility: typed Record i Map działają identycznie; istniejące string-only Record/Map zachowują wynik.

--- a/docs/design/issue-plans/344-compile-time-factory-migration.md
+++ b/docs/design/issue-plans/344-compile-time-factory-migration.md
@@ -27,6 +27,7 @@ Podczas `prs compile` przenieść jednoznaczne, user-owned legacy Factory hooks 
 - `prs hooks install factory` nadal używa tego samego pure helpera i zachowuje obecny safe behavior.
 - `promptscript.lock` jest dependency lockfile, nie concurrency lock. Migracja wymaga osobnego compile-wide lock.
 - Dwa `rename` nie są prawdziwą filesystem transaction. Gwarancja oznacza: rollback po obsłużonym błędzie oraz recovery journal po przerwaniu procesu.
+- Symlink hardening odrzuca pre-existing escape i wykryte zmiany podczas transaction, ale nie gwarantuje containment przeciw malicious same-privilege processowi ignorującemu compile lock i wykonującemu ancestor swap. Pełna taka gwarancja wymaga handle-relative `openat`/`renameat` primitives, których cross-platform Node API nie udostępnia.
 
 ## Plan implementacji
 
@@ -58,6 +59,9 @@ Podczas `prs compile` przenieść jednoznaczne, user-owned legacy Factory hooks 
    - `compileCommandWithResult` przyjmuje internal `CompileExecutionContext` z acquired tokenem. Nested calls z `--all-builds` używają tego tokenu i nie próbują nabyć locka ponownie.
    - `--all-builds` nabywa jeden lock przed pierwszym profilem i zwalnia po ostatnim success/error report. Inny compile nie może wejść między profile.
    - Lock key obejmuje canonical project root i output root. Profile piszące do różnych output roots nadal należą do jednej outer invocation; lista roots jest sortowana przed acquire, aby uniknąć deadlocku.
+   - Candidate filename koduje validated PID, process start timestamp i random owner token przed `open`, np. `.promptscript-compile.lock.candidate.<pid>.<start>.<token>`. Candidate powstaje przez injected `open(candidate, 'wx')`, otrzymuje kompletne metadata, `FileHandle.sync()` i parent fsync. Dopiero atomic `link(candidate, lockPath)` publikuje lock; `EEXIST` oznacza przegraną bez nadpisania ownera. Po successful link usunąć candidate i fsync parent. `exists` plus `writeFile` na final lock path jest zabronione.
+   - Crash przed metadata write albo `link` może zostawić wyłącznie candidate z owner identity w filename, nigdy pusty final lock. Startup skanuje tylko exact candidate pattern, wymaga regular non-symlink file i usuwa candidate wyłącznie, gdy filename PID nie żyje. Live/PID-reused candidate nie blokuje final lock acquisition i może pozostać do późniejszego cleanup. Malformed candidate name nie jest automatycznie usuwany. Malformed final lock nie jest zgadywany jako stale: compile failuje natychmiast z path i manual recovery guidance zamiast timeoutować bez wyjaśnienia.
+   - Multi-root acquire bierze sorted locks po kolei. Przy konflikcie zwalnia tylko wcześniej nabyte własne tokens i retryuje cały zestaw do timeoutu.
    - Lock file zawiera PID, project root, start time i random owner token. Release usuwa lock tylko przy zgodnym tokenie.
    - Stale recovery sprawdza żywotność procesu, nie tylko arbitralny 30-second age, aby nie przerwać długiego aktywnego compile.
    - Drugi compile czeka z timeoutem albo kończy actionable error. Nie może cicho pominąć kompilacji.
@@ -65,16 +69,17 @@ Podczas `prs compile` przenieść jednoznaczne, user-owned legacy Factory hooks 
    - Dry-run omija mutating lock i używa optimistic snapshot contractu. Normal compile nigdy nie korzysta z tego wyjątku.
 
 4. **Recoverable Factory transaction**
-   - Rozszerzyć `CliFileSystem` o wszystkie potrzebne primitives: `open`, `fsync`/`FileHandle.sync`, `rename`, `rm`, `lstat`, `realpath`, `mkdir`, `readFile`, `writeFile`, `readdir`, `chmod` i `exists`.
-   - Dodać utility zapisujący temp files w tych samych katalogach, sprawdzający każdy symlink ancestor i używający wyłącznie injected filesystem.
+   - Rozszerzyć `CliFileSystem` o wszystkie potrzebne primitives: `open`, `link`, `fsync`/`FileHandle.sync`, `rename`, `rm`, `lstat`, `realpath`, `mkdir`, `readFile`, `writeFile`, `readdir`, `chmod` i `exists`.
+   - Dodać utility zapisujący temp files w tych samych katalogach, sprawdzający każdy symlink ancestor i używający wyłącznie injected filesystem. Pre/post `lstat`/`realpath` oraz exclusive no-follow final open, gdy platforma je wspiera, failują przy wykrytej zmianie. Dokumentować powyższą same-privilege race boundary zamiast obiecywać pełne handle-relative containment.
    - Przed commit utworzyć backups poprzednich plików oraz fsync temp/backup content i parent directories. Jeśli platforma nie wspiera durability primitive, migration kończy się actionable error zamiast obniżać gwarancję po cichu.
    - Zapisać recovery journal z owner token, original paths, original/new content fingerprints, temp paths, backup paths i phase przed pierwszym rename. Journal content i parent directory muszą być durable przed destination rename.
    - Commit order: canonical hooks, legacy settings, journal complete. Po każdym rename fsync odpowiedni parent directory; complete phase także jest durable.
    - Usunąć backups i journal dopiero po obu udanych writes. Po cleanup fsync parent directories.
    - Przy obsłużonym błędzie drugiego rename odtworzyć previous states tylko wtedy, gdy current destination fingerprints odpowiadają phase zapisanej w journalu i backup fingerprints są zgodne. Unknown mismatch blokuje automatyczną mutację.
    - Przy startup pod compile lockiem wykryć incomplete journal. Rollback jest dozwolony wyłącznie dla original/new fingerprints znanych z journalu oraz zweryfikowanych backups.
-   - Completed journal po crashu przed cleanup nie jest rollbackowany automatycznie. Recovery weryfikuje oba new fingerprints: zgodne destinations finalizują cleanup.
-   - Każdy unknown/tampered destination albo backup fingerprint zachowuje wszystkie destinations, backups, temp files i journal bez zmian, kończy compile actionable manual-recovery error i nie nadpisuje możliwych post-crash user edits.
+   - Completed journal po crashu przed cleanup nie jest rollbackowany automatycznie. Recovery weryfikuje oba new fingerprints: zgodne destinations finalizują cleanup idempotentnie.
+   - W completed phase każdy existing backup/temp musi mieć journaled fingerprint przed usunięciem; absent cleanup artifact oznacza już wykonany krok i nie jest tampering. Journal znika dopiero po zweryfikowaniu destinations i usunięciu albo potwierdzeniu absence wszystkich cleanup artifacts.
+   - Każdy unknown/tampered destination albo existing backup/temp fingerprint zachowuje wszystkie pozostałe destinations, backups, temp files i journal bez zmian, kończy compile actionable manual-recovery error i nie nadpisuje możliwych post-crash user edits.
    - Testy oraz docs nazywają to recoverable transaction, nie pojedynczym atomowym rename wielu plików.
    - Nie usuwać legacy file, jeśli po migracji pozostają unknown/ambiguous entries.
 
@@ -99,13 +104,14 @@ Podczas `prs compile` przenieść jednoznaczne, user-owned legacy Factory hooks 
 - Filesystem boundary: injected service przechwytuje każdy output-state read oraz write/rename/remove/chmod/fsync od wejścia w locked output lifecycle; test failuje przy bezpośrednim Node fs callu wewnątrz tej granicy.
 - Recoverable failure: inject failure między renames i assert previous files restored.
 - Crash recovery: zostawić journal po każdej incomplete commit phase, uruchomić kolejny compile i assert guarded rollback przed nowym write. Durable complete phase podlega osobnemu finalize testowi, nie rollback assertion.
-- Completed-journal recovery: crash po durable complete przed cleanup finalizuje zgodne destinations; tampered/missing destination lub backup nie powoduje overwrite, zachowuje evidence i wymaga manual recovery.
+- Completed-journal recovery: crash po durable complete przed każdym cleanup step finalizuje zgodne destinations; już usunięty backup/temp jest akceptowany, existing tampered artifact albo tampered/missing destination zachowuje evidence i wymaga manual recovery.
 - Incomplete-journal safety: known phase fingerprints rollbackują; unknown post-crash edits zatrzymują recovery bez mutacji.
 - Concurrency: dwa direct compile, hook-triggered compile i watch recompile nie zapisują równolegle; drugi proces nie jest cicho pomijany.
 - Multi-build concurrency: jeden outer lock obejmuje wszystkie profiles, bez interleaving i self-deadlocku.
 - Long compile: active lock starszy niż 30 sekund nie jest uznany za stale, jeśli owner process żyje.
 - Lock ownership: proces nie usuwa locka z obcym owner tokenem.
-- Symlink ancestors: staging i backups nie wychodzą poza project/output root.
+- Atomic locking: concurrent creators publikują complete durable candidates przez hard link; dokładnie jeden nabywa key, crash bezpośrednio po candidate open zostawia filename z dead PID i nie tworzy final lock, malformed final metadata daje immediate actionable error, a multi-root conflict zwalnia tylko własne partial locks przed retry.
+- Symlink ancestors: pre-existing escape i injected mid-transaction detected swap failują; docs/test threat boundary nie obiecuje ochrony przed malicious same-privilege race bez handle-relative primitives.
 - Dry-run: no file mutation, planned actions visible.
 - Dry-run concurrency: brak lock file; stable snapshot daje report, concurrent mutation daje retry error, concurrent dry-runs nie blokują się.
 - Opt-out: warning preserved, no migration.

--- a/docs/design/issue-plans/344-compile-time-factory-migration.md
+++ b/docs/design/issue-plans/344-compile-time-factory-migration.md
@@ -1,0 +1,124 @@
+# Issue #344 - safe compile-time Factory hook migration
+
+Issue: https://github.com/mrwogu/promptscript/issues/344
+
+## Cel
+
+Podczas `prs compile` przenieść jednoznaczne, user-owned legacy Factory hooks z `.factory/settings.json` do `.factory/hooks.json`, bez utraty ustawień i bez częściowej migracji.
+
+## Stan obecny
+
+- `packages/cli/src/utils/legacy-factory-hooks.ts:115` ma pure `migrateLegacyFactoryHooks`.
+- `packages/cli/src/commands/hooks.ts:79` używa migracji przy `prs hooks install factory`.
+- `packages/cli/src/commands/compile.ts:895` tylko wykrywa legacy hooks i emituje warning.
+- `writeOutputs` ma dry-run, ownership merge i cleanup, ale compile migration nie jest częścią write transaction.
+
+## Decyzje
+
+- Default compile migration uruchamia się wyłącznie, gdy `.factory/hooks.json` nie istnieje.
+- Gdy canonical file istnieje, compile pozostaje warning-only. Explicit merge mode może być osobnym follow-upem, nie ukrytą zmianą zachowania.
+- Dodać `--no-migrate-legacy-hooks` jako opt-out warning-only. Flagę propagować także do watch recompiles.
+- Migracja jest all-or-nothing: unknown event, malformed entry, mixed ambiguous handler, malformed JSON lub malformed canonical shape zatrzymuje całą migrację.
+- Unrelated keys w `settings.json` pozostają value-semantically identyczne. Writer zachowuje wykryte indentation i EOL, ale nie obiecuje byte equality po JSON serialization.
+- PromptScript-owned entries nie są przenoszone jako user entries i nie mogą się zdublować.
+- Dry-run tylko raportuje canonical write, legacy cleanup i count; nie tworzy plików.
+- Dry-run nie tworzy concurrency locka. Wykonuje read-only optimistic snapshot: fingerprintuje oba Factory documents i managed output state przed analizą, odczytuje je ponownie przed reportem, a przy zmianie kończy się actionable retry error. Concurrent dry-runs są dozwolone.
+- Gdy legacy Factory hooks są aktywne, lecz migration jest wyłączona, ambiguous albo malformed, compile nie może utworzyć `.factory/hooks.json`, ponieważ canonical file wyłączyłby legacy fallback. Inne target outputs mogą powstać, ale Factory canonical write jest suppressed i compile zwraca warning-only diagnostic z remediation.
+- `prs hooks install factory` nadal używa tego samego pure helpera i zachowuje obecny safe behavior.
+- `promptscript.lock` jest dependency lockfile, nie concurrency lock. Migracja wymaga osobnego compile-wide lock.
+- Dwa `rename` nie są prawdziwą filesystem transaction. Gwarancja oznacza: rollback po obsłużonym błędzie oraz recovery journal po przerwaniu procesu.
+
+## Plan implementacji
+
+1. **Migration analysis API**
+   - Rozszerzyć result helpera o reason/status: `migratable`, `ambiguous`, `malformed`, `unchanged`.
+   - Dodać rozróżnienie absent canonical, existing canonical i malformed canonical.
+   - Zwracać deterministic paths, entries, count, next canonical document i next legacy document do wykorzystania przez CLI.
+   - Nie mieszać I/O z klasyfikacją hook ownership.
+   - Porównywać unrelated settings po parsed values. Serialization zachowuje wykryte indentation, trailing newline i EOL, ale key order/whitespace nie jest częścią kontraktu.
+
+2. **Compile integration**
+   - Compiler nadal produkuje in-memory outputs. CLI przejmuje filesystem lifecycle po udanym compile.
+   - Przed jakimkolwiek read-modify-write outputów nabyć compile-wide lock i pod lockiem ponownie odczytać `.factory/hooks.json`, `.factory/settings.json` oraz managed output state.
+   - Gdy Factory target jest wybrany i canonical file jest absent, połączyć migratable user entries z generated canonical output w pamięci i deduplicate stable serialization.
+   - Jeśli formatter nie wygenerował `.factory/hooks.json`, utworzyć canonical seed `{ hooks: {} }`, dodać migrated user entries i zarejestrować path jako transaction-owned mixed-ownership output. Późniejszy cleanup nie może usunąć user-only canonical file.
+   - Gdy canonical istnieje, zachować warning-only i nie zmieniać legacy settings; fallback jest już canonical.
+   - Gdy canonical nie istnieje, ale legacy hooks są ambiguous/malformed albo opt-out jest aktywny, usunąć `.factory/hooks.json` z `FilesystemPlan`, nie uruchamiać Factory cleanup i pozostawić legacy settings nietknięte. Diagnostic wyjaśnia, że canonical output został celowo suppressed, aby nie wyłączyć aktywnych legacy hooks.
+   - W warning-only message podać realne remediation: popraw ambiguous entries albo uruchom `prs hooks install factory` po ręcznym przeglądzie. Nie dokumentować nieistniejącego `--migrate-legacy-hooks`.
+   - Zbudować jeden `FilesystemPlan` przed write. Plan rozdziela normal outputs/cleanup od dwóch transaction-owned Factory paths.
+   - Wyłączyć transaction-owned `.factory/hooks.json` i `.factory/settings.json` z normalnego `writeOutputs` oraz cleanup, aby żaden path nie był zapisany dwa razy.
+   - Wykonać normal writes i cleanup przed Factory transaction. Jeśli wcześniejszy krok zawiedzie, nie rozpoczynać migracji. Factory transaction jest ostatnim mutating krokiem przed success report.
+   - Przepiąć `writeOutputs`, ownership reads/rewrites, `cleanupManagedOutputs`, migration analysis, staging i recovery na jeden `CliFileSystem`. Żaden mutating call w compile path nie importuje bezpośrednio `fs/promises`.
+   - Granica injection obejmuje output lifecycle od pierwszego managed-output/Factory state read pod lockiem do finalnego reportu. Config loading i resolver source reads pozostają poza transaction boundary.
+
+3. **Compile-wide lock**
+   - Dodać osobny lock utility dla outer `compileCommand`; nie używać `promptscript.lock`.
+   - Lock obejmuje state reads, ownership merge, normal writes, cleanup, migration commit i success reporting.
+   - Obecny hook debounce lock nie może otaczać compile i jednocześnie powodować self-deadlock. Przenieść ownership locka do compile flow albo przekazywać jawny acquired lock token.
+   - `compileCommandWithResult` przyjmuje internal `CompileExecutionContext` z acquired tokenem. Nested calls z `--all-builds` używają tego tokenu i nie próbują nabyć locka ponownie.
+   - `--all-builds` nabywa jeden lock przed pierwszym profilem i zwalnia po ostatnim success/error report. Inny compile nie może wejść między profile.
+   - Lock key obejmuje canonical project root i output root. Profile piszące do różnych output roots nadal należą do jednej outer invocation; lista roots jest sortowana przed acquire, aby uniknąć deadlocku.
+   - Lock file zawiera PID, project root, start time i random owner token. Release usuwa lock tylko przy zgodnym tokenie.
+   - Stale recovery sprawdza żywotność procesu, nie tylko arbitralny 30-second age, aby nie przerwać długiego aktywnego compile.
+   - Drugi compile czeka z timeoutem albo kończy actionable error. Nie może cicho pominąć kompilacji.
+   - Watch recompiles używają tego samego lock boundary.
+   - Dry-run omija mutating lock i używa optimistic snapshot contractu. Normal compile nigdy nie korzysta z tego wyjątku.
+
+4. **Recoverable Factory transaction**
+   - Rozszerzyć `CliFileSystem` o wszystkie potrzebne primitives: `open`, `fsync`/`FileHandle.sync`, `rename`, `rm`, `lstat`, `realpath`, `mkdir`, `readFile`, `writeFile`, `readdir`, `chmod` i `exists`.
+   - Dodać utility zapisujący temp files w tych samych katalogach, sprawdzający każdy symlink ancestor i używający wyłącznie injected filesystem.
+   - Przed commit utworzyć backups poprzednich plików oraz fsync temp/backup content i parent directories. Jeśli platforma nie wspiera durability primitive, migration kończy się actionable error zamiast obniżać gwarancję po cichu.
+   - Zapisać recovery journal z owner token, original paths, original/new content fingerprints, temp paths, backup paths i phase przed pierwszym rename. Journal content i parent directory muszą być durable przed destination rename.
+   - Commit order: canonical hooks, legacy settings, journal complete. Po każdym rename fsync odpowiedni parent directory; complete phase także jest durable.
+   - Usunąć backups i journal dopiero po obu udanych writes. Po cleanup fsync parent directories.
+   - Przy obsłużonym błędzie drugiego rename odtworzyć previous states tylko wtedy, gdy current destination fingerprints odpowiadają phase zapisanej w journalu i backup fingerprints są zgodne. Unknown mismatch blokuje automatyczną mutację.
+   - Przy startup pod compile lockiem wykryć incomplete journal. Rollback jest dozwolony wyłącznie dla original/new fingerprints znanych z journalu oraz zweryfikowanych backups.
+   - Completed journal po crashu przed cleanup nie jest rollbackowany automatycznie. Recovery weryfikuje oba new fingerprints: zgodne destinations finalizują cleanup.
+   - Każdy unknown/tampered destination albo backup fingerprint zachowuje wszystkie destinations, backups, temp files i journal bez zmian, kończy compile actionable manual-recovery error i nie nadpisuje możliwych post-crash user edits.
+   - Testy oraz docs nazywają to recoverable transaction, nie pojedynczym atomowym rename wielu plików.
+   - Nie usuwać legacy file, jeśli po migracji pozostają unknown/ambiguous entries.
+
+5. **CLI options**
+   - Dodać `--no-migrate-legacy-hooks` do compile command help, parsera i watch callback.
+   - Dry-run output ma wymieniać: source, destination, migrated count, preserved settings, and whether legacy key would be removed.
+   - Exit/status semantics: ambiguity jest warning-only zgodnie z opt-out policy, filesystem/write error jest compile error.
+
+6. **Docs**
+   - Uzupełnić `docs/guides/hooks.md`, `docs/reference/cli/hooks.md` i compile CLI docs.
+   - Opisać trigger condition: canonical missing.
+   - Pokazać successful migration, warning-only ambiguity, malformed JSON, dry-run i opt-out.
+   - Opisać compile lock, recovery po interrupted migration i granicę gwarancji recoverable transaction.
+   - Wyraźnie rozdzielić language-level `@hooks` output od `prs hooks install`.
+
+## Testy i weryfikacja
+
+- Pure helper: unambiguous events, duplicates, owned entries, unknown events, malformed arrays, mixed handlers.
+- CLI integration: missing canonical, existing canonical, unrelated settings, malformed JSON, ambiguous entry, rerun idempotence.
+- CLI integration: migration tworzy canonical user-only file także wtedy, gdy source nie generuje żadnego Factory hooka.
+- Filesystem plan: transaction-owned paths nie trafiają do normal writer ani cleanup.
+- Filesystem boundary: injected service przechwytuje każdy output-state read oraz write/rename/remove/chmod/fsync od wejścia w locked output lifecycle; test failuje przy bezpośrednim Node fs callu wewnątrz tej granicy.
+- Recoverable failure: inject failure między renames i assert previous files restored.
+- Crash recovery: zostawić journal po każdej incomplete commit phase, uruchomić kolejny compile i assert guarded rollback przed nowym write. Durable complete phase podlega osobnemu finalize testowi, nie rollback assertion.
+- Completed-journal recovery: crash po durable complete przed cleanup finalizuje zgodne destinations; tampered/missing destination lub backup nie powoduje overwrite, zachowuje evidence i wymaga manual recovery.
+- Incomplete-journal safety: known phase fingerprints rollbackują; unknown post-crash edits zatrzymują recovery bez mutacji.
+- Concurrency: dwa direct compile, hook-triggered compile i watch recompile nie zapisują równolegle; drugi proces nie jest cicho pomijany.
+- Multi-build concurrency: jeden outer lock obejmuje wszystkie profiles, bez interleaving i self-deadlocku.
+- Long compile: active lock starszy niż 30 sekund nie jest uznany za stale, jeśli owner process żyje.
+- Lock ownership: proces nie usuwa locka z obcym owner tokenem.
+- Symlink ancestors: staging i backups nie wychodzą poza project/output root.
+- Dry-run: no file mutation, planned actions visible.
+- Dry-run concurrency: brak lock file; stable snapshot daje report, concurrent mutation daje retry error, concurrent dry-runs nie blokują się.
+- Opt-out: warning preserved, no migration.
+- Opt-out/ambiguity safety: przy absent canonical compile nie tworzy `.factory/hooks.json`, legacy hooks pozostają aktywne, inne target outputs nadal zapisują się.
+- Compile output: generated Factory hooks plus migrated user entries, no duplicates.
+- Existing `prs hooks install factory` tests remain green.
+- Cross-target fixture #347 covers migration during repeated compilation and cleanup.
+
+## Kryterium gotowości
+
+- Compile safely removes stale active legacy hooks only when migration is unambiguous.
+- Obsłużony write failure rollbackuje oba Factory documents. Interrupted commit jest naprawiany z journal pod lockiem przed kolejnym compile.
+- Canonical i settings paths mają jednego writera w compile lifecycle.
+- Concurrent compile nie może ominąć locka ani zostać cicho pominięty.
+- Rerun is idempotent.
+- User can opt out and receive actionable warning.

--- a/docs/design/issue-plans/345-terminal-command-event.md
+++ b/docs/design/issue-plans/345-terminal-command-event.md
@@ -66,9 +66,11 @@ Matrix wynika z obecnego `HOOK_RUNTIME_CAPABILITIES`: Cursor i Gemini już mają
    - Jeśli użytkownik poda matcher w target override, nie dopisywać drugiego default matcher.
    - Windsurf mapuje event bez matcher; VS Code używa `matcherEnforcement: 'payload-filter'`, ponieważ host ignoruje matcher field.
    - Factory, Claude i Codex emitują guaranteed mapping. Cursor, Gemini i VS Code emitują mapping wraz z best-effort diagnostic. GitHub i Grok nie emitują entry.
-   - Dla VS Code formatter emituje owned cross-platform Node helper `.promptscript/generated/vscode-hook-filter.mjs`. Hook entry przekazuje helperowi expected tool name, effective timeout w milliseconds i effective command array jako JSON arguments. Helper buforuje stdin, parsuje payload, sprawdza exact `tool_name`, uruchamia resource bez shell parsing i przekazuje oryginalny payload do child stdin. Non-match kończy się `0` bez uruchomienia user command/script.
+   - Dla VS Code formatter emituje owned cross-platform Node helper `.promptscript/generated/vscode-hook-filter.mjs`. Hook entry przekazuje helperowi expected tool name, child timeout w milliseconds, child cwd i effective command array jako JSON arguments. Helper buforuje stdin, parsuje payload, sprawdza exact `tool_name`, uruchamia resource bez shell parsing i przekazuje oryginalny payload do child stdin. Non-match kończy się `0` bez uruchomienia user command/script.
    - Jeśli payload schema jest malformed albo nie można go odczytać, wrapper failuje closed z non-zero i diagnostic; nie uruchamia user resource.
-   - Effective duration pochodzi z target override, portable `timeoutMs` albo documented VS Code default, w tej kolejności. Helper dostaje integer milliseconds; native VS Code hook dostaje `ceil(milliseconds / 1000)` seconds. Oba reprezentują tę samą duration, nie tę samą wartość liczbową.
+   - Native VS Code `cwd` field ustawia effective workspace/nested cwd dla helpera. Helper dostaje `childCwd: "."`, resolves je względem własnego `process.cwd()` i przekazuje jawnie do child spawn. Script argv używa existing native-CWD relative path adjustment, więc nested cwd nadal wskazuje repository script.
+   - Effective child duration pochodzi z target override, portable `timeoutMs` albo documented VS Code default, w tej kolejności. Helper dostaje integer milliseconds.
+   - Dodać stałe `VSCODE_FILTER_CLEANUP_GRACE_MS`. Native VS Code timeout dostaje `ceil((childTimeoutMs + cleanupGraceMs) / 1000)` seconds, dzięki czemu helper ma czas zakończyć child tree po własnym timerze.
    - Helper jest transparentnym process proxy: child stdout/stderr są dziedziczone, child exit code zostaje exit code helpera, spawn error daje non-zero diagnostic, a effective timeout obejmuje wrapper i child.
    - Helper forwarduje catchable termination signals do child process group i czeka na cleanup. Owned timeout kończy cały child tree, aby sentinel/resource nie został orphaned. Implementacja ma osobne Unix i Windows cleanup branches bez shell parsing.
    - Nie obiecywać cleanup po uncatchable hard kill, host crash ani machine loss. Docs opisują tę granicę; recovery takich procesów należy do hosta/OS.
@@ -107,7 +109,8 @@ Matrix wynika z obecnego `HOOK_RUNTIME_CAPABILITIES`: Cursor i Gemini już mają
 - Assertions for default matcher, override matcher, unsupported omission and best-effort warning.
 - VS Code runtime tests: matching payload uruchamia sentinel raz; non-matching payload nie uruchamia; malformed payload failuje closed; Unix i Windows command variants zachowują ownership marker.
 - VS Code proxy tests: child exit code, stdout, stderr i spawn error są propagowane; catchable SIGTERM i owned timeout usuwają child tree bez orphan process.
-- VS Code timeout tests: override/portable/default precedence, helper milliseconds i native rounded-up seconds.
+- VS Code cwd tests: project, nested i absent cwd; command oraz script sentinel wykonują się w expected directory.
+- VS Code timeout tests: override/portable/default precedence, helper milliseconds, cleanup grace i native rounded-up seconds, także dla exact whole-second child timeout.
 - Registry test: validator accepted events, formatter event type i capability docs są derived z core registries, bez równoległych list.
 - Emission context test: VS Code wskazuje GitHub `multifile/full` plus required override; każdy inny native target wskazuje realny formatter/version.
 - Assertion: target override matcher wygrywa z portable matcher, a portable matcher wygrywa z default.

--- a/docs/design/issue-plans/345-terminal-command-event.md
+++ b/docs/design/issue-plans/345-terminal-command-event.md
@@ -1,0 +1,125 @@
+# Issue #345 - explicit terminal command lifecycle event
+
+Issue: https://github.com/mrwogu/promptscript/issues/345
+
+## Cel
+
+Dodać portable `pre-terminal-command`, które opisuje intencję przechwycenia uruchomienia komendy terminala. Nie udawać uniwersalnego coverage tam, gdzie host nie ma równoważnego lifecycle event.
+
+```promptscript
+@hooks {
+  validate-terminal: {
+    event: "pre-terminal-command"
+    script: {
+      path: ".promptscript/scripts/check-terminal.py"
+      interpreter: "python3"
+    }
+  }
+}
+```
+
+## Decyzja coverage
+
+| Target   | Native mapping                           | Status                |
+| -------- | ---------------------------------------- | --------------------- |
+| Factory  | `PreToolUse`, default matcher `Execute`  | guaranteed            |
+| Claude   | `PreToolUse`, default matcher `Bash`     | guaranteed            |
+| Codex    | `PreToolUse`, default matcher `Bash`     | guaranteed            |
+| Windsurf | `pre_run_command`                        | guaranteed            |
+| VS Code  | `PreToolUse`/`run_in_terminal` matcher   | best effort           |
+| GitHub   | no cross-host equivalent                 | unsupported, `PS4002` |
+| Cursor   | `preToolUse`/`run_terminal_cmd` matcher  | best effort           |
+| Gemini   | `BeforeTool`/`run_shell_command` matcher | best effort           |
+| Grok     | no proven terminal contract              | unsupported, `PS4002` |
+
+Matrix wynika z obecnego `HOOK_RUNTIME_CAPABILITIES`: Cursor i Gemini już mają best-effort terminal metadata, a GitHub ma `not-guaranteed`. Implementacja rozszerza ten istniejący contract zamiast wprowadzać drugi registry. Unsupported rows nie emitują misleading hook entry.
+
+## Stan obecny
+
+- Portable events i target maps są w `hook-adapters.ts`.
+- Validator `VALID_HOOK_EVENTS` nie zawiera eventu.
+- Windsurf ma event fan-out, pozostałe targety mają mapy scalar.
+- `getHookCompatibilityWarnings` już raportuje unsupported events i matcher limitations.
+- `HookTargetOverride.matcher` istnieje i wystarcza jako optional native tool-name override.
+- `HookTerminalCapability` już przechowuje `guarantee`, `toolNames` i notes dla GitHub, Claude, Cursor, Factory, Gemini, Windsurf, Codex i VS Code.
+
+## Plan implementacji
+
+1. **Core contract**
+   - Wyeksportować `PORTABLE_HOOK_EVENTS` i derived `PortableHookEvent` z core. Usunąć ręczne `PortableHookEvent` z formatters i `VALID_HOOK_EVENTS` z validatora; obie warstwy importują core registry.
+   - Dodać `pre-terminal-command` wyłącznie do core `PORTABLE_HOOK_EVENTS`; validator i syntax docs korzystają z derived registry.
+   - Rozszerzyć istniejący `HookTerminalCapability` o `preEvent`, `defaultMatcher` i `emission: 'emit' | 'omit'`.
+   - Rozszerzyć capability o `matcherEnforcement: 'native' | 'payload-filter' | 'none'`.
+   - Dodać `emissionContexts: readonly HookEmissionContext[]`, gdzie context wskazuje formatter, output versions i optional `requiresTargetOverride`. VS Code deklaruje emitter `github`, versions `multifile/full` i wymaga `targets.vscode`; nie udaje osobnego formattera ani nie używa fikcyjnej wersji `workspace`.
+   - Zachować istniejące `guarantee` i `toolNames` jako public capability metadata. `defaultMatcher` musi należeć do `toolNames`, jeśli target używa native matchera albo payload filter.
+   - Brak terminal capability albo `emission: 'omit'` oznacza unsupported. `not-guaranteed` GitHub mapuje do omit, nie do pozornego best-effort output.
+   - `PORTABLE_HOOK_EVENTS` i `HOOK_RUNTIME_CAPABILITIES` pozostają jedynymi źródłami portable event names, native terminal event, default matcher, matcher enforcement, emission i guarantee.
+   - Existing `nativeVersions` staje się generated compatibility projection z `emissionContexts` dla targetów emitowanych przez własny formatter. Tests i #347 używają `emissionContexts`.
+   - Nie dodawać drugiego pola typu `nativeToolName`; istniejące `matcher` w `targets.<target>` jest target-specific override.
+   - Dla `pre-terminal-command` matcher grammar to exact, case-sensitive native tool name, nie regex ani alternation. Override musi być non-empty i należeć do capability `toolNames`; inne events zachowują obecny matcher contract.
+
+2. **Mapping layer**
+   - Dla zwykłych events zachować obecne mapping behavior. Dla `pre-terminal-command` `mapEvent` czyta wyłącznie `terminal.preEvent` z `HOOK_RUNTIME_CAPABILITIES`; nie dodawać tego eventu do target-specific map constants.
+   - `getDefaultMatcher` czyta wyłącznie `terminal.defaultMatcher`.
+   - Merge order: target override matcher > portable matcher > event default matcher. Target override jest najbardziej specific source.
+   - Portable matcher użyty przez `pre-terminal-command` podlega exact tool-name validation osobno dla każdego targetu. Unknown native name emituje capability diagnostic i pomija entry zamiast rozszerzać coverage.
+   - Jeśli użytkownik poda matcher w target override, nie dopisywać drugiego default matcher.
+   - Windsurf mapuje event bez matcher; VS Code używa `matcherEnforcement: 'payload-filter'`, ponieważ host ignoruje matcher field.
+   - Factory, Claude i Codex emitują guaranteed mapping. Cursor, Gemini i VS Code emitują mapping wraz z best-effort diagnostic. GitHub i Grok nie emitują entry.
+   - Dla VS Code formatter emituje owned cross-platform Node helper `.promptscript/generated/vscode-hook-filter.mjs`. Hook entry przekazuje helperowi expected tool name, effective timeout w milliseconds i effective command array jako JSON arguments. Helper buforuje stdin, parsuje payload, sprawdza exact `tool_name`, uruchamia resource bez shell parsing i przekazuje oryginalny payload do child stdin. Non-match kończy się `0` bez uruchomienia user command/script.
+   - Jeśli payload schema jest malformed albo nie można go odczytać, wrapper failuje closed z non-zero i diagnostic; nie uruchamia user resource.
+   - Effective duration pochodzi z target override, portable `timeoutMs` albo documented VS Code default, w tej kolejności. Helper dostaje integer milliseconds; native VS Code hook dostaje `ceil(milliseconds / 1000)` seconds. Oba reprezentują tę samą duration, nie tę samą wartość liczbową.
+   - Helper jest transparentnym process proxy: child stdout/stderr są dziedziczone, child exit code zostaje exit code helpera, spawn error daje non-zero diagnostic, a effective timeout obejmuje wrapper i child.
+   - Helper forwarduje catchable termination signals do child process group i czeka na cleanup. Owned timeout kończy cały child tree, aby sentinel/resource nie został orphaned. Implementacja ma osobne Unix i Windows cleanup branches bez shell parsing.
+   - Nie obiecywać cleanup po uncatchable hard kill, host crash ani machine loss. Docs opisują tę granicę; recovery takich procesów należy do hosta/OS.
+   - Generated helper ma PromptScript marker, należy do managed outputs i podlega temu samemu ownership-safe cleanup co hook config.
+
+3. **Capability diagnostics**
+   - Rozdzielić `unsupported` od `best-effort` w warning code i message. Wybrać stabilny nowy rule ID po sprawdzeniu registry; nie przeciążać jednego komunikatu dwoma znaczeniami.
+   - Warning ma podać host limitation i rzeczywistą alternatywę. Dla VS Code: generated payload filter albo `prs compile --watch`; nie polecać ignorowanego matcher field jako samodzielnego rozwiązania.
+   - Generated docs nie mogą używać słów `guaranteed` dla best effort.
+   - Capability docs, generated formatter docs, diagnostics i serializer emission są generowane lub testowane względem tego samego runtime registry.
+
+4. **Serializers**
+   - Zaktualizować Factory, Claude, Codex, Windsurf, Cursor, Gemini, VS Code i każdy target z `terminal.emission: 'emit'`.
+   - Sprawdzić, że `matcher` trafia do właściwego native field przy `matcherEnforcement: 'native'`.
+   - Przy `payload-filter` matcher steruje generated wrapperem, nie martwym native field. Native matcher można zachować tylko jako human-readable metadata z warningiem, nigdy jako enforcement.
+   - Dla GitHub i Grok unsupported output pozostaje pusty, ale compile result zawiera diagnostic.
+
+5. **Docs**
+   - Dodać event do language reference i hook capability matrix.
+   - Opisać różnicę między terminal command lifecycle a ogólnym `pre-tool-use`.
+   - Pokazać target-specific override:
+
+     ```promptscript
+     targets: {
+       vscode: { matcher: "run_in_terminal" }
+     }
+     ```
+
+   - Wyjaśnić, że VS Code override konfiguruje generated payload filter, ponieważ host ignoruje native matcher.
+
+## Testy i weryfikacja
+
+- Validator accepts event and rejects typo.
+- Mapping tests generowane dla każdego runtime capability row, bez ręcznej listy pomijającej target.
+- Generated output tests dla Factory, Claude, Codex, Windsurf, Cursor, Gemini, GitHub, Grok i VS Code.
+- Assertions for default matcher, override matcher, unsupported omission and best-effort warning.
+- VS Code runtime tests: matching payload uruchamia sentinel raz; non-matching payload nie uruchamia; malformed payload failuje closed; Unix i Windows command variants zachowują ownership marker.
+- VS Code proxy tests: child exit code, stdout, stderr i spawn error są propagowane; catchable SIGTERM i owned timeout usuwają child tree bez orphan process.
+- VS Code timeout tests: override/portable/default precedence, helper milliseconds i native rounded-up seconds.
+- Registry test: validator accepted events, formatter event type i capability docs są derived z core registries, bez równoległych list.
+- Emission context test: VS Code wskazuje GitHub `multifile/full` plus required override; każdy inny native target wskazuje realny formatter/version.
+- Assertion: target override matcher wygrywa z portable matcher, a portable matcher wygrywa z default.
+- Matcher grammar: terminal exact names accepted; regex/alternation i unknown tool names odrzucone lub pominięte z capability diagnostic; non-terminal matcher behavior unchanged.
+- Capability docs/generated formatter docs consistency.
+- Cross-target fixture from #347 includes terminal hook and warning assertions.
+
+## Kryterium gotowości
+
+- Portable event maps deterministically.
+- Runtime capability registry jest jedynym właścicielem terminal mapping i default matcher.
+- Guaranteed/best-effort/unsupported status is visible in diagnostics and docs.
+- Cursor i Gemini zachowują istniejący best-effort contract.
+- No target claims coverage it cannot provide.
+- Existing `pre-tool-use` behavior remains unchanged.

--- a/docs/design/issue-plans/346-fail-closed-project-root.md
+++ b/docs/design/issue-plans/346-fail-closed-project-root.md
@@ -1,0 +1,90 @@
+# Issue #346 - fail closed when project root is unavailable
+
+Issue: https://github.com/mrwogu/promptscript/issues/346
+
+## Cel
+
+Generated portable script and command wrappers must stop before resource execution when required project root cannot be resolved. Never silently run from agent session CWD.
+
+## Stan obecny
+
+- `projectRootExpression` in `packages/formatters/src/hook-adapters.ts:112` emits target environment variables.
+- `projectCwdPrefix` prepends `cd` but does not guard empty variables.
+- POSIX `serializeGitRootScriptCommand` używa assignment z `&&`, więc zatrzymuje non-zero `git rev-parse`, ale nie odrzuca blank output.
+- `serializePowerShellScriptCommand` assigns Git root without validating result.
+- Command resource bez script omija Git-root resolution nawet wtedy, gdy ma `cwd`.
+- Native-CWD i workspace-CWD serializers intentionally rely on host-provided CWD.
+- Existing smoke tests cover nested dirs and warnings, but not all empty-root/error paths.
+
+## Decyzje
+
+- Environment-root targets fail if variable is unset or empty.
+- Git-root targets fail if `git rev-parse --show-toplevel` returns non-zero or blank.
+- Native-CWD targets retain native `cwd`; they do not claim project-root guarantee and continue to emit `PS4002` when applicable.
+- Workspace-CWD jest osobną strategią. VS Code zachowuje host workspace cwd i osobny warning contract, nie jest klasyfikowany jako native-CWD.
+- Script zawsze wymaga root dla repository-local path w environment-root i Git-root targetach. Command wymaga root guard, gdy używa `cwd: "project"` lub project-relative `cwd`.
+- Error goes to stderr, names target and missing root strategy, and exits non-zero before interpreter/command.
+- Guard must precede `cd`, interpreter, command and ownership marker. Marker remains final token of successful generated command.
+- Do not use shell fallback such as `pwd`, `$PWD` or current session directory.
+
+## Target strategies
+
+| Strategy      | Targets                       | Guard                                              |
+| ------------- | ----------------------------- | -------------------------------------------------- |
+| env root      | Claude, Factory, Gemini, Grok | non-empty variable check                           |
+| Git root      | Cursor, Codex                 | checked `git rev-parse --show-toplevel`            |
+| native CWD    | GitHub, Windsurf              | preserve native CWD, warning for no guarantee      |
+| workspace CWD | VS Code                       | preserve workspace CWD, workspace-specific warning |
+
+Actual target list must come from `HOOK_RUNTIME_CAPABILITIES`; table is a design contract, not a second registry.
+
+## Plan implementacji
+
+1. **Central guard functions**
+   - Add `serializeRequiredEnvRootGuard(target, variable)` returning POSIX-safe prefix.
+   - Add checked Git-root prefix with temporary variable and explicit status/blank check.
+   - Add PowerShell equivalents using `$env:VAR`, `$LASTEXITCODE` and `[string]::IsNullOrWhiteSpace`.
+   - Escape target/variable names as fixed constants, not user input.
+   - Guard helper przyjmuje `HookProjectRootStrategy` i obsługuje exhaustively `environment`, `git-root`, `native-cwd`, `workspace-cwd` i `none`. Dodanie nowej strategy powoduje TypeScript exhaustive failure.
+
+2. **Integrate serializers**
+   - Apply env guard do każdego script oraz command z project-relative `cwd`.
+   - Apply Git guard do Cursor/Codex script oraz command z project-relative `cwd`.
+   - Command bez script i bez `cwd` nie wymaga sztucznego root lookup. Zachowuje obecne native command behavior.
+   - Per-target command/script overrides z #343 przechodzą przez ten sam effective-resource guard path.
+   - Ensure cwd path with spaces still uses existing quoting after root resolution.
+   - Preserve `getScriptPathFromNativeCwd` behavior for native-CWD targets.
+   - Preserve VS Code workspace-CWD behavior osobno od native-CWD. Nie mapować `workspace-cwd` na `native-cwd` bez jawnej branch i diagnostic.
+   - Keep ownership marker final after guard and command.
+
+3. **Diagnostics**
+   - Update capability warning text osobno dla native-CWD i workspace-CWD limitations.
+   - Compile-time validation still checks source `cwd`; runtime guard handles unavailable host root.
+   - Error wording identifies target, strategy, and required env variable or Git worktree.
+   - Cursor/Codex command z `cwd` nie może już kończyć tylko warningiem i wykonać się w session CWD. Ma dostać guarded wrapper albo compile error, jeśli target serializer nie potrafi go bezpiecznie opakować.
+
+4. **Documentation**
+   - Remove wording that implies fallback to session CWD.
+   - Add generated POSIX/PowerShell examples and failure behavior.
+   - Document that a hook may be skipped by the host if it does not provide project root; this differs from running in the wrong root.
+
+## Testy i weryfikacja
+
+- Exact script i command strings dla każdego env target z unset, empty i valid variable.
+- Git-root script oraz command z `cwd`: success, non-zero exit i blank output.
+- PowerShell script/command generation and error path.
+- Paths with spaces and nested `cwd`.
+- Assert interpreter i raw command są textually after guard.
+- Execute wrappers z sentinel script/command i potwierdzić, że sentinel nie został wywołany przy missing root.
+- Native-CWD targets retain behavior plus `PS4002`.
+- VS Code retains workspace-CWD behavior i workspace-specific diagnostic.
+- Command bez `cwd` zachowuje obecny output i nie dostaje zbędnego Git/env lookup.
+- Execute generated wrappers in temporary Unix fixtures where shell exists; PowerShell tests remain platform-independent string/fixture tests when CI lacks `pwsh`.
+- Cross-target smoke fixture from #347 asserts no wrong-directory execution.
+
+## Kryterium gotowości
+
+- Missing required root always causes non-zero exit before script lub command execution.
+- No generated wrapper silently falls back to process CWD.
+- Unix and PowerShell guards use identical fail-closed semantics.
+- Native-CWD i workspace-CWD limitations są odrębne, explicit i tested.

--- a/docs/design/issue-plans/347-cross-target-hook-fixture.md
+++ b/docs/design/issue-plans/347-cross-target-hook-fixture.md
@@ -1,0 +1,125 @@
+# Issue #347 - cross-target hook merge and cleanup fixture
+
+Issue: https://github.com/mrwogu/promptscript/issues/347
+
+## Cel
+
+Dodać jeden end-to-end fixture, który testuje pełny lifecycle `@hooks`: compile, target serialization, merge z istniejącą konfiguracją, ownership, migration, repeated compile i removal.
+
+## Stan obecny
+
+- `packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts` testuje root/cwd i capability warnings.
+- `packages/formatters/src/__tests__/hook-adapters.spec.ts` ma szerokie unit coverage adapterów.
+- `packages/cli/src/utils/__tests__/legacy-factory-hooks.spec.ts` testuje pure migration.
+- Cleanup działa w compile flow i rozpoznaje ownership marker.
+- Brakuje jednego fixture spinającego wszystkie warstwy i target overrides.
+
+## Fixture
+
+Source `.prs`:
+
+- portable repository script under `.promptscript/scripts/`.
+- `@hooks` with `pre-tool-use`, `post-tool-use` i `pre-terminal-command`.
+- Factory, GitHub i VS Code target resource/matcher overrides z #343/#345.
+- Portable resource jest także kompilowany dla Claude, Cursor, Codex, Gemini, Windsurf i Grok, aby assertions dla root strategy i terminal capability miały jawny target setup.
+- `cwd: "project"`, nested cwd i args/path ze spacjami.
+
+Pre-existing files:
+
+- `.factory/hooks.json` or absent depending scenario.
+- `.factory/settings.json` with unrelated settings, unmanaged hooks and legacy owned entries.
+- `.github/hooks/promptscript.json` with unmanaged entries.
+- VS Code target output only when `targets.vscode` is selected.
+- unmanaged file/dir adjacent to generated output.
+
+## Plan implementacji
+
+1. **Fixture harness**
+   - Dodać reusable temp-project builder w CLI integration tests, obok `packages/cli/src/commands/__tests__/compile.spec.ts`.
+   - Tworzyć source, scripts, target config, existing JSON and ownership markers deterministically.
+   - Expose helper wywołujący publiczny `compileCommand` z target selection, formatter output mode/version, output root, dry-run, watch-compatible options, injected `CliFileSystem` faults oraz repeated invocation.
+   - Capture stdout, stderr, exit status i filesystem tree po każdym run.
+   - Nie opierać lifecycle fixture na `Compiler.compile()`, ponieważ compiler zwraca in-memory outputs i nie wykonuje write, cleanup, migration ani dry-run.
+   - Zachować osobne compiler smoke tests dla pipeline i formatter output bez filesystem assertions.
+
+2. **Initial compilation assertions**
+   - Factory emits `.factory/hooks.json` with PascalCase events.
+   - GitHub emits `.github/hooks/promptscript.json` with current schema.
+   - VS Code output appears only when `targets.vscode` is present.
+   - Per-target command/script resources survive serialization.
+   - Terminal event maps, warns lub jest omitted zgodnie z `HOOK_RUNTIME_CAPABILITIES`, bez ręcznej drugiej matrix.
+   - Root guards są obecne dla env/Git-root script oraz command resources wymagających `cwd`.
+   - Cursor i Gemini emitują best-effort terminal mapping, GitHub i Grok nie emitują misleading terminal entry.
+   - VS Code terminal hook przechodzi przez generated payload filter: matching payload uruchamia sentinel, non-matching payload nie uruchamia.
+
+3. **Merge and ownership assertions**
+   - Unmanaged settings and hook entries remain value-semantically equivalent. Byte equality sprawdzać tylko dla plików, których compile nie zapisuje.
+   - PromptScript-owned entries update in place.
+   - Repeated compilation does not duplicate generated entries or marker commands.
+   - Changed source replaces only owned entry, not unmanaged sibling.
+   - Removed target output is cleaned only when fully PromptScript-owned.
+
+4. **Legacy migration assertions**
+   - Legacy `.factory/settings.json` unambiguous user hooks migrate to canonical file.
+   - Unrelated settings survive.
+   - Owned legacy hooks do not duplicate.
+   - Unknown event, malformed JSON, mixed ownership and ambiguous handler nie mutują legacy settings i nie tworzą częściowo migrated canonical state.
+   - Rerun after migration is unchanged.
+   - `--dry-run` and `--no-migrate-legacy-hooks` report/no-op correctly.
+   - Inject failure między Factory transaction renames i sprawdzić rollback.
+   - Pozostawić recovery journal po każdej phase, uruchomić następny compile i sprawdzić recovery przed nowym output.
+   - Sprawdzić, że `.factory/hooks.json` i `.factory/settings.json` są zapisane tylko przez transaction path, nie wcześniej przez generic writer/cleanup.
+   - Uruchomić `--all-builds` z co najmniej dwoma profiles do wspólnego output root i potwierdzić jeden outer lock, brak interleaving oraz brak self-deadlocku.
+   - Uruchomić drugi `--all-builds` scenario z różnymi output roots. Asertować sorted lock acquisition, cleanup wszystkich wcześniej nabytych locków po partial acquire failure i brak deadlocku przy odwróconej kolejności profiles.
+
+5. **Removal and cleanup**
+   - Remove `@hooks` from source, compile again.
+   - Only PromptScript-owned generated files/entries disappear.
+   - Managed empty directories are pruned.
+   - Unmanaged files and directories survive.
+   - Legacy settings are not deleted wholesale.
+
+6. **Runtime root failure assertions**
+   - Wykonać wygenerowane POSIX wrappers w temp project z sentinel script/command.
+   - Dla unset/empty env root, non-zero `git rev-parse` i blank Git root assert non-zero exit oraz brak sentinel invocation.
+   - Powtórzyć dla portable i per-target command/script z `cwd`.
+   - PowerShell sprawdzać wykonaniem, gdy `pwsh` jest dostępne, inaczej exact structural assertions wspólnego guard contract.
+   - Native-CWD i workspace-CWD nie używają session fallback udającego repository guarantee; diagnostics są zgodne z odrębnymi strategies.
+
+7. **CI wiring**
+   - Register fixture in CLI integration target.
+   - Parametryzować każdy runtime target po `HOOK_RUNTIME_CAPABILITIES[target].emissionContexts`: realny formatter, wszystkie hook-emitting versions i required target override.
+   - VS Code uruchamia GitHub formatter w `multifile` i `full` z `targets.vscode`; `simple` asertuje brak outputu. Nie traktować `vscode` jako formattera ani `workspace` jako formatter version.
+   - Unsupported modes muszą jawnie asertować brak outputu.
+   - Ensure test runs on Unix i Windows-compatible assertions. POSIX runtime wykonuje się na Unix; PowerShell runtime wykonuje się, gdy `pwsh` jest dostępne, inaczej używa structural contract assertions.
+   - Avoid relying on installed external AI tools; assert generated contract locally.
+   - Keep focused adapter tests for exact serialization; fixture asserts cross-layer behavior.
+
+## Test matrix
+
+| Scenario                   | Expected                                     |
+| -------------------------- | -------------------------------------------- |
+| first compile              | all selected outputs created                 |
+| repeat compile             | no duplicates, unchanged result              |
+| changed source             | owned entries updated                        |
+| unmanaged sibling          | parsed value preserved                       |
+| legacy unambiguous         | committed through recoverable transaction    |
+| legacy ambiguous           | no legacy mutation, diagnostic               |
+| transaction write failure  | previous Factory documents restored          |
+| interrupted transaction    | next compile recovers journal before writing |
+| missing project root       | script/command fails closed before sentinel  |
+| terminal event best effort | output plus explicit capability diagnostic   |
+| terminal event unsupported | `PS4002`, no false output                    |
+| remove `@hooks`            | owned output removed, unmanaged retained     |
+| dry-run                    | actions reported, files unchanged            |
+| all builds                 | one outer lock, no interleaving/deadlock     |
+| all builds, multiple roots | sorted acquire, partial failure cleanup      |
+| supported output modes     | every hook-emitting mode covered in CI       |
+
+## Kryterium gotowości
+
+- One CLI fixture catches regressions across compiler, formatters, CLI migration, write and cleanup.
+- All acceptance criteria from #347 are direct assertions, not snapshots alone.
+- Filesystem lifecycle nie jest testowany przez in-memory compiler helper.
+- Recoverable transaction, root guards i capability-driven terminal behavior są wykonywane, nie tylko snapshotowane.
+- Fixture can be extended for new hook events/targets without copying setup.

--- a/docs/design/issue-plans/348-canonical-block-shapes.md
+++ b/docs/design/issue-plans/348-canonical-block-shapes.md
@@ -1,0 +1,111 @@
+# Issue #348 - canonical block shapes and diagnostics
+
+Issue: https://github.com/mrwogu/promptscript/issues/348
+
+## Cel
+
+Stworzyć jedną, wyszukiwalną referencję shape blocków oraz walidację, która wyjaśnia oczekiwany model i wpływ na output. Nie robić pełnego redesignu grammar niezależnie od #330.
+
+Issue nie wymaga redesignu #330 ani funkcji #331/#349. Reference, fixtures i validator rule mają działać na obecnym AST przez compatibility shape accessor. Jeśli #330 jest już wdrożone, ten sam accessor czyta canonical `BlockBody`. W tej serii #348 jest implementowane po #349 wyłącznie w celu ograniczenia churn w tych samych docs i fixtures, nie jako dependency kontraktu.
+
+## Zakres shape
+
+Canonical reference ma opisywać:
+
+| Shape  | Canonical use                              | Merge                                            |
+| ------ | ------------------------------------------ | ------------------------------------------------ |
+| text   | identity, free-form context, prose         | text concat z deduplication                      |
+| object | context metadata, shortcuts, hooks, skills | deep merge, block-specific rules                 |
+| array  | list-like content; restrictions dash-list  | unique concat, legacy dash-list syntax preserved |
+| mixed  | structured fields plus prose               | niezależny merge text i properties               |
+
+Dla każdego built-in blocku opisać canonical shape, dozwolone legacy shapes, formatter behavior, merge behavior i pełny compile-ready przykład. Lista obejmuje co najmniej `identity`, `context`, `standards`, `restrictions`, `knowledge`, `shortcuts`, `commands`, `guards`, `params`, `skills`, `agents`, `local`, `workflows`, `prompts`, `examples`, `hooks`, `mcpServers` i `plugins`.
+
+## Decyzje
+
+- Canonical shape matrix opisuje closed union `text | object | array | mixed`; nie tworzy drugiego modelu tylko dla dokumentacji.
+- Standalone implementacja przed #330 dodaje `getObservedBlockShape(block: Block)` nad obecnym `BlockContent`. Gdy #330 jest dostępne, zachowuje ten overload i dodaje `BlockInput`, czytając canonical `BlockBody` bez zmiany publicznego wyniku.
+- Dash-list jest surface syntax normalizowanym do `array`, nie piątym shape.
+- Custom blocks pozostają open-world; validator sprawdza syntax, nie narzuca schema.
+- `@shortcuts` zachowuje scalar/multiline compatibility, ale canonical przykład używa explicit `content` dla commandu wieloliniowego:
+
+  ```promptscript
+  @shortcuts {
+    "/test": {
+      content: """
+        Run the complete test suite.
+      """
+    }
+  }
+  ```
+
+  Formatter może nadal przyjmować istniejący scalar i multiline scalar. `content` jest preferowany w nowych plikach, aby usunąć output ambiguity.
+
+- Opcjonalne contextual `@header` entries z #331 są opisane poza domain properties. Zwykłe fields `header`/`headers` pozostają domain data.
+
+## Stan obecny
+
+- `packages/parser/src/grammar/visitor.ts:468` robi implicit classification.
+- `packages/core/src/types/ast.ts:327` ma shape union bez canonical matrix.
+- `packages/resolver/src/inheritance.ts:61` i `imports.ts:162` mają shape-dependent merge.
+- `packages/validator/src/rules/index.ts` nie ma generic shape rule.
+- `docs/reference/language.md` opisuje blocki w rozproszonych sekcjach.
+- Shortcut serialization jest w `MarkdownInstructionFormatter` i testach comprehensive.
+
+## Plan implementacji
+
+1. **Reference contract**
+   - Dodać `docs/reference/block-shapes.md` jako single searchable reference.
+   - Dla każdego blocku opisać: cel, canonical body, supported legacy, invalid/ambiguous forms, output examples i merge.
+   - Dodać link z `docs/reference/language.md`, guide formatterów i docs automation.
+   - Wszystkie przykłady trzymać w fixture files lub compile smoke snippets, aby nie rozjechały się z parserem.
+   - Generować lub sprawdzać snippets z tych samych fixtures. Nie utrzymywać ręcznie dwóch kopii przykładu.
+
+2. **Canonical examples**
+   - Dodać fixture dla każdego built-in blocku.
+   - Oprócz podstawowej postaci pokryć nested object, arrays, multiline, mixed content i inheritance tam, gdzie mają znaczenie.
+   - Dla shortcutów pokazać scalar legacy, multiline legacy oraz `content` canonical.
+   - Dla `hooks` połączyć examples z capability docs, ale nie powielać pełnego hook contractu.
+
+3. **Validator rule**
+   - Dodać rule po istniejącym PS034-PS036, z nowym stabilnym ID wybranym po sprawdzeniu registry.
+   - Diagnostics mają zawierać block, observed shape, expected shape, poprawny minimal example i migration hint.
+   - Error tylko dla shape jawnie nieobsługiwanego lub zmieniającego znaczenie outputu; warning dla supported legacy i ambiguous form.
+   - Nie zgłaszać błędu dla custom blocków bez predefined schema.
+   - Walidować shortcut `content` i canonical shapes built-inów w jednym rule family.
+   - Nie walidować presentation metadata w #348. #331 jest wyłącznym właścicielem `@header` diagnostics.
+   - Rule nie zależy od `@override` ani presentation metadata. Integracje z #331/#349 są additive tests uruchamianymi tylko wtedy, gdy features istnieją w syntax registry.
+
+4. **Resolver i formatter semantics**
+   - Użyć shape accessor działającego dla legacy i canonical AST. Jeśli #330 jest wdrożone, nie utrzymywać drugiego merge modelu.
+   - Ustalić block-specific exceptions w registry, nie w przypadkowych formatterach.
+   - Testować `@inherit`, top-level i inline `@use`, aliases, `@extend` i mixed content z zachowaniem obecnej semantyki. `@override` dodaje osobny matrix row tylko gdy #349 jest dostępne.
+   - Node i browser compiler używają tego samego shared merge/operation engine. Matrix nie dokumentuje osobnych semantyk dla browsera.
+   - Shortcut serializers mają preferować `content`, a scalar/multiline legacy utrzymać byte-compatible tam, gdzie obecny output jest określony.
+
+5. **Tooling alignment**
+   - Dodać playground examples i linki do reference.
+   - `header`, `headers` i shortcut `content` są zwykłymi identifier fields. Optional `@header` z #331 jest contextual directive i podlega jego trzy-highlighter sync.
+   - Dla contextual directive `@override` z #349 synchronizować Pygments, TextMate i Monaco.
+   - Obecny `grammar:check` sprawdza parser token coverage w TextMate oraz block directives w trzech highlighterach. Rozszerzyć go o contextual directive parity dla `@override` w Pygments i Monaco. Nie wymagać nieistniejącego parser tokenu ani dodawać redundantnego ogólnego "missing tokens" check.
+
+## Testy i weryfikacja
+
+- Compile każdy canonical example.
+- Validator: canonical pass, legacy pass/warning, unsupported error, custom block pass.
+- Validator scope: built-in/custom `header`/`headers` i nested MCP `headers` pass bez #348 presentation diagnostic.
+- Resolver: merge matrix shape x operation (`inherit`, `use`, `extend`, `override`) z różnymi merge policies dla inheritance i import.
+- Ordering: top-level declarations oraz inline `@use` nie są grupowane po typie.
+- Browser: ten sam matrix przechodzi przez browser compiler.
+- Formatter: shortcut scalar/multiline/content i wszystkie relevant targety.
+- Docs CI: no stale examples, strict validation, grammar sync.
+
+## Kryterium gotowości
+
+- Jedna referencja opisuje wszystkie built-in blocks.
+- Każdy przykład compile-uje się.
+- Gdy #330, #331 lub #349 są dostępne, reference pobiera ich shapes/features z compatibility accessor i syntax registry zamiast utrzymywać ręczną alternatywną specyfikację.
+- Reference jest zamykalne na obecnym AST i aktualizuje feature rows automatycznie z registry, więc nie jest blokowane przez #330, #331 ani #349.
+- Diagnostics mówią, co jest nie tak i jak to naprawić.
+- Legacy syntax nie znika bez migration note.
+- Shape rules nie blokują custom blocks.

--- a/docs/design/issue-plans/349-explicit-override-semantics.md
+++ b/docs/design/issue-plans/349-explicit-override-semantics.md
@@ -1,0 +1,132 @@
+# Issue #349 - explicit override block semantics
+
+Issue: https://github.com/mrwogu/promptscript/issues/349
+
+## Cel
+
+Dodać `@override` jako jawne, atomowe replacement, bez zmiany dotychczasowego merge behavior `@extend` i `field!`.
+
+```promptscript
+@extend standards {
+  testing: ["Use Vitest"]
+}
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+```
+
+Standalone value wewnątrz body jest nową, celową częścią grammar `@override`. Nie jest traktowane jako istniejący regular block body.
+
+## Stan obecny
+
+- `parser.ts:39` i `:116` znają tylko `@extend`.
+- `Program.extends` oraz `ExtendBlock` są w `core/src/types/ast.ts`.
+- `applyExtends` w `resolver/src/extensions.ts` aplikuje merge w kolejności tablicy, ale `Program` nie zachowuje global order względem blocks.
+- `mergeAtPath` tworzy brakujące nested paths.
+- `assertSkillPathCanExtend` egzekwuje sealed properties.
+- Syntax registry kończy się na `1.4.0`.
+
+## Decyzje semantyczne
+
+- `@extend` pozostaje additive/merge.
+- `@override <dot-path> { body }` wymaga, aby pełny target path istniał. Brak targetu to `ResolveError` z path i location.
+- Replacement dotyczy całego target value. `@override standards` zastępuje cały block body; `@override standards.testing` zastępuje property.
+- Root replacement zastępuje cały `BlockBody`, w tym inline uses i presentation metadata. Brak tych elementów w replacement oznacza ich usunięcie.
+- Nested override nie adresuje presentation metadata, aby nie kolidować z legalnymi domain fields. Root replacement zastępuje presentation atomowo; scoped title update używa `@extend` z contextual `@header` z #331.
+- Zastąpienie jest atomiczne: resolver nie mutuje częściowo AST przed walidacją targetu i sealed constraints.
+- Operations wykonują się w jednym declaration stream z #330. `@inherit`, top-level `@use`, block, `@extend` i `@override` nie są ponownie grupowane po typie. Inline `@use` zachowuje pozycję w ordered block body. `@extend` po `@override` może mergeować w replacement.
+- `@override` nie omija sealed skill properties. Root skill replacement jest odrzucany, jeśli usuwa lub zmienia sealed metadata.
+- `field!` zostaje jako compatibility syntax dla direct fields w `@extend`.
+- Nowa funkcja wymaga `1.6.0`; plik z niższą syntax version dostaje compatibility diagnostic, nie ciche zachowanie.
+- `override` pozostaje legalną nazwą custom blocku w legacy syntax. Directive jest contextual: `@override { ... }` to custom block, a `@override <dot-path> { ... }` to operation. Upgrade nie może zmienić istniejącego custom blocku w directive.
+- Syntax `1.6.0` włącza sequential operation policy z #330. Syntax do `1.5.x` bez override usage zachowuje legacy phase order dla istniejących blocks i `@extend`; presence `@override` wymusza sequential policy także przy lower declaration i równolegle emituje PS018.
+
+## Plan implementacji
+
+1. **AST i grammar**
+   - Nie dodawać lexer tokenu `Override` i nie dodawać `override` do `RESERVED_WORDS`. Lexer zawsze emituje zwykły `Identifier`, więc fields, values, aliases, params, dot-path segments i custom block names pozostają kompatybilne.
+   - Dodać contextual `overrideBlock` z Chevrotain `GATE`: po `@` pierwszy `Identifier.image === 'override'`, następny token zaczyna dot-path, a nie `{`. `@override {` przechodzi przez regular block rule.
+   - Dodać `OverrideBlock` z `targetPath`, `OverrideReplacement` i loc.
+   - `OverrideReplacement` jest discriminated union: `BlockReplacement { body, presentation }` albo `ValueReplacement { value: ValueNode, loc }`. Raw `Value` powstaje tylko w compatibility projection.
+   - Dodać `overrideBody`, które rozpoznaje regular ordered block entries albo dokładnie jeden standalone `ValueNode`. Dzięki temu `{ ["Use Vitest"] }`, `{ "text" }` i `{ { key: "value" } }` są parseable replacement values, ale nie stają się legalnym regular block body.
+   - Root block override normalizuje standalone array/object/string/TextBlock do odpowiedniego `BlockBody`. Standalone number, boolean i null są parseable dla nested paths, ale root block replacement odrzuca je jako `ResolveError` z accepted root shapes i location.
+   - Nested override zachowuje exact `ValueNode`, w tym number, boolean i null.
+   - Wspólnie z #330 użyć `Program.operations: ProgramOperation[]`, zachowując `extends` jako read-only API compatibility projection.
+   - Visitor wpisuje `@override` do tego samego ordered array co `@inherit`, top-level `@use`, block i `@extend`, bez sortowania po typie.
+   - Zaktualizować Pygments, TextMate i Monaco jako contextual directive pattern, mimo braku dedicated lexer tokenu.
+
+2. **Syntax versioning**
+   - Dodać `SYNTAX_FEATURES.EXPLICIT_OVERRIDE`.
+   - Dodać wersję `1.6.0` z poprzednimi blocks/features i nową feature.
+   - Dodać usage tracking w parserze przy contextual identifierze `@override` oraz zachować usage przez wszystkie destructive resolver passes.
+   - Rozszerzyć browser-safe `collectSyntaxCompatibilityIssues(ast)` wprowadzone przez #331. Node i browser resolver wywołują collector dla każdego parsed AST przed semantic operations i propagują issues w `ResolvedAST`, także gdy późniejsza operacja zwróci `ResolveError`.
+   - PS018 `syntax-version-compat` pozostaje jedynym właścicielem user-facing message, configured severity i suggestion. Parser nadaje usage stabilne ID. Compiler deduplikuje collected oraz direct-validator issue przez `usage.id`, z compatibility fallback `file + (offset ?? line:column) + feature`.
+   - Zmienić PS018, aby raportował `usage.location`, nie `meta.loc`.
+   - `prs validate --fix` używa collected usages/issues do wyliczenia minimum version nawet wtedy, gdy resolution później failuje; po fix ponowna walidacja nie emituje starego issue.
+   - Dodać test monotoniczności registry.
+   - `@meta.syntax` bez `1.6.0` raportuje dokładny feature i location identifiera `@override`, nawet jeśli target nie istnieje albo replacement narusza sealed constraint.
+
+3. **Resolver operation engine**
+   - Rozszerzyć browser-safe shared `applyOperation` z #330, używane przez Node i browser resolver dla `@extend` i `@override`.
+   - Przed operation engine zebrać syntax compatibility issue bez rzucania. Compiler raportuje je razem z późniejszym target existence, traversal lub sealed error, więc PS018 nie jest maskowane.
+   - Resolver wybiera sequential policy dla syntax `1.6.0` albo presence `@override`, następnie wykonuje `Program.operations` sekwencyjnie. `@inherit` ładuje base przed kolejnymi declarations, a top-level `@use` mergeuje source w swojej pozycji z import/source-wins policy z #330.
+   - Najpierw rozwiązać alias/import marker do surviving block, potem zweryfikować cały path.
+   - `@override` na root tworzy replacement block body tylko po znalezieniu target block.
+   - Nested replacement traversuje wyłącznie istniejące object/mixed nodes; brak segmentu, scalar po drodze lub array path daje actionable `ResolveError`.
+   - Nested paths `header` i `headers` pozostają zwykłymi domain properties. Presentation zmienia wyłącznie root replacement albo `@extend` z `@header`.
+   - Clone target i candidate replacement przed commit; wyjątek nie może zostawić częściowego merge.
+   - Root replacement nie zachowuje implicit inline uses ani presentation metadata. Replacement body jest kompletnym nowym stanem.
+   - `BlockReplacement.presentation` pochodzi z contextual `@header` entries lub legacy heading extraction z #331. Brak presentation w replacement usuwa wcześniejsze metadata.
+   - Nie aktualizować `blocks`, `uses` ani `extends` bezpośrednio. Po operation commit AST factory z #330 regeneruje read-only compatibility projections.
+
+4. **Browser compiler**
+   - Usunąć osobną implementację extension/path replacement z `packages/browser-compiler/src/resolver.ts` albo przepiąć ją na dokładnie ten sam shared operation engine.
+   - Shared module nie może zależeć od Node filesystem APIs.
+   - Browser compile musi wykonywać `@override`, alias resolution, syntax usage preservation i sealed checks identycznie jak Node resolver.
+   - Parity test porównuje resolved AST, errors z location i formatter output. Same snapshots bez wykonania browser operation engine nie zamykają zakresu.
+
+5. **Skills i sealed**
+   - Przed replacementem przejść wszystkie affected skill paths i zbudować set sealed keys z base.
+   - Reject `sealed` path, removal of sealed property i replacement całego skill, który narusza sealed contract.
+   - Zachować istniejące dedicated skill merge strategies dla `@extend`; `@override` nie może ich obchodzić.
+   - Błędy mają wskazywać target path, property i źródłową lokalizację.
+
+6. **Validator**
+   - Parser waliduje structure dot-path i non-empty body. Shared collector zapisuje version issue przed resolution.
+   - Parser sprawdza tylko strukturę dot-path/body. Resolver po zastosowaniu wcześniejszych inheritance/use operations sprawdza target existence, traversal, root shape i sealed constraints, po czym emituje `ResolveError` na location `@override`.
+   - PS018 konsumuje resolver-collected issues i direct AST usages przez jeden dedup path. Nie tworzyć drugiego resolver-specific message ani zmieniać rule severity.
+   - Nie dublować semantic validation między resolverem i validatorem.
+
+7. **Docs**
+   - Rozszerzyć `@extend` section o porównanie `@extend`, `field!`, `@override`.
+   - Dodać compile-checked examples standalone array/object/text value, regular block body, declaration order, root/nested replacement, presentation replacement, missing target i sealed error.
+   - Migration guidance: używaj `@extend` dla additive, `field!` dla compatibility direct field, `@override` dla intentional complete replacement.
+
+## Testy i weryfikacja
+
+- Parser/CST: directive, dot paths, standalone array/object/text values, regular body shapes i pełny operation order.
+- Parser/CST: legacy custom `@override { ... }` nadal jest zwykłym blockiem; `@override target { ... }` jest operation.
+- Resolver: root array/object/text/mixed replacement, rejection root number/boolean/null, nested primitive replacement, aliases, `@inherit`, `@use` i declaration order bez grupowania.
+- Ordering: `use -> block -> extend -> override -> extend` oraz inline `field -> use -> field`.
+- Ordering compatibility: syntax do `1.5.x` bez override usage zachowuje legacy phase result; `1.6.0` lub override usage używa sequential result. Lower override usage raportuje PS018.
+- Presentation: root replacement usuwa stare metadata/inline uses, a explicit replacement zachowuje tylko podane wartości.
+- Errors: missing root, missing nested segment, scalar traversal, sealed skill, lower syntax version.
+- Error aggregation: lower syntax issue nie jest maskowane przez missing target, invalid root shape ani sealed error.
+- Diagnostics: lower syntax PS018 i semantic ResolveError mogą wystąpić razem, ale PS018 pojawia się raz i zachowuje configured severity/off policy.
+- Version matrix: `1.4.x` raportuje PS018 dla `@header` i `@override`; bez override zachowuje phased policy. `1.5.x` akceptuje `@header`; bez override zachowuje phased policy, a z override raportuje PS018 i używa sequential policy. `1.6.0` akceptuje oba oraz używa sequential policy. Matrix przechodzi w Node resolver, browser resolver, direct validator i `prs validate --fix`.
+- Syntax diagnostic: location wskazuje `@override`, nie `@meta`.
+- Regression: `field!`, existing skill merge, non-existent `@extend` warning.
+- Browser compiler wykonuje shared operation engine; resolved AST, diagnostics i formatter output są zgodne z Node.
+- Docs examples strict validation.
+
+## Kryterium gotowości
+
+- `@override` ma osobny AST operation i syntax gate.
+- Przykład standalone array jest obsługiwany przez jawne `overrideBody`, nie przez przypadkową lukę regular grammar.
+- Replacement jest atomowy i target musi istnieć.
+- Order obejmujący inherit/use/block/extend/override i inline use jest deterministyczny.
+- Root replacement ma jednoznaczną semantykę dla presentation metadata i inline uses.
+- Sealed skill rules pozostają nienaruszalne.
+- Node i browser compiler używają tego samego operation engine.
+- Żaden formatter nie wymaga zmian target-specific.

--- a/docs/design/issue-plans/349-explicit-override-semantics.md
+++ b/docs/design/issue-plans/349-explicit-override-semantics.md
@@ -52,7 +52,7 @@ Standalone value wewnątrz body jest nową, celową częścią grammar `@overrid
    - Dodać `overrideBody`, które rozpoznaje regular ordered block entries albo dokładnie jeden standalone `ValueNode`. Dzięki temu `{ ["Use Vitest"] }`, `{ "text" }` i `{ { key: "value" } }` są parseable replacement values, ale nie stają się legalnym regular block body.
    - Root block override normalizuje standalone array/object/string/TextBlock do odpowiedniego `BlockBody`. Standalone number, boolean i null są parseable dla nested paths, ale root block replacement odrzuca je jako `ResolveError` z accepted root shapes i location.
    - Nested override zachowuje exact `ValueNode`, w tym number, boolean i null.
-   - Wspólnie z #330 użyć `Program.operations: ProgramOperation[]`, zachowując `extends` jako read-only API compatibility projection.
+   - Wspólnie z #330 użyć `CanonicalProgram.operations: readonly ProgramOperation[]`, zachowując canonical `extends` jako read-only compatibility projection.
    - Visitor wpisuje `@override` do tego samego ordered array co `@inherit`, top-level `@use`, block i `@extend`, bez sortowania po typie.
    - Zaktualizować Pygments, TextMate i Monaco jako contextual directive pattern, mimo braku dedicated lexer tokenu.
 
@@ -70,7 +70,7 @@ Standalone value wewnątrz body jest nową, celową częścią grammar `@overrid
 3. **Resolver operation engine**
    - Rozszerzyć browser-safe shared `applyOperation` z #330, używane przez Node i browser resolver dla `@extend` i `@override`.
    - Przed operation engine zebrać syntax compatibility issue bez rzucania. Compiler raportuje je razem z późniejszym target existence, traversal lub sealed error, więc PS018 nie jest maskowane.
-   - Resolver wybiera sequential policy dla syntax `1.6.0` albo presence `@override`, następnie wykonuje `Program.operations` sekwencyjnie. `@inherit` ładuje base przed kolejnymi declarations, a top-level `@use` mergeuje source w swojej pozycji z import/source-wins policy z #330.
+   - Resolver wybiera sequential policy dla syntax `1.6.0` albo presence `@override`, następnie wykonuje `CanonicalProgram.operations` sekwencyjnie. `@inherit` ładuje base przed kolejnymi declarations, a top-level `@use` mergeuje source w swojej pozycji z cross-layer composition i import/source-wins policy z #330. First local block mergeuje inherited/imported first match; dopiero następny same-layer block pozostaje duplicate.
    - Najpierw rozwiązać alias/import marker do surviving block, potem zweryfikować cały path.
    - `@override` na root tworzy replacement block body tylko po znalezieniu target block.
    - Nested replacement traversuje wyłącznie istniejące object/mixed nodes; brak segmentu, scalar po drodze lub array path daje actionable `ResolveError`.


### PR DESCRIPTION
## Summary

- add implementation plans for open issues #330, #331, and #343 through #349
- define dependency order, compatibility boundaries, browser parity, and filesystem safety contracts
- resolve cross-plan conflicts around ordered AST operations, presentation metadata, hook capabilities, and Factory migration
- preserve legacy AST inputs, custom block syntax, hook ownership, and output behavior

## Verification

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:validate:check`
- `pnpm docs:build`

## Review

- six independent defect-review passes completed
- final review result: no issues
- documentation examples and strict MkDocs build pass

Refs #330
Refs #331
Refs #343
Refs #344
Refs #345
Refs #346
Refs #347
Refs #348
Refs #349
