### PR TITLE
feat(core): add section header overrides

### DIFF
--- a/.claude/skills/promptscript/SKILL.md
+++ b/.claude/skills/promptscript/SKILL.md
@@ -991,6 +991,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
+| `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
 
 ### Block Version Requirements
 
@@ -1005,11 +1006,37 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
+Generated section title overrides with `@header` require syntax `1.5.0`.
+
+### Generated Section Headers
+
+Use `@header` inside a registered owner block to rename human-readable output
+sections without changing filenames, frontmatter, XML tags, or structured keys:
+
+```promptscript
+@meta { id: "localized" syntax: "1.5.0" }
+
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  code: ["Use strict TypeScript"]
+}
+```
+
+- `@header "Title"` targets the block's primary section.
+- `@header <section-key> "Title"` targets an owned derived section.
+- Titles must be non-empty, single-line strings.
+- Source overrides take precedence over formatter configuration and target defaults.
+- Child inheritance, imported source, and the latest root extension take precedence.
+- An initial `## Heading` in a registered text-only primary owner is a syntax
+  `1.5.0` compatibility fallback. Explicit `@header` metadata wins.
+- Ordinary `header` and `headers` fields remain domain data.
 
 ### Validation Rules
 
 - **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
+- **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).

--- a/.factory/skills/promptscript/SKILL.md
+++ b/.factory/skills/promptscript/SKILL.md
@@ -796,6 +796,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
+| `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
 
 ### Block Version Requirements
 
@@ -810,11 +811,37 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
+Generated section title overrides with `@header` require syntax `1.5.0`.
+
+### Generated Section Headers
+
+Use `@header` inside a registered owner block to rename human-readable output
+sections without changing filenames, frontmatter, XML tags, or structured keys:
+
+```promptscript
+@meta { id: "localized" syntax: "1.5.0" }
+
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  code: ["Use strict TypeScript"]
+}
+```
+
+- `@header "Title"` targets the block's primary section.
+- `@header <section-key> "Title"` targets an owned derived section.
+- Titles must be non-empty, single-line strings.
+- Source overrides take precedence over formatter configuration and target defaults.
+- Child inheritance, imported source, and the latest root extension take precedence.
+- An initial `## Heading` in a registered text-only primary owner is a syntax
+  `1.5.0` compatibility fallback. Explicit `@header` metadata wins.
+- Ordinary `header` and `headers` fields remain domain data.
 
 ### Validation Rules
 
 - **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
+- **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).

--- a/.github/skills/promptscript/SKILL.md
+++ b/.github/skills/promptscript/SKILL.md
@@ -827,6 +827,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
+| `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
 
 ### Block Version Requirements
 
@@ -841,11 +842,37 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
+Generated section title overrides with `@header` require syntax `1.5.0`.
+
+### Generated Section Headers
+
+Use `@header` inside a registered owner block to rename human-readable output
+sections without changing filenames, frontmatter, XML tags, or structured keys:
+
+```promptscript
+@meta { id: "localized" syntax: "1.5.0" }
+
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  code: ["Use strict TypeScript"]
+}
+```
+
+- `@header "Title"` targets the block's primary section.
+- `@header <section-key> "Title"` targets an owned derived section.
+- Titles must be non-empty, single-line strings.
+- Source overrides take precedence over formatter configuration and target defaults.
+- Child inheritance, imported source, and the latest root extension take precedence.
+- An initial `## Heading` in a registered text-only primary owner is a syntax
+  `1.5.0` compatibility fallback. Explicit `@header` metadata wins.
+- Ordinary `header` and `headers` fields remain domain data.
 
 ### Validation Rules
 
 - **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
+- **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).

--- a/.promptscript/skills/promptscript/SKILL.md
+++ b/.promptscript/skills/promptscript/SKILL.md
@@ -991,6 +991,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
+| `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
 
 ### Block Version Requirements
 
@@ -1005,11 +1006,37 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
+Generated section title overrides with `@header` require syntax `1.5.0`.
+
+### Generated Section Headers
+
+Use `@header` inside a registered owner block to rename human-readable output
+sections without changing filenames, frontmatter, XML tags, or structured keys:
+
+```promptscript
+@meta { id: "localized" syntax: "1.5.0" }
+
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  code: ["Use strict TypeScript"]
+}
+```
+
+- `@header "Title"` targets the block's primary section.
+- `@header <section-key> "Title"` targets an owned derived section.
+- Titles must be non-empty, single-line strings.
+- Source overrides take precedence over formatter configuration and target defaults.
+- Child inheritance, imported source, and the latest root extension take precedence.
+- An initial `## Heading` in a registered text-only primary owner is a syntax
+  `1.5.0` compatibility fallback. Explicit `@header` metadata wins.
+- Ordinary `header` and `headers` fields remain domain data.
 
 ### Validation Rules
 
 - **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
+- **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).

--- a/apps/vscode/syntaxes/promptscript.tmLanguage.json
+++ b/apps/vscode/syntaxes/promptscript.tmLanguage.json
@@ -36,7 +36,7 @@
       "name": "entity.name.import.registry.prs"
     },
     "control-directive": {
-      "match": "@(?:meta|inherit|use|extend)\\b",
+      "match": "@(?:meta|inherit|use|extend|header)\\b",
       "name": "keyword.control.directive.prs"
     },
     "block-directive": {

--- a/docs/__snapshots__/docs/reference/language.md/localized-project_L2114/claude.md
+++ b/docs/__snapshots__/docs/reference/language.md/localized-project_L2114/claude.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+## Coding Rules
+
+- Use strict TypeScript
+
+## Commit Rules
+
+- Format: conventional
+
+## Dokumentacja zespołu
+
+- Update docs after changes

--- a/docs/__snapshots__/docs/reference/language.md/localized-project_L2114/cursor.mdc
+++ b/docs/__snapshots__/docs/reference/language.md/localized-project_L2114/cursor.mdc
@@ -1,0 +1,15 @@
+---
+description: "Project-specific rules"
+alwaysApply: true
+---
+
+You are working on the project.
+
+Coding Rules:
+- Use strict TypeScript
+
+Commit Rules:
+- format: conventional
+
+Dokumentacja zespołu:
+- verifyAfter

--- a/docs/__snapshots__/docs/reference/language.md/localized-project_L2114/github.md
+++ b/docs/__snapshots__/docs/reference/language.md/localized-project_L2114/github.md
@@ -1,0 +1,18 @@
+# GitHub Copilot Instructions
+
+## Coding Rules
+
+### code
+
+- Use strict TypeScript
+
+## Commit Rules
+
+- Use [conventional](https://www.conventionalcommits.org/) format
+- Format: `<type>(<scope>): <description>`
+
+## Dokumentacja zespołu
+
+- **After** making code changes, verify consistency with `README.md` and `docs/` - update documentation if needed
+- If adding new features, add corresponding documentation in `docs/`
+- If changing existing behavior, update affected documentation sections

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -124,12 +124,12 @@ The `syntax` field in `@meta` declares which version of the PromptScript languag
 | `1.1.0` | Stable  | All 1.0.0 blocks + `@agents`, `@workflows`; reserves internal `@prompts`                                                                   |
 | `1.2.0` | Stable  | All 1.1.0 blocks + `@examples`                                                                                                             |
 | `1.3.0` | Stable  | All 1.2.0 features + regular block field replacement in `@extend`                                                                          |
-| `1.4.0` | Current | All 1.3.0 features + `@hooks`, `@mcpServers`, `@plugins`                                                                                   |
+| `1.4.0` | Stable  | All 1.3.0 features + `@hooks`, `@mcpServers`, `@plugins`                                                                                   |
+| `1.5.0` | Current | All 1.4.0 features + generated section title overrides with contextual `@header`                                                           |
 
 !!! note "Block Availability"
-`@workflows` is user-facing and emits workflow files for targets that support them, such as
-`.claude/workflows/<name>.md`. `@prompts` is reserved for internal prompt output. `@hooks`,
-`@mcpServers`, and `@plugins` require syntax `1.4.0`.
+`@workflows` emits workflow files such as `.claude/workflows/<name>.md`.
+`@prompts` is internal. `@hooks`, `@mcpServers`, and `@plugins` require syntax `1.4.0`.
 
 ### Block Version Requirements
 
@@ -145,7 +145,7 @@ The `syntax` field in `@meta` declares which version of the PromptScript languag
 
 All other built-in blocks are available from `1.0.0`.
 
-Regular block field replacement with `field!: value` requires syntax `1.3.0`.
+Regular block field replacement with `field!: value` requires syntax `1.3.0`. Generated section title overrides with `@header` require syntax `1.5.0`.
 
 ### Validation (PS018, PS019)
 
@@ -2104,3 +2104,69 @@ If a variable is not set and no default is provided:
     1. **Always provide defaults** for non-sensitive values
     2. **Never commit secrets** - use environment variables for API keys
     3. **Document required variables** in your project README
+
+## Generated Section Headers
+
+Syntax `1.5.0` lets source files override human-readable section titles without
+forking a formatter. Place contextual `@header` directives directly inside a
+registered owner block:
+
+```promptscript
+@meta {
+  id: "localized-project"
+  syntax: "1.5.0"
+}
+
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  @header documentation "Dokumentacja zespołu"
+
+  code: ["Use strict TypeScript"]
+  git: { format: "conventional" }
+  documentation: { verifyAfter: true }
+}
+```
+
+- `@header "Title"` names the block's primary generated section.
+- `@header <section-key> "Title"` names a derived section.
+- Titles must be non-empty, single-line strings.
+- Canonical section keys use kebab-case.
+- Source overrides take precedence over formatter configuration and target defaults.
+- Overrides change only human-readable titles. Filenames, frontmatter properties,
+  XML tags, and structured JSON, TOML, or YAML keys stay unchanged.
+- Ordinary `header` and `headers` fields remain domain data, including nested HTTP
+  headers in `@mcpServers`.
+
+| Section key           | Primary owner   | Fallback owners           | Keyless `@header` owner   |
+| --------------------- | --------------- | ------------------------- | ------------------------- |
+| `project`             | `@identity`     | `@context`                | `@identity`               |
+| `tech-stack`          | `@context`      | `@standards`              | -                         |
+| `architecture`        | `@context`      | -                         | -                         |
+| `context`             | `@context`      | -                         | `@context`                |
+| `code-standards`      | `@standards`    | -                         | `@standards`              |
+| `git-commits`         | `@standards`    | -                         | -                         |
+| `configuration-files` | `@standards`    | -                         | -                         |
+| `commands`            | `@shortcuts`    | `@commands`, `@knowledge` | `@shortcuts`, `@commands` |
+| `post-work`           | `@knowledge`    | -                         | -                         |
+| `documentation`       | `@standards`    | -                         | -                         |
+| `diagrams`            | `@standards`    | -                         | -                         |
+| `knowledge`           | `@knowledge`    | -                         | `@knowledge`              |
+| `restrictions`        | `@restrictions` | -                         | `@restrictions`           |
+| `examples`            | `@examples`     | -                         | `@examples`               |
+
+For registered text-only primary owners, syntax `1.5.0` also recognizes an
+initial `## Heading` as a compatibility fallback:
+
+```promptscript
+@identity {
+  """
+  ## Project Instructions
+  Follow repository conventions.
+  """
+}
+```
+
+The formatter emits that heading once and preserves the remaining body. Explicit
+`@header` metadata always wins over this fallback. Syntax `1.4.x` and earlier
+keep the heading as ordinary body text, so existing output remains unchanged.

--- a/docs_extensions/promptscript_lexer.py
+++ b/docs_extensions/promptscript_lexer.py
@@ -39,6 +39,8 @@ BLOCK_DIRECTIVES = (
     "examples",
 )
 
+CONTEXTUAL_DIRECTIVES = ("header",)
+
 ENV_VAR_PATTERN = r"\$\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\}"
 TEMPLATE_VAR_PATTERN = r"(\{\{)([A-Za-z_][A-Za-z0-9_]*)(\}\})"
 IMPORT_PATH_PATTERN = (
@@ -141,6 +143,11 @@ class PromptScriptLexer(RegexLexer):
             (
                 r"(@use)(\s+)(" + IMPORT_PATH_PATTERN + r")",
                 bygroups(Keyword.Namespace, Whitespace, String),
+            ),
+            # Contextual directives are recognized only inside block bodies
+            (
+                r"(@)(" + "|".join(CONTEXTUAL_DIRECTIVES) + r")(?=[^\w-]|$)",
+                bygroups(Punctuation, Keyword.Namespace),
             ),
             # 'as' keyword for inline @use aliases
             (r"(?<![\w-])(as)(?![\w-])", Keyword.Namespace),

--- a/packages/browser-compiler/src/__tests__/compiler.spec.ts
+++ b/packages/browser-compiler/src/__tests__/compiler.spec.ts
@@ -183,6 +183,55 @@ describe('compile', () => {
     );
   });
 
+  it('should report and format section header overrides in browser builds', async () => {
+    const files = {
+      'project.prs': `@meta { id: "test" syntax: "1.4.0" }
+@restrictions {
+  @header "Forbidden Practices"
+  - "No unsafe casts"
+}
+`,
+    };
+
+    const result = await compile(files, 'project.prs');
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'PS018',
+          message: expect.stringContaining('section-header-override'),
+          location: expect.objectContaining({
+            file: 'project.prs',
+            line: 3,
+            column: 3,
+          }),
+        }),
+      ])
+    );
+    expect(result.outputs.get('CLAUDE.md')?.content).toContain('## Forbidden Practices');
+    expect(result.outputs.get('CLAUDE.md')?.content).toContain('No unsafe casts');
+  });
+
+  it('should consume a registered initial heading once at syntax 1.5.0', async () => {
+    const files = {
+      'project.prs': `@meta { id: "test" syntax: "1.5.0" }
+@identity {
+  """## Localized Project
+  Project details"""
+}
+`,
+    };
+
+    const result = await compile(files, 'project.prs');
+    const content = result.outputs.get('CLAUDE.md')?.content ?? '';
+
+    expect(result.success).toBe(true);
+    expect(content.match(/Localized Project/g)).toHaveLength(1);
+    expect(content).toContain('Project details');
+    expect(content).not.toContain('## Project\n');
+  });
+
   it('should return error for missing entry file', async () => {
     const files = {
       'other.prs': '@meta { id: "other" syntax: "1.0.0" }',

--- a/packages/browser-compiler/src/resolver.ts
+++ b/packages/browser-compiler/src/resolver.ts
@@ -948,7 +948,8 @@ export class BrowserResolver {
           ext.canonicalBody,
           baseContent,
           extensionContent,
-          content
+          content,
+          block.name
         ),
       };
     }

--- a/packages/cli/skills/promptscript/SKILL.md
+++ b/packages/cli/skills/promptscript/SKILL.md
@@ -991,6 +991,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
+| `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
 
 ### Block Version Requirements
 
@@ -1005,11 +1006,37 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
+Generated section title overrides with `@header` require syntax `1.5.0`.
+
+### Generated Section Headers
+
+Use `@header` inside a registered owner block to rename human-readable output
+sections without changing filenames, frontmatter, XML tags, or structured keys:
+
+```promptscript
+@meta { id: "localized" syntax: "1.5.0" }
+
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  code: ["Use strict TypeScript"]
+}
+```
+
+- `@header "Title"` targets the block's primary section.
+- `@header <section-key> "Title"` targets an owned derived section.
+- Titles must be non-empty, single-line strings.
+- Source overrides take precedence over formatter configuration and target defaults.
+- Child inheritance, imported source, and the latest root extension take precedence.
+- An initial `## Heading` in a registered text-only primary owner is a syntax
+  `1.5.0` compatibility fallback. Explicit `@header` metadata wins.
+- Ordinary `header` and `headers` fields remain domain data.
 
 ### Validation Rules
 
 - **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
+- **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).

--- a/packages/cli/src/commands/__tests__/validate-fix.spec.ts
+++ b/packages/cli/src/commands/__tests__/validate-fix.spec.ts
@@ -363,6 +363,43 @@ describe('validateCommand --fix', () => {
     expect(content).toContain('syntax: "1.3.0"');
   });
 
+  it('should fix syntax version for direct and inherited section header overrides', async () => {
+    mkdirSync(join(tmpDir, '.promptscript'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.promptscript', 'base.prs'),
+      `@meta { id: "base" syntax: "1.4.0" }
+@standards {
+  @header "Shared Rules"
+  code: ["Use strict TypeScript"]
+}
+`
+    );
+    writeFileSync(
+      join(tmpDir, '.promptscript', 'project.prs'),
+      `@meta { id: "project" syntax: "1.4.0" }
+@inherit ./base
+`
+    );
+    writeFileSync(
+      join(tmpDir, '.promptscript', 'direct.prs'),
+      `@meta { id: "direct" syntax: "1.4.0" }
+@restrictions {
+  @header "Forbidden Practices"
+  - "No unsafe casts"
+}
+`
+    );
+
+    await validateCommand({ fix: true });
+
+    expect(readFileSync(join(tmpDir, '.promptscript', 'project.prs'), 'utf-8')).toContain(
+      'syntax: "1.5.0"'
+    );
+    expect(readFileSync(join(tmpDir, '.promptscript', 'direct.prs'), 'utf-8')).toContain(
+      'syntax: "1.5.0"'
+    );
+  });
+
   it('should report no fixes needed when syntax is correct', async () => {
     mkdirSync(join(tmpDir, '.promptscript'), { recursive: true });
     writeFileSync(

--- a/packages/compiler/src/__tests__/syntax-feature-validation.spec.ts
+++ b/packages/compiler/src/__tests__/syntax-feature-validation.spec.ts
@@ -130,4 +130,90 @@ describe('syntax feature validation after resolution', () => {
       ])
     );
   });
+
+  it('should report inherited section header usage at its source location', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-syntax-feature-'));
+    directories.push(directory);
+    const basePath = join(directory, 'base.prs');
+    writeFileSync(
+      basePath,
+      `@meta { id: "base" syntax: "1.4.0" }
+@standards {
+  @header "Shared Rules"
+  code: ["Use strict TypeScript"]
+}
+`
+    );
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta { id: "project" syntax: "1.4.0" }
+@inherit ./base
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'PS018',
+          message: expect.stringContaining('section-header-override'),
+          location: expect.objectContaining({
+            file: basePath,
+            line: 3,
+            column: 3,
+          }),
+        }),
+      ])
+    );
+  });
+
+  it('should report inherited legacy heading usage at its source location', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-syntax-feature-'));
+    directories.push(directory);
+    const basePath = join(directory, 'base.prs');
+    writeFileSync(
+      basePath,
+      `@meta { id: "base" syntax: "1.5.0" }
+@identity {
+  """## Shared Project
+  Shared details"""
+}
+`
+    );
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta { id: "project" syntax: "1.4.0" }
+@inherit ./base
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'PS018',
+          message: expect.stringContaining('section-header-override'),
+          location: expect.objectContaining({
+            file: basePath,
+            line: 3,
+            column: 3,
+          }),
+        }),
+      ])
+    );
+  });
 });

--- a/packages/core/src/__tests__/block-merge.spec.ts
+++ b/packages/core/src/__tests__/block-merge.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { InlineUseDeclaration, MixedContent, ObjectContent } from '../types/ast.js';
+import type {
+  InlineUseDeclaration,
+  MixedContent,
+  ObjectContent,
+  PresentationEntry,
+} from '../types/ast.js';
 import {
   IMPORT_MERGE_POLICY,
   INHERITANCE_MERGE_POLICY,
@@ -33,6 +38,21 @@ function inlineUse(raw: string): InlineUseDeclaration {
       loc: LOC,
     },
     loc: LOC,
+  };
+}
+
+function presentation(
+  title: string,
+  source: PresentationEntry['source'] = 'explicit',
+  sectionId?: string
+): PresentationEntry {
+  return {
+    type: 'PresentationEntry',
+    ...(sectionId ? { sectionId } : {}),
+    title,
+    source,
+    loc: LOC,
+    titleLoc: LOC,
   };
 }
 
@@ -80,6 +100,92 @@ describe('block merge policies', () => {
         nested: { left: true, right: true, shared: 'source' },
       },
     });
+  });
+
+  it('merges presentation entries by rank and content precedence', () => {
+    const createBlock = (entries: PresentationEntry[]) =>
+      toLegacyBlock(createCanonicalBlock('standards', createBlockBody(entries, LOC), LOC), {
+        preserveCanonicalBody: true,
+      });
+    const base = createBlock([
+      presentation('Base code style'),
+      presentation('Base commits', 'explicit', 'git-commits'),
+    ]);
+    const incoming = createBlock([
+      presentation('Incoming legacy', 'legacy'),
+      presentation('Incoming commits', 'explicit', 'git-commits'),
+      presentation('Incoming config', 'explicit', 'configuration-files'),
+    ]);
+
+    const inherited = mergeBlockCollections([base], [incoming], {
+      content: INHERITANCE_MERGE_POLICY,
+      outputOrder: 'base',
+    });
+    const imported = mergeBlockCollections([base], [incoming], {
+      content: IMPORT_MERGE_POLICY,
+      outputOrder: 'base',
+    });
+
+    expect(inherited[0]!.canonicalBody?.entries).toMatchObject([
+      { type: 'PresentationEntry', title: 'Base code style', source: 'explicit' },
+      {
+        type: 'PresentationEntry',
+        sectionId: 'git-commits',
+        title: 'Incoming commits',
+      },
+      {
+        type: 'PresentationEntry',
+        sectionId: 'configuration-files',
+        title: 'Incoming config',
+      },
+    ]);
+    expect(imported[0]!.canonicalBody?.entries).toMatchObject([
+      { type: 'PresentationEntry', title: 'Base code style' },
+      {
+        type: 'PresentationEntry',
+        sectionId: 'git-commits',
+        title: 'Base commits',
+      },
+      {
+        type: 'PresentationEntry',
+        sectionId: 'configuration-files',
+        title: 'Incoming config',
+      },
+    ]);
+    expect(inherited[0]!.content).toEqual({
+      type: 'ObjectContent',
+      properties: {},
+      loc: LOC,
+    });
+  });
+
+  it('treats keyless and explicit primary section entries as equivalent', () => {
+    const createBlock = (entries: PresentationEntry[]) =>
+      toLegacyBlock(createCanonicalBlock('standards', createBlockBody(entries, LOC), LOC), {
+        preserveCanonicalBody: true,
+      });
+    const base = createBlock([presentation('Base rules')]);
+    const incoming = createBlock([presentation('Incoming rules', 'explicit', 'code-standards')]);
+
+    const inherited = mergeBlockCollections([base], [incoming], {
+      content: INHERITANCE_MERGE_POLICY,
+      outputOrder: 'base',
+    });
+    const imported = mergeBlockCollections([base], [incoming], {
+      content: IMPORT_MERGE_POLICY,
+      outputOrder: 'base',
+    });
+
+    expect(inherited[0]!.canonicalBody?.entries).toMatchObject([
+      {
+        type: 'PresentationEntry',
+        sectionId: 'code-standards',
+        title: 'Incoming rules',
+      },
+    ]);
+    expect(imported[0]!.canonicalBody?.entries).toMatchObject([
+      { type: 'PresentationEntry', title: 'Base rules' },
+    ]);
   });
 
   it('preserves text order for both policies', () => {

--- a/packages/core/src/__tests__/canonical-ast.spec.ts
+++ b/packages/core/src/__tests__/canonical-ast.spec.ts
@@ -1475,7 +1475,9 @@ describe('canonical AST compatibility', () => {
             ? entry.declaration.path.raw
             : entry.type === 'TextEntry'
               ? entry.text
-              : valueNodeToValue(entry.value)
+              : entry.type === 'ListEntry'
+                ? valueNodeToValue(entry.value)
+                : entry.title
       )
     ).toEqual(['./first', ['runtime', 'node'], 'list item', './second', 'Instructions']);
     expect(reconciled.entries.map((entry) => entry.loc)).toEqual([

--- a/packages/core/src/__tests__/presentation.spec.ts
+++ b/packages/core/src/__tests__/presentation.spec.ts
@@ -5,6 +5,24 @@ import { normalizeLegacyHeadingEntries } from '../presentation.js';
 const LOC: SourceLocation = { file: 'presentation.prs', line: 3, column: 3, offset: 42 };
 
 describe('presentation metadata', () => {
+  it('preserves legacy headings before syntax 1.5.0', () => {
+    const entries: BlockEntry[] = [
+      {
+        type: 'TextEntry',
+        text: '## Project Rules\nKeep the body.',
+        loc: LOC,
+      },
+    ];
+
+    expect(normalizeLegacyHeadingEntries('identity', entries, '1.4.0')).toBe(entries);
+  });
+
+  it('ignores blocks without text entries', () => {
+    const entries: BlockEntry[] = [];
+
+    expect(normalizeLegacyHeadingEntries('identity', entries, '1.5.0')).toBe(entries);
+  });
+
   it('normalizes tab-separated legacy headings with CRLF endings', () => {
     const entries: BlockEntry[] = [
       {

--- a/packages/core/src/__tests__/presentation.spec.ts
+++ b/packages/core/src/__tests__/presentation.spec.ts
@@ -23,6 +23,12 @@ describe('presentation metadata', () => {
     expect(normalizeLegacyHeadingEntries('identity', entries, '1.5.0')).toBe(entries);
   });
 
+  it.each(['Plain body text.', '##Missing separator'])('ignores non-heading text: %s', (text) => {
+    const entries: BlockEntry[] = [{ type: 'TextEntry', text, loc: LOC }];
+
+    expect(normalizeLegacyHeadingEntries('identity', entries, '1.5.0')).toBe(entries);
+  });
+
   it('normalizes tab-separated legacy headings with CRLF endings', () => {
     const entries: BlockEntry[] = [
       {

--- a/packages/core/src/__tests__/presentation.spec.ts
+++ b/packages/core/src/__tests__/presentation.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { BlockEntry, SourceLocation } from '../types/index.js';
+import { normalizeLegacyHeadingEntries } from '../presentation.js';
+
+const LOC: SourceLocation = { file: 'presentation.prs', line: 3, column: 3, offset: 42 };
+
+describe('presentation metadata', () => {
+  it('normalizes tab-separated legacy headings with CRLF endings', () => {
+    const entries: BlockEntry[] = [
+      {
+        type: 'TextEntry',
+        text: '##\tProject Rules\r\nKeep the body.',
+        loc: LOC,
+      },
+    ];
+
+    const normalized = normalizeLegacyHeadingEntries('identity', entries, '1.5.0');
+
+    expect(normalized).toMatchObject([
+      {
+        type: 'PresentationEntry',
+        title: 'Project Rules',
+        source: 'legacy',
+      },
+      {
+        type: 'TextEntry',
+        text: 'Keep the body.',
+      },
+    ]);
+  });
+
+  it('ignores whitespace-only headings in linear time', () => {
+    const entries: BlockEntry[] = [
+      {
+        type: 'TextEntry',
+        text: `##\t${'\t\t'.repeat(10_000)}`,
+        loc: LOC,
+      },
+    ];
+
+    expect(normalizeLegacyHeadingEntries('identity', entries, '1.5.0')).toBe(entries);
+  });
+});

--- a/packages/core/src/__tests__/section-registry.spec.ts
+++ b/packages/core/src/__tests__/section-registry.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SECTION_REGISTRY,
+  blockOwnsSection,
+  getPrimarySectionForBlock,
+  getSectionContract,
+  getSectionsForBlock,
+} from '../section-registry.js';
+
+describe('section registry', () => {
+  it('should expose unique canonical IDs and formatter aliases', () => {
+    const ids = SECTION_REGISTRY.map((section) => section.id);
+    const aliases = SECTION_REGISTRY.flatMap((section) => section.formatterAliases);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(getSectionContract('git-commits')?.id).toBe('git-commits');
+    expect(getSectionContract('gitCommits')?.id).toBe('git-commits');
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+
+  it('should define primary and derived sections per owner block', () => {
+    expect(getPrimarySectionForBlock('standards')?.id).toBe('code-standards');
+    expect(getPrimarySectionForBlock('context')?.id).toBe('context');
+    expect(getSectionsForBlock('standards').map((section) => section.id)).toEqual([
+      'tech-stack',
+      'code-standards',
+      'git-commits',
+      'configuration-files',
+      'documentation',
+      'diagrams',
+    ]);
+    expect(blockOwnsSection('knowledge', 'commands')).toBe(true);
+    expect(blockOwnsSection('identity', 'git-commits')).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/syntax-versions.spec.ts
+++ b/packages/core/src/__tests__/syntax-versions.spec.ts
@@ -51,11 +51,25 @@ describe('registry consistency', () => {
       expect(latestBlocks).toContain(blockType);
     }
   });
+
+  it('should keep blocks and syntax features cumulative across versions', () => {
+    const versions = Object.keys(SYNTAX_VERSIONS);
+    for (let index = 1; index < versions.length; index++) {
+      const previous = SYNTAX_VERSIONS[versions[index - 1]!]!;
+      const current = SYNTAX_VERSIONS[versions[index]!]!;
+      for (const block of previous.blocks) {
+        expect(current.blocks).toContain(block);
+      }
+      for (const feature of previous.features) {
+        expect(current.features).toContain(feature);
+      }
+    }
+  });
 });
 
 describe('getLatestSyntaxVersion', () => {
   it('should return the highest known version', () => {
-    expect(getLatestSyntaxVersion()).toBe('1.4.0');
+    expect(getLatestSyntaxVersion()).toBe('1.5.0');
   });
 });
 
@@ -107,11 +121,16 @@ describe('syntax feature capabilities', () => {
   it('should expose cumulative features by syntax version', () => {
     expect(getFeaturesForVersion('1.2.0')).toEqual([]);
     expect(getFeaturesForVersion('1.3.0')).toContain(SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE);
+    expect(getFeaturesForVersion('1.5.0')).toEqual([
+      SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE,
+      SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE,
+    ]);
     expect(getFeaturesForVersion('9.9.9')).toBeUndefined();
   });
 
   it('should return the minimum version for registered features', () => {
     expect(getMinimumVersionForFeature(SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE)).toBe('1.3.0');
+    expect(getMinimumVersionForFeature(SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE)).toBe('1.5.0');
     expect(getMinimumVersionForFeature('unknown-feature' as SyntaxFeature)).toBeUndefined();
   });
 

--- a/packages/core/src/block-merge.ts
+++ b/packages/core/src/block-merge.ts
@@ -19,6 +19,7 @@ import {
   reconcileBlockBody,
   valueNodeToValue,
 } from './canonical-ast.js';
+import { selectPresentationEntries } from './presentation.js';
 
 export interface BlockMergePolicy {
   readonly valuePrecedence: 'base' | 'incoming';
@@ -314,12 +315,21 @@ function mergeCanonicalBodies(
   baseContent: BlockContent,
   incomingContent: BlockContent,
   content: BlockContent,
-  policy: BlockMergePolicy
+  policy: BlockMergePolicy,
+  blockName: string
 ): BlockBody {
   const baseBody = base ? reconcileBlockBody(base, baseContent) : blockContentToBody(baseContent);
   const incomingBody = incoming
     ? reconcileBlockBody(incoming, incomingContent)
     : blockContentToBody(incomingContent);
+  const presentation = selectPresentationEntries(
+    baseBody.entries,
+    incomingBody.entries,
+    policy.valuePrecedence,
+    blockName
+  );
+  const selectedBasePresentation = new Set(presentation.base);
+  const selectedIncomingPresentation = new Set(presentation.incoming);
 
   const taggedEntries = [
     ...baseBody.entries.map((entry) => ({ entry, layer: 'base' as const })),
@@ -424,6 +434,11 @@ function mergeCanonicalBodies(
 
   for (const [index, tagged] of taggedEntries.entries()) {
     const { entry, layer } = tagged;
+    if (entry.type === 'PresentationEntry') {
+      const selected = layer === 'base' ? selectedBasePresentation : selectedIncomingPresentation;
+      if (selected.has(entry)) entries.push(deepClone(entry));
+      continue;
+    }
     if (entry.type === 'FieldEntry') {
       if (!Object.hasOwn(properties, entry.name) || selectedFieldLayers.get(entry.name) !== layer) {
         continue;
@@ -562,7 +577,8 @@ export function mergeBlockCollections(
       baseBlock.content,
       incomingBlock.content,
       mergedContent,
-      policy.content
+      policy.content,
+      baseBlock.name
     );
     result.push({
       ...deepClone(incomingBlock),

--- a/packages/core/src/canonical-ast.ts
+++ b/packages/core/src/canonical-ast.ts
@@ -40,6 +40,7 @@ import type {
 } from './types/index.js';
 import type { SyntaxFeatureUsage } from './syntax-versions.js';
 import { deepClone } from './utils/index.js';
+import { selectPresentationEntries } from './presentation.js';
 
 type LegacyContentType = BlockContent['type'];
 
@@ -770,6 +771,10 @@ export function reconcileBlockBody(body: BlockBody, content: BlockContent): Bloc
   let emittedText = false;
 
   for (const [index, entry] of body.entries.entries()) {
+    if (entry.type === 'PresentationEntry') {
+      entries.push(deepClone(entry));
+      continue;
+    }
     if (entry.type === 'FieldEntry') {
       if (!Object.hasOwn(properties, entry.name)) continue;
       entries.push(
@@ -900,7 +905,8 @@ export function composeBlockBodies(
   incomingBody: BlockBody | undefined,
   baseContent: BlockContent,
   incomingContent: BlockContent,
-  mergedContent: BlockContent
+  mergedContent: BlockContent,
+  blockName?: string
 ): BlockBody {
   const base = baseBody ?? blockContentToBody(baseContent);
   const incoming = incomingBody ?? blockContentToBody(incomingContent);
@@ -919,32 +925,47 @@ export function composeBlockBodies(
     mergedContent.type === 'ObjectContent' || mergedContent.type === 'MixedContent'
       ? mergedContent.properties
       : {};
+  const presentation = selectPresentationEntries(
+    base.entries,
+    incoming.entries,
+    'incoming',
+    blockName
+  );
+  const selectedBasePresentation = new Set(presentation.base);
+  const selectedIncomingPresentation = new Set(presentation.incoming);
   const baseEntries = base.entries.filter(
-    (entry) => entry.type !== 'FieldEntry' || !incomingFieldNames.has(entry.name)
+    (entry) =>
+      (entry.type !== 'PresentationEntry' || selectedBasePresentation.has(entry)) &&
+      (entry.type !== 'FieldEntry' || !incomingFieldNames.has(entry.name))
   );
   const lastIncomingIndexes = new Map<string, number>();
   for (const [index, entry] of incoming.entries.entries()) {
     if (entry.type === 'FieldEntry') lastIncomingIndexes.set(entry.name, index);
   }
-  const incomingEntries = incoming.entries.map((entry, index) => {
-    const baseField = entry.type === 'FieldEntry' ? baseFields.get(entry.name) : undefined;
-    const mergedValue = entry.type === 'FieldEntry' ? mergedProperties[entry.name] : undefined;
-    return baseField &&
-      entry.type === 'FieldEntry' &&
-      lastIncomingIndexes.get(entry.name) === index &&
-      mergedValue !== undefined
-      ? {
-          ...deepClone(entry),
-          value: mergeValueNodeLocations(
-            baseField.value,
-            entry.value,
-            mergedValue,
-            'incoming',
-            entry.value
-          ),
-        }
-      : deepClone(entry);
-  });
+  const incomingEntries = incoming.entries
+    .map((entry, index) => ({ entry, index }))
+    .filter(
+      ({ entry }) => entry.type !== 'PresentationEntry' || selectedIncomingPresentation.has(entry)
+    )
+    .map(({ entry, index }) => {
+      const baseField = entry.type === 'FieldEntry' ? baseFields.get(entry.name) : undefined;
+      const mergedValue = entry.type === 'FieldEntry' ? mergedProperties[entry.name] : undefined;
+      return baseField &&
+        entry.type === 'FieldEntry' &&
+        lastIncomingIndexes.get(entry.name) === index &&
+        mergedValue !== undefined
+        ? {
+            ...deepClone(entry),
+            value: mergeValueNodeLocations(
+              baseField.value,
+              entry.value,
+              mergedValue,
+              'incoming',
+              entry.value
+            ),
+          }
+        : deepClone(entry);
+    });
   return reconcileBlockBody(
     createBlockBody([...baseEntries.map(deepClone), ...incomingEntries], mergedContent.loc, {
       projection: mergedContent.type,
@@ -1259,12 +1280,13 @@ export function createCanonicalBlock(
 
 export function updateCanonicalBlockBody(block: CanonicalBlock, body: BlockBody): CanonicalBlock {
   const requestedProjection = body.legacyProjection ?? block.body.legacyProjection;
+  const contentEntries = body.entries.filter((entry) => entry.type !== 'PresentationEntry');
   const projection =
     requestedProjection === 'ArrayContent' &&
-    !body.entries.every((entry) => entry.type === 'ListEntry')
+    !contentEntries.every((entry) => entry.type === 'ListEntry')
       ? undefined
       : requestedProjection === 'TextContent' &&
-          !body.entries.every((entry) => entry.type === 'TextEntry')
+          !contentEntries.every((entry) => entry.type === 'TextEntry')
         ? undefined
         : requestedProjection;
   return createCanonicalBlock(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,9 +29,11 @@ export * from './template.js';
 // Canonical AST compatibility layer
 export * from './canonical-ast.js';
 export * from './block-merge.js';
+export * from './presentation.js';
 
 // Syntax version registry
 export * from './syntax-versions.js';
+export * from './section-registry.js';
 
 // Target catalog
 export * from './target-catalog.js';

--- a/packages/core/src/presentation.ts
+++ b/packages/core/src/presentation.ts
@@ -19,6 +19,21 @@ function sourceRank(entry: PresentationEntry): number {
   return entry.source === 'explicit' ? 2 : 1;
 }
 
+function parseLegacyHeading(text: string): { title: string; end: number } | undefined {
+  if (!text.startsWith('##')) return undefined;
+
+  let index = 2;
+  if (text[index] !== ' ' && text[index] !== '\t') return undefined;
+  while (text[index] === ' ' || text[index] === '\t') index++;
+
+  const lineEnd = text.indexOf('\n', index);
+  const end = lineEnd === -1 ? text.length : lineEnd + 1;
+  let titleEnd = lineEnd === -1 ? text.length : lineEnd;
+  if (titleEnd > index && text[titleEnd - 1] === '\r') titleEnd--;
+  const title = text.slice(index, titleEnd).trim();
+  return title ? { title, end } : undefined;
+}
+
 /**
  * Select presentation metadata by source rank and operation precedence.
  */
@@ -89,18 +104,17 @@ export function normalizeLegacyHeadingEntries(
   const textIndex = entries.findIndex((entry) => entry.type === 'TextEntry');
   const textEntry = entries[textIndex];
   if (!textEntry || textEntry.type !== 'TextEntry') return entries;
-  const heading = /^##[ \t]+([^\r\n]+)(?:\r?\n|$)/.exec(textEntry.text);
-  const title = heading?.[1]?.trim();
-  if (!heading || !title) return entries;
+  const heading = parseLegacyHeading(textEntry.text);
+  if (!heading) return entries;
 
   const presentation: PresentationEntry = {
     type: 'PresentationEntry',
-    title,
+    title: heading.title,
     source: 'legacy',
     loc: textEntry.loc,
     titleLoc: textEntry.loc,
   };
-  const remainder = textEntry.text.slice(heading[0].length);
+  const remainder = textEntry.text.slice(heading.end);
   return [
     ...entries.slice(0, textIndex),
     presentation,

--- a/packages/core/src/presentation.ts
+++ b/packages/core/src/presentation.ts
@@ -1,0 +1,110 @@
+import type { BlockEntry, PresentationEntry } from './types/index.js';
+import { getPrimarySectionForBlock } from './section-registry.js';
+import { compareVersions, isValidVersion } from './utils/version.js';
+
+export type PresentationPrecedence = 'base' | 'incoming';
+
+export interface PresentationSelection {
+  readonly base: readonly PresentationEntry[];
+  readonly incoming: readonly PresentationEntry[];
+}
+
+export function presentationEntryKey(entry: PresentationEntry, blockName?: string): string {
+  return (
+    entry.sectionId ?? (blockName ? getPrimarySectionForBlock(blockName)?.id : undefined) ?? ''
+  );
+}
+
+function sourceRank(entry: PresentationEntry): number {
+  return entry.source === 'explicit' ? 2 : 1;
+}
+
+/**
+ * Select presentation metadata by source rank and operation precedence.
+ */
+export function selectPresentationEntries(
+  baseEntries: readonly BlockEntry[],
+  incomingEntries: readonly BlockEntry[],
+  precedence: PresentationPrecedence,
+  blockName?: string
+): PresentationSelection {
+  const base = baseEntries.filter(
+    (entry): entry is PresentationEntry => entry.type === 'PresentationEntry'
+  );
+  const incoming = incomingEntries.filter(
+    (entry): entry is PresentationEntry => entry.type === 'PresentationEntry'
+  );
+  const selectedBase = new Set<PresentationEntry>();
+  const selectedIncoming = new Set<PresentationEntry>();
+  const keys = new Set([
+    ...base.map((entry) => presentationEntryKey(entry, blockName)),
+    ...incoming.map((entry) => presentationEntryKey(entry, blockName)),
+  ]);
+
+  for (const key of keys) {
+    const baseMatches = base.filter((entry) => presentationEntryKey(entry, blockName) === key);
+    const incomingMatches = incoming.filter(
+      (entry) => presentationEntryKey(entry, blockName) === key
+    );
+    const baseRank = Math.max(0, ...baseMatches.map(sourceRank));
+    const incomingRank = Math.max(0, ...incomingMatches.map(sourceRank));
+    const selectedLayer =
+      baseRank > incomingRank ? 'base' : incomingRank > baseRank ? 'incoming' : precedence;
+    const matches = selectedLayer === 'base' ? baseMatches : incomingMatches;
+    const rank = selectedLayer === 'base' ? baseRank : incomingRank;
+    const selected = selectedLayer === 'base' ? selectedBase : selectedIncoming;
+    for (const entry of matches) {
+      if (sourceRank(entry) === rank) selected.add(entry);
+    }
+  }
+
+  return {
+    base: base.filter((entry) => selectedBase.has(entry)),
+    incoming: incoming.filter((entry) => selectedIncoming.has(entry)),
+  };
+}
+
+/**
+ * Promote an initial text heading for opted-in blocks in syntax 1.5.0+.
+ */
+export function normalizeLegacyHeadingEntries(
+  blockName: string,
+  entries: readonly BlockEntry[],
+  syntaxVersion: string | undefined
+): readonly BlockEntry[] {
+  const section = getPrimarySectionForBlock(blockName);
+  if (
+    !syntaxVersion ||
+    !isValidVersion(syntaxVersion) ||
+    compareVersions(syntaxVersion, '1.5.0') < 0 ||
+    !section?.legacyHeadingFallback ||
+    entries.some(
+      (entry) =>
+        entry.type === 'FieldEntry' || entry.type === 'ListEntry' || entry.type === 'InlineUseEntry'
+    )
+  ) {
+    return entries;
+  }
+
+  const textIndex = entries.findIndex((entry) => entry.type === 'TextEntry');
+  const textEntry = entries[textIndex];
+  if (!textEntry || textEntry.type !== 'TextEntry') return entries;
+  const heading = /^##[ \t]+([^\r\n]+)(?:\r?\n|$)/.exec(textEntry.text);
+  const title = heading?.[1]?.trim();
+  if (!heading || !title) return entries;
+
+  const presentation: PresentationEntry = {
+    type: 'PresentationEntry',
+    title,
+    source: 'legacy',
+    loc: textEntry.loc,
+    titleLoc: textEntry.loc,
+  };
+  const remainder = textEntry.text.slice(heading[0].length);
+  return [
+    ...entries.slice(0, textIndex),
+    presentation,
+    ...(remainder ? [{ ...textEntry, text: remainder }] : []),
+    ...entries.slice(textIndex + 1),
+  ];
+}

--- a/packages/core/src/section-registry.ts
+++ b/packages/core/src/section-registry.ts
@@ -1,0 +1,217 @@
+/**
+ * Browser-safe contract for a generated human-readable section.
+ */
+export const CONTEXTUAL_DIRECTIVES = ['@header'] as const;
+
+export interface SectionContract {
+  readonly id: string;
+  readonly defaultTitle: string;
+  readonly description: string;
+  /** Blocks whose keyless @header directive names this section. */
+  readonly primaryForBlocks: readonly string[];
+  readonly primaryOwner: string;
+  readonly fallbackOwners: readonly string[];
+  readonly sourceBlocks: readonly string[];
+  readonly required: boolean;
+  readonly legacyHeadingFallback: boolean;
+  readonly formatterAliases: readonly string[];
+}
+
+/**
+ * Canonical registry shared by parsing, validation, and formatting.
+ */
+export const SECTION_REGISTRY: readonly SectionContract[] = [
+  {
+    id: 'project',
+    defaultTitle: 'Project',
+    description: 'Project identity and purpose',
+    primaryForBlocks: ['identity'],
+    primaryOwner: 'identity',
+    fallbackOwners: ['context'],
+    sourceBlocks: ['identity', 'context'],
+    required: true,
+    legacyHeadingFallback: true,
+    formatterAliases: ['project'],
+  },
+  {
+    id: 'tech-stack',
+    defaultTitle: 'Tech Stack',
+    description: 'Languages, frameworks, and tools',
+    primaryForBlocks: [],
+    primaryOwner: 'context',
+    fallbackOwners: ['standards'],
+    sourceBlocks: ['context', 'standards'],
+    required: false,
+    legacyHeadingFallback: false,
+    formatterAliases: ['techStack'],
+  },
+  {
+    id: 'architecture',
+    defaultTitle: 'Architecture',
+    description: 'System structure and components',
+    primaryForBlocks: [],
+    primaryOwner: 'context',
+    fallbackOwners: [],
+    sourceBlocks: ['context'],
+    required: false,
+    legacyHeadingFallback: false,
+    formatterAliases: ['architecture'],
+  },
+  {
+    id: 'context',
+    defaultTitle: 'Context',
+    description: 'Additional project context',
+    primaryForBlocks: ['context'],
+    primaryOwner: 'context',
+    fallbackOwners: [],
+    sourceBlocks: ['context'],
+    required: false,
+    legacyHeadingFallback: true,
+    formatterAliases: ['context'],
+  },
+  {
+    id: 'code-standards',
+    defaultTitle: 'Code Style',
+    description: 'Language, naming, error handling, and testing standards',
+    primaryForBlocks: ['standards'],
+    primaryOwner: 'standards',
+    fallbackOwners: [],
+    sourceBlocks: ['standards'],
+    required: false,
+    legacyHeadingFallback: true,
+    formatterAliases: ['codeStandards'],
+  },
+  {
+    id: 'git-commits',
+    defaultTitle: 'Git Commits',
+    description: 'Commit message conventions',
+    primaryForBlocks: [],
+    primaryOwner: 'standards',
+    fallbackOwners: [],
+    sourceBlocks: ['standards'],
+    required: false,
+    legacyHeadingFallback: false,
+    formatterAliases: ['gitCommits'],
+  },
+  {
+    id: 'configuration-files',
+    defaultTitle: 'Config Files',
+    description: 'Configuration file guidelines',
+    primaryForBlocks: [],
+    primaryOwner: 'standards',
+    fallbackOwners: [],
+    sourceBlocks: ['standards'],
+    required: false,
+    legacyHeadingFallback: false,
+    formatterAliases: ['configFiles'],
+  },
+  {
+    id: 'commands',
+    defaultTitle: 'Commands',
+    description: 'Development commands and shortcuts',
+    primaryForBlocks: ['shortcuts', 'commands'],
+    primaryOwner: 'shortcuts',
+    fallbackOwners: ['commands', 'knowledge'],
+    sourceBlocks: ['shortcuts', 'commands', 'knowledge'],
+    required: false,
+    legacyHeadingFallback: true,
+    formatterAliases: ['commands'],
+  },
+  {
+    id: 'post-work',
+    defaultTitle: 'Post-Work Verification',
+    description: 'Commands to run after changes',
+    primaryForBlocks: [],
+    primaryOwner: 'knowledge',
+    fallbackOwners: [],
+    sourceBlocks: ['knowledge'],
+    required: false,
+    legacyHeadingFallback: false,
+    formatterAliases: ['postWork'],
+  },
+  {
+    id: 'documentation',
+    defaultTitle: 'Documentation',
+    description: 'Documentation guidelines',
+    primaryForBlocks: [],
+    primaryOwner: 'standards',
+    fallbackOwners: [],
+    sourceBlocks: ['standards'],
+    required: false,
+    legacyHeadingFallback: false,
+    formatterAliases: ['documentation'],
+  },
+  {
+    id: 'diagrams',
+    defaultTitle: 'Diagrams',
+    description: 'Diagram format guidelines',
+    primaryForBlocks: [],
+    primaryOwner: 'standards',
+    fallbackOwners: [],
+    sourceBlocks: ['standards'],
+    required: false,
+    legacyHeadingFallback: false,
+    formatterAliases: ['diagrams'],
+  },
+  {
+    id: 'knowledge',
+    defaultTitle: 'Knowledge',
+    description: 'Additional project knowledge',
+    primaryForBlocks: ['knowledge'],
+    primaryOwner: 'knowledge',
+    fallbackOwners: [],
+    sourceBlocks: ['knowledge'],
+    required: false,
+    legacyHeadingFallback: true,
+    formatterAliases: ['knowledge'],
+  },
+  {
+    id: 'restrictions',
+    defaultTitle: 'Restrictions',
+    description: 'Forbidden practices',
+    primaryForBlocks: ['restrictions'],
+    primaryOwner: 'restrictions',
+    fallbackOwners: [],
+    sourceBlocks: ['restrictions'],
+    required: false,
+    legacyHeadingFallback: true,
+    formatterAliases: ['restrictions'],
+  },
+  {
+    id: 'examples',
+    defaultTitle: 'Examples',
+    description: 'Input and output examples',
+    primaryForBlocks: ['examples'],
+    primaryOwner: 'examples',
+    fallbackOwners: [],
+    sourceBlocks: ['examples'],
+    required: false,
+    legacyHeadingFallback: true,
+    formatterAliases: ['examples'],
+  },
+] as const;
+
+export function getSectionContract(sectionIdOrAlias: string): SectionContract | undefined {
+  return SECTION_REGISTRY.find(
+    (section) =>
+      section.id === sectionIdOrAlias || section.formatterAliases.includes(sectionIdOrAlias)
+  );
+}
+
+export function getPrimarySectionForBlock(blockName: string): SectionContract | undefined {
+  return SECTION_REGISTRY.find((section) => section.primaryForBlocks.includes(blockName));
+}
+
+export function getSectionsForBlock(blockName: string): readonly SectionContract[] {
+  return SECTION_REGISTRY.filter(
+    (section) => section.primaryOwner === blockName || section.fallbackOwners.includes(blockName)
+  );
+}
+
+export function blockOwnsSection(blockName: string, sectionIdOrAlias: string): boolean {
+  const section = getSectionContract(sectionIdOrAlias);
+  return (
+    section !== undefined &&
+    (section.primaryOwner === blockName || section.fallbackOwners.includes(blockName))
+  );
+}

--- a/packages/core/src/syntax-versions.ts
+++ b/packages/core/src/syntax-versions.ts
@@ -6,6 +6,7 @@ import type { Program, SourceLocation } from './types/index.js';
  */
 export const SYNTAX_FEATURES = {
   REGULAR_BLOCK_REPLACE: 'regular-block-replace',
+  SECTION_HEADER_OVERRIDE: 'section-header-override',
 } as const;
 
 export type SyntaxFeature = (typeof SYNTAX_FEATURES)[keyof typeof SYNTAX_FEATURES];
@@ -131,10 +132,33 @@ export const SYNTAX_VERSIONS: Readonly<Record<string, SyntaxVersionDef>> = {
     ],
     features: [SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE],
   },
+  '1.5.0': {
+    blocks: [
+      'identity',
+      'context',
+      'standards',
+      'restrictions',
+      'knowledge',
+      'shortcuts',
+      'commands',
+      'guards',
+      'params',
+      'skills',
+      'local',
+      'agents',
+      'workflows',
+      'hooks',
+      'mcpServers',
+      'plugins',
+      'prompts',
+      'examples',
+    ],
+    features: [SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE, SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE],
+  },
 };
 
 /** Latest known syntax version. */
-export const LATEST_SYNTAX_VERSION = '1.4.0';
+export const LATEST_SYNTAX_VERSION = '1.5.0';
 
 /**
  * Get the latest known syntax version.

--- a/packages/core/src/types/ast.ts
+++ b/packages/core/src/types/ast.ts
@@ -548,9 +548,22 @@ export interface InlineUseEntry extends CanonicalNode {
 }
 
 /**
+ * Canonical presentation metadata for a generated section title.
+ */
+export interface PresentationEntry extends CanonicalNode {
+  readonly type: 'PresentationEntry';
+  /** Canonical section ID. Omitted for the block's primary section. */
+  readonly sectionId?: string;
+  readonly title: string;
+  readonly source: 'explicit' | 'legacy';
+  readonly sectionLoc?: SourceLocation;
+  readonly titleLoc: SourceLocation;
+}
+
+/**
  * Ordered canonical block entry.
  */
-export type BlockEntry = TextEntry | FieldEntry | ListEntry | InlineUseEntry;
+export type BlockEntry = TextEntry | FieldEntry | ListEntry | InlineUseEntry | PresentationEntry;
 
 /**
  * Uniform canonical body shared by every block type.

--- a/packages/formatters/src/__tests__/markdown-instruction-formatter.spec.ts
+++ b/packages/formatters/src/__tests__/markdown-instruction-formatter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import type { Program, SourceLocation, Value } from '@promptscript/core';
+import { createBlockBody, type Program, type SourceLocation, type Value } from '@promptscript/core';
 import { MarkdownInstructionFormatter } from '../markdown-instruction-formatter.js';
 import type { MarkdownFormatterConfig } from '../markdown-instruction-formatter.js';
 
@@ -491,6 +491,84 @@ describe('MarkdownInstructionFormatter', () => {
       const result = customFormatter.format(ast);
       expect(result.content).toContain("## Don'ts");
       expect(result.content).not.toContain('## Restrictions');
+    });
+
+    it('should prefer source section titles without dropping block content', () => {
+      const customFormatter = new TestFormatter({
+        sectionNames: { restrictions: "Don'ts" },
+      });
+      const loc = createLoc();
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'restrictions',
+            content: {
+              type: 'ArrayContent',
+              elements: ['No foo', 'No bar'],
+              loc,
+            },
+            canonicalBody: createBlockBody(
+              [
+                {
+                  type: 'PresentationEntry',
+                  title: 'Forbidden Practices',
+                  source: 'explicit',
+                  loc,
+                  titleLoc: loc,
+                },
+              ],
+              loc
+            ),
+            loc,
+          },
+        ],
+      };
+
+      const result = customFormatter.format(ast);
+
+      expect(result.content).toContain('## Forbidden Practices');
+      expect(result.content).toContain('No foo');
+      expect(result.content).toContain('No bar');
+      expect(result.content).not.toContain("## Don'ts");
+    });
+
+    it('should keep XML section keys stable when source titles are overridden', () => {
+      const loc = createLoc();
+      const ast: Program = {
+        ...createMinimalProgram(),
+        blocks: [
+          {
+            type: 'Block',
+            name: 'restrictions',
+            content: {
+              type: 'ArrayContent',
+              elements: ['No foo'],
+              loc,
+            },
+            canonicalBody: createBlockBody(
+              [
+                {
+                  type: 'PresentationEntry',
+                  title: 'Forbidden Practices',
+                  source: 'explicit',
+                  loc,
+                  titleLoc: loc,
+                },
+              ],
+              loc
+            ),
+            loc,
+          },
+        ],
+      };
+
+      const result = formatter.format(ast, { convention: 'xml' });
+
+      expect(result.content).toContain('<restrictions>');
+      expect(result.content).not.toContain('<forbidden-practices>');
+      expect(result.content).toContain('No foo');
     });
   });
 

--- a/packages/formatters/src/__tests__/section-header-overrides.spec.ts
+++ b/packages/formatters/src/__tests__/section-header-overrides.spec.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { createBlockBody, type Program, type SourceLocation } from '@promptscript/core';
+import { AntigravityFormatter } from '../formatters/antigravity.js';
+import { ClaudeFormatter } from '../formatters/claude.js';
+import { CursorFormatter } from '../formatters/cursor.js';
+import { FactoryFormatter } from '../formatters/factory.js';
+import { GitHubFormatter } from '../formatters/github.js';
+
+const loc: SourceLocation = { file: 'headers.prs', line: 4, column: 3, offset: 52 };
+
+function createProgram(): Program {
+  return {
+    type: 'Program',
+    meta: {
+      type: 'MetaBlock',
+      fields: { id: 'headers', syntax: '1.5.0' },
+      loc,
+    },
+    blocks: [
+      {
+        type: 'Block',
+        name: 'restrictions',
+        content: {
+          type: 'ArrayContent',
+          elements: ['No unsafe casts', 'No skipped validation'],
+          loc,
+        },
+        canonicalBody: createBlockBody(
+          [
+            {
+              type: 'PresentationEntry',
+              title: 'Forbidden Practices',
+              source: 'explicit',
+              loc,
+              titleLoc: loc,
+            },
+          ],
+          loc
+        ),
+        loc,
+      },
+    ],
+    uses: [],
+    extends: [],
+    loc,
+  };
+}
+
+function createKnowledgeProgram(): Program {
+  return {
+    type: 'Program',
+    meta: {
+      type: 'MetaBlock',
+      fields: { id: 'headers', syntax: '1.5.0' },
+      loc,
+    },
+    blocks: [
+      {
+        type: 'Block',
+        name: 'knowledge',
+        content: {
+          type: 'TextContent',
+          value: 'General operational guidance.',
+          loc,
+        },
+        canonicalBody: createBlockBody(
+          [
+            {
+              type: 'PresentationEntry',
+              title: 'Operational Notes',
+              source: 'explicit',
+              loc,
+              titleLoc: loc,
+            },
+            {
+              type: 'TextEntry',
+              text: 'General operational guidance.',
+              loc,
+            },
+          ],
+          loc
+        ),
+        loc,
+      },
+    ],
+    uses: [],
+    extends: [],
+    loc,
+  };
+}
+
+function createContextProgram(
+  source: 'explicit' | 'legacy' = 'explicit',
+  sectionId?: string,
+  mixed = false
+): Program {
+  const text = 'Preserve this context body.';
+  return {
+    type: 'Program',
+    meta: {
+      type: 'MetaBlock',
+      fields: { id: 'headers', syntax: '1.5.0' },
+      loc,
+    },
+    blocks: [
+      {
+        type: 'Block',
+        name: 'context',
+        content: mixed
+          ? {
+              type: 'MixedContent',
+              text: { type: 'TextContent', value: text, loc },
+              properties: { languages: ['TypeScript'] },
+              loc,
+            }
+          : { type: 'TextContent', value: text, loc },
+        canonicalBody: createBlockBody(
+          [
+            {
+              type: 'PresentationEntry',
+              ...(sectionId ? { sectionId, sectionLoc: loc } : {}),
+              title: 'Project Notes',
+              source,
+              loc,
+              titleLoc: loc,
+            },
+            {
+              type: 'TextEntry',
+              text,
+              loc,
+            },
+          ],
+          loc
+        ),
+        loc,
+      },
+    ],
+    uses: [],
+    extends: [],
+    loc,
+  };
+}
+
+describe('section header overrides across formatters', () => {
+  const formatters = [
+    ['claude', new ClaudeFormatter()],
+    ['factory', new FactoryFormatter()],
+    ['github', new GitHubFormatter()],
+    ['cursor', new CursorFormatter()],
+    ['antigravity', new AntigravityFormatter()],
+  ] as const;
+
+  it.each(formatters)(
+    'should use source titles and preserve content for %s',
+    (_name, formatter) => {
+      const output = formatter.format(createProgram(), { version: 'simple' });
+
+      expect(output.content).toContain('Forbidden Practices');
+      expect(output.content).toContain('No unsafe casts');
+      expect(output.content).toContain('No skipped validation');
+    }
+  );
+
+  it.each(formatters)('should title free-form knowledge content for %s', (_name, formatter) => {
+    const output = formatter.format(createKnowledgeProgram(), { version: 'simple' });
+
+    expect(output.content).toContain('Operational Notes');
+    expect(output.content).toContain('General operational guidance.');
+  });
+
+  it.each(formatters)('should preserve text-only context content for %s', (_name, formatter) => {
+    const output = formatter.format(createContextProgram(), { version: 'simple' });
+
+    expect(output.content).toContain('Project Notes');
+    expect(output.content).toContain('Preserve this context body.');
+  });
+
+  it.each(formatters)(
+    'should preserve legacy context heading content for %s',
+    (_name, formatter) => {
+      const output = formatter.format(createContextProgram('legacy'), { version: 'simple' });
+
+      expect(output.content).toContain('Project Notes');
+      expect(output.content).toContain('Preserve this context body.');
+    }
+  );
+
+  it.each(formatters)(
+    'should render mixed context content exactly once for %s',
+    (_name, formatter) => {
+      const output = formatter.format(createContextProgram('explicit', undefined, true), {
+        version: 'simple',
+      });
+
+      expect(output.content).toContain('Project Notes');
+      expect(output.content.match(/Preserve this context body\./g)).toHaveLength(1);
+    }
+  );
+
+  it.each(formatters)(
+    'should preserve text-only project content owned by context for %s',
+    (_name, formatter) => {
+      const output = formatter.format(createContextProgram('explicit', 'project'), {
+        version: 'simple',
+      });
+
+      expect(output.content).toContain('Project Notes');
+      expect(output.content).toContain('Preserve this context body.');
+    }
+  );
+});

--- a/packages/formatters/src/__tests__/section-header-overrides.spec.ts
+++ b/packages/formatters/src/__tests__/section-header-overrides.spec.ts
@@ -89,6 +89,46 @@ function createKnowledgeProgram(): Program {
   };
 }
 
+function createIdentityProgram(): Program {
+  const text = 'Preserve this identity body.';
+  return {
+    type: 'Program',
+    meta: {
+      type: 'MetaBlock',
+      fields: { id: 'headers', syntax: '1.5.0' },
+      loc,
+    },
+    blocks: [
+      {
+        type: 'Block',
+        name: 'identity',
+        content: { type: 'TextContent', value: text, loc },
+        canonicalBody: createBlockBody(
+          [
+            {
+              type: 'PresentationEntry',
+              title: 'Localized Project',
+              source: 'explicit',
+              loc,
+              titleLoc: loc,
+            },
+            {
+              type: 'TextEntry',
+              text,
+              loc,
+            },
+          ],
+          loc
+        ),
+        loc,
+      },
+    ],
+    uses: [],
+    extends: [],
+    loc,
+  };
+}
+
 function createContextProgram(
   source: 'explicit' | 'legacy' = 'explicit',
   sectionId?: string,
@@ -208,4 +248,11 @@ describe('section header overrides across formatters', () => {
       expect(output.content).toContain('Preserve this context body.');
     }
   );
+
+  it.each(formatters)('should title identity content for %s', (_name, formatter) => {
+    const output = formatter.format(createIdentityProgram(), { version: 'simple' });
+
+    expect(output.content).toContain('Localized Project');
+    expect(output.content).toContain('Preserve this identity body.');
+  });
 });

--- a/packages/formatters/src/__tests__/section-title-resolver.spec.ts
+++ b/packages/formatters/src/__tests__/section-title-resolver.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBlockBody,
+  type Block,
+  type PresentationEntry,
+  type Program,
+  type SourceLocation,
+} from '@promptscript/core';
+import { resolveSectionTitle } from '../section-title-resolver.js';
+
+const loc: SourceLocation = { file: 'titles.prs', line: 1, column: 1, offset: 0 };
+
+function header(
+  title: string,
+  sectionId?: string,
+  source: PresentationEntry['source'] = 'explicit'
+): PresentationEntry {
+  return {
+    type: 'PresentationEntry',
+    ...(sectionId ? { sectionId } : {}),
+    title,
+    source,
+    loc,
+    titleLoc: loc,
+  };
+}
+
+function block(name: string, entries: PresentationEntry[]): Block {
+  return {
+    type: 'Block',
+    name,
+    content: { type: 'ObjectContent', properties: {}, loc },
+    canonicalBody: createBlockBody(entries, loc),
+    loc,
+  };
+}
+
+function program(blocks: Block[]): Program {
+  return {
+    type: 'Program',
+    blocks,
+    uses: [],
+    extends: [],
+    loc,
+  };
+}
+
+describe('resolveSectionTitle', () => {
+  it('should resolve primary and derived source overrides', () => {
+    const ast = program([
+      block('standards', [header('Coding Rules'), header('Commit Rules', 'git-commits')]),
+    ]);
+
+    expect(resolveSectionTitle(ast, 'code-standards')).toBe('Coding Rules');
+    expect(resolveSectionTitle(ast, 'git-commits')).toBe('Commit Rules');
+  });
+
+  it('should prefer source overrides over config aliases and target defaults', () => {
+    const ast = program([block('standards', [header('Source Rules')])]);
+
+    expect(
+      resolveSectionTitle(ast, 'codeStandards', {
+        formatterTitles: { codeStandards: 'Configured Rules' },
+        defaultTitle: 'Target Rules',
+      })
+    ).toBe('Source Rules');
+    expect(
+      resolveSectionTitle(program([]), 'code-standards', {
+        formatterTitles: { codeStandards: 'Configured Rules' },
+        defaultTitle: 'Target Rules',
+      })
+    ).toBe('Configured Rules');
+  });
+
+  it('should apply owner precedence within the highest presentation rank', () => {
+    const explicitFallback = program([
+      block('identity', [header('Legacy Project', undefined, 'legacy')]),
+      block('context', [header('Explicit Project', 'project')]),
+    ]);
+    const explicitOwners = program([
+      block('identity', [header('Identity Project')]),
+      block('context', [header('Context Project', 'project')]),
+    ]);
+
+    expect(resolveSectionTitle(explicitFallback, 'project')).toBe('Explicit Project');
+    expect(resolveSectionTitle(explicitOwners, 'project')).toBe('Identity Project');
+  });
+
+  it('should preserve target and registry defaults when no override exists', () => {
+    expect(resolveSectionTitle(program([]), 'restrictions', { defaultTitle: "Don'ts" })).toBe(
+      "Don'ts"
+    );
+    expect(resolveSectionTitle(program([]), 'git-commits')).toBe('Git Commits');
+    expect(resolveSectionTitle(program([]), 'unregistered', { defaultTitle: 'Fallback' })).toBe(
+      'Fallback'
+    );
+  });
+});

--- a/packages/formatters/src/formatters/antigravity.ts
+++ b/packages/formatters/src/formatters/antigravity.ts
@@ -8,6 +8,7 @@ import {
   extractMcpServers,
   serializeMcpServersToJsonString,
 } from '../mcp-helpers.js';
+import { resolveSectionTitle, resolveSourceSectionTitle } from '../section-title-resolver.js';
 
 /**
  * Supported Antigravity format versions.
@@ -459,15 +460,17 @@ export class AntigravityFormatter extends BaseFormatter {
       content = this.extractText(identity.content);
     } else {
       const context = this.findBlock(ast, 'context');
-      if (context?.content.type === 'MixedContent' && context.content.text) {
-        content = context.content.text.value.trim();
+      const contextTitle = resolveSourceSectionTitle(ast, 'context');
+      const projectTitle = resolveSourceSectionTitle(ast, 'project');
+      if (!contextTitle && context && (context.content.type === 'MixedContent' || projectTitle)) {
+        content = this.extractText(context.content).trim();
       }
     }
 
     if (!content) return null;
 
     // Apply stripAllIndent to normalize merged identity content for Prettier compatibility
-    return `## Project Identity
+    return `## ${resolveSectionTitle(ast, 'project', { defaultTitle: 'Project Identity' })}
 
 ${this.stripAllIndent(content)}`;
   }
@@ -480,7 +483,7 @@ ${this.stripAllIndent(content)}`;
     if (context) {
       const items = this.extractTechStackFromContext(context);
       if (items.length > 0) {
-        return `## Tech Stack\n\n${items.join('\n')}`;
+        return `## ${resolveSectionTitle(ast, 'tech-stack', { defaultTitle: 'Tech Stack' })}\n\n${items.join('\n')}`;
       }
     }
 
@@ -489,7 +492,7 @@ ${this.stripAllIndent(content)}`;
     if (standards) {
       const items = this.extractTechStackFromStandards(standards);
       if (items.length > 0) {
-        return `## Tech Stack\n\n${items.join(', ')}`;
+        return `## ${resolveSectionTitle(ast, 'tech-stack', { defaultTitle: 'Tech Stack' })}\n\n${items.join(', ')}`;
       }
     }
 
@@ -576,7 +579,7 @@ ${this.stripAllIndent(content)}`;
       if (archMatch) {
         const content = archMatch.replace('## Architecture', '').trim();
         // Apply stripAllIndent to normalize content for Prettier compatibility
-        return `## Architecture
+        return `## ${resolveSectionTitle(ast, 'architecture', { defaultTitle: 'Architecture' })}
 
 ${this.stripAllIndent(content)}`;
       }
@@ -587,7 +590,7 @@ ${this.stripAllIndent(content)}`;
       if (arch) {
         const archText = typeof arch === 'string' ? arch : this.valueToString(arch);
         if (archText.trim()) {
-          return `## Architecture
+          return `## ${resolveSectionTitle(ast, 'architecture', { defaultTitle: 'Architecture' })}
 
 ${this.stripAllIndent(archText.trim())}`;
         }
@@ -599,7 +602,7 @@ ${this.stripAllIndent(archText.trim())}`;
     if (archBlock) {
       const content = this.extractText(archBlock.content);
       if (content) {
-        return `## Architecture
+        return `## ${resolveSectionTitle(ast, 'architecture', { defaultTitle: 'Architecture' })}
 
 ${this.stripAllIndent(content)}`;
       }
@@ -610,7 +613,7 @@ ${this.stripAllIndent(content)}`;
 
   private contextSection(ast: Program, _renderer: ConventionRenderer): string | null {
     const identity = this.findBlock(ast, 'identity');
-    if (!identity) return null; // identity() fallback handles @context text
+    if (!identity && !resolveSourceSectionTitle(ast, 'context')) return null;
 
     const contextBlock = this.findBlock(ast, 'context');
     if (!contextBlock) return null;
@@ -625,7 +628,7 @@ ${this.stripAllIndent(content)}`;
 
     // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
     const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
-    return `## Context
+    return `## ${resolveSectionTitle(ast, 'context', { defaultTitle: 'Context' })}
 
 ${this.stripAllIndent(downgradedText)}`;
   }
@@ -651,7 +654,7 @@ ${this.stripAllIndent(downgradedText)}`;
 
     if (subsections.length === 0) return null;
 
-    return `## Code Standards\n\n${subsections.join('\n\n')}`;
+    return `## ${resolveSectionTitle(ast, 'code-standards', { defaultTitle: 'Code Standards' })}\n\n${subsections.join('\n\n')}`;
   }
 
   /**
@@ -699,7 +702,7 @@ ${this.stripAllIndent(downgradedText)}`;
 
     if (items.length === 0) return null;
 
-    return `## Git Commits
+    return `## ${resolveSectionTitle(ast, 'git-commits', { defaultTitle: 'Git Commits' })}
 
 ${items.map((i) => '- ' + i).join('\n')}`;
   }
@@ -733,7 +736,7 @@ ${items.map((i) => '- ' + i).join('\n')}`;
 
     if (subsections.length === 0) return null;
 
-    return `## Configuration Files
+    return `## ${resolveSectionTitle(ast, 'configuration-files', { defaultTitle: 'Configuration Files' })}
 
 ${subsections.join('\n\n')}`;
   }
@@ -766,7 +769,7 @@ ${subsections.join('\n\n')}`;
     // Only return if there are non-workflow commands
     if (lines.length === 0) return null;
 
-    return `## Commands
+    return `## ${resolveSectionTitle(ast, 'commands', { defaultTitle: 'Commands' })}
 
 ${lines.join('\n')}`;
   }
@@ -784,7 +787,7 @@ ${lines.join('\n')}`;
 
     const content = commandsMatch.replace('## Development Commands', '').trim();
     // Apply stripAllIndent to normalize content for Prettier compatibility
-    return `## Development Commands
+    return `## ${resolveSectionTitle(ast, 'commands', { defaultTitle: 'Development Commands' })}
 
 ${this.stripAllIndent(content)}`;
   }
@@ -804,7 +807,7 @@ ${this.stripAllIndent(content)}`;
       'After completing any code changes, run the following commands to ensure code quality:';
     const content = postMatch.replace('## Post-Work Verification', '').trim();
     // Apply stripAllIndent to normalize content for Prettier compatibility
-    return `## Post-Work Verification
+    return `## ${resolveSectionTitle(ast, 'post-work', { defaultTitle: 'Post-Work Verification' })}
 
 ${intro}
 ${this.stripAllIndent(content)}`;
@@ -842,7 +845,7 @@ ${this.stripAllIndent(content)}`;
 
     if (items.length === 0) return null;
 
-    return `## Documentation
+    return `## ${resolveSectionTitle(ast, 'documentation', { defaultTitle: 'Documentation' })}
 
 ${items.map((i) => '- ' + i).join('\n')}`;
   }
@@ -882,7 +885,7 @@ ${items.map((i) => '- ' + i).join('\n')}`;
 
     if (items.length === 0) return null;
 
-    return `## Diagrams
+    return `## ${resolveSectionTitle(ast, 'diagrams', { defaultTitle: 'Diagrams' })}
 
 ${items.map((i) => '- ' + i).join('\n')}`;
   }
@@ -921,7 +924,9 @@ ${items.map((i) => '- ' + i).join('\n')}`;
     remaining = remaining.trim();
     if (!remaining) return null;
 
-    return this.stripAllIndent(remaining);
+    const content = this.stripAllIndent(remaining);
+    const title = resolveSourceSectionTitle(ast, 'knowledge');
+    return title ? `## ${title}\n\n${content}` : content;
   }
 
   private restrictions(ast: Program, _renderer: ConventionRenderer): string | null {
@@ -931,7 +936,7 @@ ${items.map((i) => '- ' + i).join('\n')}`;
     const items = this.extractRestrictionsItems(block);
     if (items.length === 0) return null;
 
-    return `## Don'ts
+    return `## ${resolveSectionTitle(ast, 'restrictions', { defaultTitle: "Don'ts" })}
 
 ${items.map((i) => '- ' + i).join('\n')}`;
   }

--- a/packages/formatters/src/formatters/claude.ts
+++ b/packages/formatters/src/formatters/claude.ts
@@ -13,6 +13,7 @@ import {
   extractMcpServers,
   serializeMcpServersToJsonString,
 } from '../mcp-helpers.js';
+import { resolveSectionTitle, resolveSourceSectionTitle } from '../section-title-resolver.js';
 
 /**
  * Claude formatter version information.
@@ -1054,6 +1055,18 @@ export class ClaudeFormatter extends BaseFormatter {
     if (content) sections.push(content);
   }
 
+  private sectionTitle(
+    ast: Program,
+    renderer: ConventionRenderer,
+    sectionId: string,
+    defaultTitle?: string
+  ): string {
+    return resolveSectionTitle(ast, sectionId, {
+      ...(defaultTitle ? { defaultTitle } : {}),
+      sourceOverrides: renderer.getConvention().name !== 'xml',
+    });
+  }
+
   private project(ast: Program, renderer: ConventionRenderer): string | null {
     const identity = this.findBlock(ast, 'identity');
 
@@ -1062,8 +1075,10 @@ export class ClaudeFormatter extends BaseFormatter {
       text = this.extractText(identity.content);
     } else {
       const context = this.findBlock(ast, 'context');
-      if (context?.content.type === 'MixedContent' && context.content.text) {
-        text = context.content.text.value.trim();
+      const contextTitle = resolveSourceSectionTitle(ast, 'context');
+      const projectTitle = resolveSourceSectionTitle(ast, 'project');
+      if (!contextTitle && context && (context.content.type === 'MixedContent' || projectTitle)) {
+        text = this.extractText(context.content).trim();
       }
     }
 
@@ -1083,7 +1098,9 @@ export class ClaudeFormatter extends BaseFormatter {
 
     // Normalize for Prettier compatibility (blank lines before lists, etc.)
     const normalizedText = this.normalizeMarkdownForPrettier(cleanText);
-    return renderer.renderSection('Project', normalizedText) + '\n';
+    return (
+      renderer.renderSection(this.sectionTitle(ast, renderer, 'project'), normalizedText) + '\n'
+    );
   }
 
   private techStack(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1091,7 +1108,10 @@ export class ClaudeFormatter extends BaseFormatter {
     if (context) {
       const items = this.extractTechStackFromContext(context);
       if (items.length > 0) {
-        return renderer.renderSection('Tech Stack', items.join(', ')) + '\n';
+        return (
+          renderer.renderSection(this.sectionTitle(ast, renderer, 'tech-stack'), items.join(', ')) +
+          '\n'
+        );
       }
     }
 
@@ -1099,7 +1119,10 @@ export class ClaudeFormatter extends BaseFormatter {
     if (standards) {
       const items = this.extractTechStackFromStandards(standards);
       if (items.length > 0) {
-        return renderer.renderSection('Tech Stack', items.join(', ')) + '\n';
+        return (
+          renderer.renderSection(this.sectionTitle(ast, renderer, 'tech-stack'), items.join(', ')) +
+          '\n'
+        );
       }
     }
 
@@ -1160,12 +1183,17 @@ export class ClaudeFormatter extends BaseFormatter {
     const content = archMatch.replace('## Architecture', '');
     // Normalize for Prettier compatibility (strip code block indentation, etc.)
     const normalizedContent = this.normalizeMarkdownForPrettier(content);
-    return renderer.renderSection('Architecture', normalizedContent.trim()) + '\n';
+    return (
+      renderer.renderSection(
+        this.sectionTitle(ast, renderer, 'architecture'),
+        normalizedContent.trim()
+      ) + '\n'
+    );
   }
 
   private contextSection(ast: Program, renderer: ConventionRenderer): string | null {
     const identity = this.findBlock(ast, 'identity');
-    if (!identity) return null; // project() fallback handles @context text
+    if (!identity && !resolveSourceSectionTitle(ast, 'context')) return null;
 
     const contextBlock = this.findBlock(ast, 'context');
     if (!contextBlock) return null;
@@ -1181,7 +1209,12 @@ export class ClaudeFormatter extends BaseFormatter {
     // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
     const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
     const normalizedContent = this.normalizeMarkdownForPrettier(downgradedText);
-    return renderer.renderSection('Context', normalizedContent.trim()) + '\n';
+    return (
+      renderer.renderSection(
+        this.sectionTitle(ast, renderer, 'context'),
+        normalizedContent.trim()
+      ) + '\n'
+    );
   }
 
   private codeStandards(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1199,7 +1232,9 @@ export class ClaudeFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection('Code Style', content) + '\n';
+    return (
+      renderer.renderSection(this.sectionTitle(ast, renderer, 'code-standards'), content) + '\n'
+    );
   }
 
   private gitCommits(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1223,7 +1258,7 @@ export class ClaudeFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection('Git Commits', content) + '\n';
+    return renderer.renderSection(this.sectionTitle(ast, renderer, 'git-commits'), content) + '\n';
   }
 
   private configFiles(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1243,7 +1278,10 @@ export class ClaudeFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection('Config Files', content) + '\n';
+    return (
+      renderer.renderSection(this.sectionTitle(ast, renderer, 'configuration-files'), content) +
+      '\n'
+    );
   }
 
   private commands(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1277,7 +1315,7 @@ export class ClaudeFormatter extends BaseFormatter {
       }
     }
 
-    return renderer.renderSection('Commands', content) + '\n';
+    return renderer.renderSection(this.sectionTitle(ast, renderer, 'commands'), content) + '\n';
   }
 
   private postWork(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1292,7 +1330,12 @@ export class ClaudeFormatter extends BaseFormatter {
     const content = match.replace('## Post-Work Verification', '');
     // Normalize for Prettier compatibility
     const normalizedContent = this.normalizeMarkdownForPrettier(content);
-    return renderer.renderSection('Post-Work Verification', normalizedContent.trim()) + '\n';
+    return (
+      renderer.renderSection(
+        this.sectionTitle(ast, renderer, 'post-work'),
+        normalizedContent.trim()
+      ) + '\n'
+    );
   }
 
   private documentation(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1317,7 +1360,9 @@ export class ClaudeFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection('Documentation', content) + '\n';
+    return (
+      renderer.renderSection(this.sectionTitle(ast, renderer, 'documentation'), content) + '\n'
+    );
   }
 
   private diagrams(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1339,14 +1384,14 @@ export class ClaudeFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection('Diagrams', content) + '\n';
+    return renderer.renderSection(this.sectionTitle(ast, renderer, 'diagrams'), content) + '\n';
   }
 
   /**
    * Render remaining @knowledge content not already consumed by
    * commands() (## Development Commands) or postWork() (## Post-Work Verification).
    */
-  private knowledgeContent(ast: Program, _renderer: ConventionRenderer): string | null {
+  private knowledgeContent(ast: Program, renderer: ConventionRenderer): string | null {
     const knowledge = this.findBlock(ast, 'knowledge');
     if (!knowledge) return null;
 
@@ -1378,7 +1423,12 @@ export class ClaudeFormatter extends BaseFormatter {
     remaining = remaining.trim();
     if (!remaining) return null;
 
-    return this.stripAllIndent(remaining) + '\n';
+    const content = this.stripAllIndent(remaining);
+    const title =
+      renderer.getConvention().name === 'xml'
+        ? undefined
+        : resolveSourceSectionTitle(ast, 'knowledge');
+    return title ? renderer.renderSection(title, content) + '\n' : content + '\n';
   }
 
   private donts(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1388,11 +1438,14 @@ export class ClaudeFormatter extends BaseFormatter {
     const items = this.extractDontsItems(block);
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection("Don'ts", content) + '\n';
+    return (
+      renderer.renderSection(this.sectionTitle(ast, renderer, 'restrictions', "Don'ts"), content) +
+      '\n'
+    );
   }
 
   private examples(ast: Program, renderer: ConventionRenderer): string | null {
-    return this.renderExamplesSection(ast, renderer);
+    return this.renderExamplesSection(ast, renderer, this.sectionTitle(ast, renderer, 'examples'));
   }
 
   private extractDontsItems(block: Block): string[] {

--- a/packages/formatters/src/formatters/cursor.ts
+++ b/packages/formatters/src/formatters/cursor.ts
@@ -15,6 +15,7 @@ import {
   serializeMcpServersToJsonString,
 } from '../mcp-helpers.js';
 import { findPluginsBlock, extractPlugins, serializePluginsToJson } from '../plugin-helpers.js';
+import { resolveSectionTitle, resolveSourceSectionTitle } from '../section-title-resolver.js';
 
 /**
  * Supported Cursor format versions.
@@ -695,6 +696,9 @@ export class CursorFormatter extends BaseFormatter {
     const architecture = this.architecture(ast);
     if (architecture) sections.push(architecture);
 
+    const context = this.contextSection(ast);
+    if (context) sections.push(context);
+
     const codeStyle = this.codeStyle(ast);
     if (codeStyle) sections.push(codeStyle);
 
@@ -732,8 +736,13 @@ export class CursorFormatter extends BaseFormatter {
   private intro(ast: Program): string {
     // First check if identity block has rich content that should be used in full
     const identity = this.findBlock(ast, 'identity');
+    const projectTitle = resolveSourceSectionTitle(ast, 'project');
     if (identity) {
       const fullText = this.dedent(this.extractText(identity.content));
+      if (fullText && projectTitle) {
+        return `${resolveSectionTitle(ast, 'project')}:
+${fullText}`;
+      }
       // If identity starts with "You are", use the full content
       if (fullText.toLowerCase().startsWith('you are')) {
         return fullText;
@@ -743,9 +752,12 @@ export class CursorFormatter extends BaseFormatter {
     // Fall back to @context MixedContent text (project description alongside properties)
     if (!identity) {
       const context = this.findBlock(ast, 'context');
-      if (context?.content.type === 'MixedContent' && context.content.text) {
-        const text = this.dedent(context.content.text.value.trim());
-        if (text) return text;
+      const contextTitle = resolveSourceSectionTitle(ast, 'context');
+      if (!contextTitle && context && (context.content.type === 'MixedContent' || projectTitle)) {
+        const text = this.dedent(this.extractText(context.content).trim());
+        if (text) {
+          return projectTitle ? `${resolveSectionTitle(ast, 'project')}:\n${text}` : text;
+        }
       }
     }
 
@@ -823,7 +835,9 @@ export class CursorFormatter extends BaseFormatter {
 
   private techStack(ast: Program): string | null {
     const items = this.extractTechStackItems(ast);
-    return items.length > 0 ? `Tech stack: ${items.join(', ')}` : null;
+    return items.length > 0
+      ? `${resolveSectionTitle(ast, 'tech-stack', { defaultTitle: 'Tech stack' })}: ${items.join(', ')}`
+      : null;
   }
 
   private extractTechStackItems(ast: Program): string[] {
@@ -884,7 +898,9 @@ export class CursorFormatter extends BaseFormatter {
     const arch = this.getProp(context.content, 'architecture');
     if (arch) {
       const text = typeof arch === 'string' ? arch : this.valueToString(arch);
-      if (text.trim()) return `Architecture:\n${text.trim()}`;
+      if (text.trim()) {
+        return `${resolveSectionTitle(ast, 'architecture', { defaultTitle: 'Architecture' })}:\n${text.trim()}`;
+      }
     }
 
     // Fall back to extracting text which may contain architecture info
@@ -896,10 +912,28 @@ export class CursorFormatter extends BaseFormatter {
     return null;
   }
 
+  private contextSection(ast: Program): string | null {
+    if (!resolveSourceSectionTitle(ast, 'context')) return null;
+
+    const context = this.findBlock(ast, 'context');
+    if (!context) return null;
+
+    const text = this.extractText(context.content);
+    if (!text) return null;
+
+    const archMatch = this.extractSectionWithCodeBlock(text, '## Architecture');
+    const remainingText = archMatch ? text.replace(archMatch, '').trim() : text.trim();
+    if (!remainingText) return null;
+
+    const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
+    return `${resolveSectionTitle(ast, 'context', { defaultTitle: 'Context' })}:
+${this.stripAllIndent(downgradedText)}`;
+  }
+
   private codeStyle(ast: Program): string | null {
     const items = this.extractCodeStyleItems(ast);
     if (items.length === 0) return null;
-    return `Code style:\n${items.map((i) => '- ' + i).join('\n')}`;
+    return `${resolveSectionTitle(ast, 'code-standards', { defaultTitle: 'Code style' })}:\n${items.map((i) => '- ' + i).join('\n')}`;
   }
 
   private extractCodeStyleItems(ast: Program): string[] {
@@ -926,7 +960,7 @@ export class CursorFormatter extends BaseFormatter {
       if (git && typeof git === 'object' && !Array.isArray(git)) {
         const items = this.extractGitItems(git as Record<string, Value>);
         if (items.length > 0) {
-          return `Git Commits:\n${items.map((i) => '- ' + i).join('\n')}`;
+          return `${resolveSectionTitle(ast, 'git-commits', { defaultTitle: 'Git Commits' })}:\n${items.map((i) => '- ' + i).join('\n')}`;
         }
       }
     }
@@ -938,7 +972,7 @@ export class CursorFormatter extends BaseFormatter {
       if (commits && typeof commits === 'object' && !Array.isArray(commits)) {
         const items = this.extractGitItems(commits as Record<string, Value>);
         if (items.length > 0) {
-          return `Git Commits:\n${items.map((i) => '- ' + i).join('\n')}`;
+          return `${resolveSectionTitle(ast, 'git-commits', { defaultTitle: 'Git Commits' })}:\n${items.map((i) => '- ' + i).join('\n')}`;
         }
       }
     }
@@ -972,7 +1006,7 @@ export class CursorFormatter extends BaseFormatter {
   private configFiles(ast: Program): string | null {
     const items = this.extractConfigItems(ast);
     if (items.length === 0) return null;
-    return `Config:\n${items.map((i) => '- ' + i).join('\n')}`;
+    return `${resolveSectionTitle(ast, 'configuration-files', { defaultTitle: 'Config' })}:\n${items.map((i) => '- ' + i).join('\n')}`;
   }
 
   private extractConfigItems(ast: Program): string[] {
@@ -1037,7 +1071,9 @@ export class CursorFormatter extends BaseFormatter {
       lines.push(`${cmd} - ${shortDesc}`);
     }
 
-    return lines.length > 0 ? `Commands:\n${lines.join('\n')}` : null;
+    return lines.length > 0
+      ? `${resolveSectionTitle(ast, 'commands', { defaultTitle: 'Commands' })}:\n${lines.join('\n')}`
+      : null;
   }
 
   private devCommands(ast: Program): string | null {
@@ -1049,7 +1085,7 @@ export class CursorFormatter extends BaseFormatter {
     if (!match) return null;
 
     const content = match.replace('## Development Commands', '').trim();
-    return `Development Commands:\n${content}`;
+    return `${resolveSectionTitle(ast, 'commands', { defaultTitle: 'Development Commands' })}:\n${content}`;
   }
 
   private postWork(ast: Program): string | null {
@@ -1061,13 +1097,13 @@ export class CursorFormatter extends BaseFormatter {
     if (!match) return null;
 
     const content = match.replace('## Post-Work Verification', '').trim();
-    return `Post-Work Verification:\n${content}`;
+    return `${resolveSectionTitle(ast, 'post-work', { defaultTitle: 'Post-Work Verification' })}:\n${content}`;
   }
 
   private documentation(ast: Program): string | null {
     const items = this.extractDocItems(ast);
     if (items.length === 0) return null;
-    return `Documentation:\n${items.map((i) => '- ' + i).join('\n')}`;
+    return `${resolveSectionTitle(ast, 'documentation', { defaultTitle: 'Documentation' })}:\n${items.map((i) => '- ' + i).join('\n')}`;
   }
 
   private extractDocItems(ast: Program): string[] {
@@ -1106,7 +1142,7 @@ export class CursorFormatter extends BaseFormatter {
   private diagrams(ast: Program): string | null {
     const items = this.extractDiagramItems(ast);
     if (items.length === 0) return null;
-    return `Diagrams:\n${items.map((i) => '- ' + i).join('\n')}`;
+    return `${resolveSectionTitle(ast, 'diagrams', { defaultTitle: 'Diagrams' })}:\n${items.map((i) => '- ' + i).join('\n')}`;
   }
 
   private extractDiagramItems(ast: Program): string[] {
@@ -1174,14 +1210,18 @@ export class CursorFormatter extends BaseFormatter {
     remaining = remaining.trim();
     if (!remaining) return null;
 
-    return this.stripAllIndent(remaining);
+    const content = this.stripAllIndent(remaining);
+    const title = resolveSourceSectionTitle(ast, 'knowledge');
+    return title ? `${title}:\n${content}` : content;
   }
 
   private examples(ast: Program): string | null {
     const examples = this.extractExamples(ast);
     if (examples.length === 0) return null;
 
-    const parts: string[] = ['Examples:'];
+    const parts: string[] = [
+      `${resolveSectionTitle(ast, 'examples', { defaultTitle: 'Examples' })}:`,
+    ];
 
     for (const example of examples) {
       parts.push(`\n### Example: ${example.name}`);
@@ -1207,7 +1247,7 @@ export class CursorFormatter extends BaseFormatter {
     const items = this.extractNeverItems(block);
     if (items.length === 0) return null;
 
-    return `Never:\n${items.map((i) => '- ' + i).join('\n')}`;
+    return `${resolveSectionTitle(ast, 'restrictions', { defaultTitle: 'Never' })}:\n${items.map((i) => '- ' + i).join('\n')}`;
   }
 
   private extractNeverItems(block: Block): string[] {

--- a/packages/formatters/src/formatters/factory.ts
+++ b/packages/formatters/src/formatters/factory.ts
@@ -6,6 +6,7 @@ import {
   type MarkdownAgentConfig,
   type MarkdownCommandConfig,
   type MarkdownSkillConfig,
+  type SectionNameKey,
 } from '../markdown-instruction-formatter.js';
 import type { FormatOptions, FormatterOutput } from '../types.js';
 import {
@@ -20,6 +21,7 @@ import {
   serializeMcpServersToJsonString,
 } from '../mcp-helpers.js';
 import { findPluginsBlock, extractPlugins, serializePluginsToJson } from '../plugin-helpers.js';
+import { resolveSourceSectionTitle } from '../section-title-resolver.js';
 
 /**
  * Supported Factory AI format versions.
@@ -200,11 +202,19 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
       if (!text) return null;
 
       const normalizedContent = this.normalizeFreeformStandardsText(text);
-      return renderer.renderSection(this.getSectionName('codeStandards'), normalizedContent) + '\n';
+      return (
+        renderer.renderSection(
+          this.getRenderedSectionName(ast, 'codeStandards', renderer),
+          normalizedContent
+        ) + '\n'
+      );
     }
 
     return (
-      renderer.renderSection(this.getSectionName('codeStandards'), subsections.join('\n\n')) + '\n'
+      renderer.renderSection(
+        this.getRenderedSectionName(ast, 'codeStandards', renderer),
+        subsections.join('\n\n')
+      ) + '\n'
     );
   }
 
@@ -726,7 +736,9 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
         if (items.length === 0) continue;
 
         const semantic = this.getSemanticRuleInfo(topic);
-        const label = semantic?.label ?? this.humanizeLabel(topic);
+        const label = semantic
+          ? this.getSectionName(ast, semantic.sectionName, semantic.label)
+          : this.humanizeLabel(topic);
         const path =
           semantic?.path ??
           `.factory/rules/standards/${this.createStableRuleSlug(topic, usedSlugs)}.md`;
@@ -743,18 +755,18 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
           files.push({
             label: 'Standards',
             path: '.factory/rules/standards.md',
-            content: `# Standards\n\n${normalized}\n`,
+            content: `# ${resolveSourceSectionTitle(ast, 'code-standards') ?? 'Standards'}\n\n${normalized}\n`,
           });
         }
       }
     }
 
-    const knowledge = this.knowledgeContent(ast, renderer);
+    const knowledge = this.knowledgeContent(ast, renderer, false);
     if (knowledge) {
       files.push({
         label: 'Knowledge',
         path: '.factory/rules/knowledge.md',
-        content: `# Knowledge\n\n${knowledge.trim()}\n`,
+        content: `# ${this.getSectionName(ast, 'knowledge')}\n\n${knowledge.trim()}\n`,
       });
     }
 
@@ -763,7 +775,7 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
       files.push({
         label: 'Restrictions',
         path: '.factory/rules/restrictions.md',
-        content: this.promoteSectionHeading(restrictions, this.getSectionName('restrictions')),
+        content: this.promoteSectionHeading(restrictions, this.getSectionName(ast, 'restrictions')),
       });
     }
 
@@ -772,7 +784,7 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
       files.push({
         label: 'Examples',
         path: '.factory/rules/examples.md',
-        content: this.promoteSectionHeading(examples, 'Examples'),
+        content: this.promoteSectionHeading(examples, this.getSectionName(ast, 'examples')),
       });
     }
 
@@ -817,12 +829,33 @@ export class FactoryFormatter extends MarkdownInstructionFormatter {
     this.addSection(sections, this.postWork(ast, renderer));
   }
 
-  private getSemanticRuleInfo(topic: string): { label: string; path: string } | undefined {
-    const semanticRules: Record<string, { label: string; path: string }> = {
-      git: { label: 'Git Workflows', path: '.factory/rules/git-workflows.md' },
-      config: { label: 'Configuration', path: '.factory/rules/configuration.md' },
-      documentation: { label: 'Documentation', path: '.factory/rules/documentation.md' },
-      diagrams: { label: 'Diagrams', path: '.factory/rules/diagrams.md' },
+  private getSemanticRuleInfo(
+    topic: string
+  ): { label: string; path: string; sectionName: SectionNameKey } | undefined {
+    const semanticRules: Record<
+      string,
+      { label: string; path: string; sectionName: SectionNameKey }
+    > = {
+      git: {
+        label: 'Git Workflows',
+        path: '.factory/rules/git-workflows.md',
+        sectionName: 'gitCommits',
+      },
+      config: {
+        label: 'Configuration',
+        path: '.factory/rules/configuration.md',
+        sectionName: 'configFiles',
+      },
+      documentation: {
+        label: 'Documentation',
+        path: '.factory/rules/documentation.md',
+        sectionName: 'documentation',
+      },
+      diagrams: {
+        label: 'Diagrams',
+        path: '.factory/rules/diagrams.md',
+        sectionName: 'diagrams',
+      },
     };
     return semanticRules[topic];
   }

--- a/packages/formatters/src/formatters/github.ts
+++ b/packages/formatters/src/formatters/github.ts
@@ -16,6 +16,7 @@ import {
   getHookCompatibilityWarnings,
 } from '../hook-adapters.js';
 import { appendTargetHookCapabilityWarnings } from '../hook-capability-warnings.js';
+import { resolveSectionTitle, resolveSourceSectionTitle } from '../section-title-resolver.js';
 
 /**
  * GitHub formatter version information.
@@ -1111,6 +1112,18 @@ export class GitHubFormatter extends BaseFormatter {
     return `# GitHub Copilot Instructions`;
   }
 
+  private sectionTitle(
+    ast: Program,
+    renderer: ConventionRenderer,
+    sectionId: string,
+    defaultTitle: string
+  ): string {
+    return resolveSectionTitle(ast, sectionId, {
+      defaultTitle,
+      sourceOverrides: renderer.getConvention().name !== 'xml',
+    });
+  }
+
   private project(ast: Program, renderer: ConventionRenderer): string | null {
     const identity = this.findBlock(ast, 'identity');
 
@@ -1119,15 +1132,20 @@ export class GitHubFormatter extends BaseFormatter {
       content = this.extractText(identity.content);
     } else {
       const context = this.findBlock(ast, 'context');
-      if (context?.content.type === 'MixedContent' && context.content.text) {
-        content = context.content.text.value.trim();
+      const contextTitle = resolveSourceSectionTitle(ast, 'context');
+      const projectTitle = resolveSourceSectionTitle(ast, 'project');
+      if (!contextTitle && context && (context.content.type === 'MixedContent' || projectTitle)) {
+        content = this.extractText(context.content).trim();
       }
     }
 
     if (!content) return null;
 
     // Apply stripAllIndent to normalize merged identity content for Prettier compatibility
-    return renderer.renderSection('project', this.stripAllIndent(content));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'project', 'project'),
+      this.stripAllIndent(content)
+    );
   }
 
   private techStack(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1136,7 +1154,10 @@ export class GitHubFormatter extends BaseFormatter {
       const items = this.extractTechStackFromContext(context);
       if (items.length > 0) {
         const content = renderer.renderList(items);
-        return renderer.renderSection('tech-stack', content);
+        return renderer.renderSection(
+          this.sectionTitle(ast, renderer, 'tech-stack', 'tech-stack'),
+          content
+        );
       }
     }
 
@@ -1146,7 +1167,10 @@ export class GitHubFormatter extends BaseFormatter {
       const items = this.extractTechStackFromStandards(standards);
       if (items.length > 0) {
         const content = renderer.renderList(items);
-        return renderer.renderSection('tech-stack', content);
+        return renderer.renderSection(
+          this.sectionTitle(ast, renderer, 'tech-stack', 'tech-stack'),
+          content
+        );
       }
     }
 
@@ -1218,12 +1242,15 @@ export class GitHubFormatter extends BaseFormatter {
 
     const content = archMatch.replace('## Architecture', '').trim();
     // Apply stripAllIndent to normalize content for Prettier compatibility
-    return renderer.renderSection('architecture', this.stripAllIndent(content));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'architecture', 'architecture'),
+      this.stripAllIndent(content)
+    );
   }
 
   private contextSection(ast: Program, renderer: ConventionRenderer): string | null {
     const identity = this.findBlock(ast, 'identity');
-    if (!identity) return null; // project() fallback handles @context text
+    if (!identity && !resolveSourceSectionTitle(ast, 'context')) return null;
 
     const contextBlock = this.findBlock(ast, 'context');
     if (!contextBlock) return null;
@@ -1238,7 +1265,10 @@ export class GitHubFormatter extends BaseFormatter {
 
     // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
     const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
-    return renderer.renderSection('Context', this.stripAllIndent(downgradedText));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'context', 'Context'),
+      this.stripAllIndent(downgradedText)
+    );
   }
 
   private codeStandards(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1260,7 +1290,10 @@ export class GitHubFormatter extends BaseFormatter {
 
     if (subsections.length === 0) return null;
 
-    return renderer.renderSection('code-standards', subsections.join('\n\n'));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'code-standards', 'code-standards'),
+      subsections.join('\n\n')
+    );
   }
 
   /**
@@ -1291,7 +1324,10 @@ export class GitHubFormatter extends BaseFormatter {
     }
 
     if (items.length === 0) return null;
-    return renderer.renderSection('shortcuts', renderer.renderList(items));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'commands', 'shortcuts'),
+      renderer.renderList(items)
+    );
   }
 
   private commands(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1304,7 +1340,10 @@ export class GitHubFormatter extends BaseFormatter {
 
     const content = commandsMatch.replace('## Development Commands', '').trim();
     // Apply stripAllIndent to normalize content for Prettier compatibility
-    return renderer.renderSection('commands', this.stripAllIndent(content));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'commands', 'commands'),
+      this.stripAllIndent(content)
+    );
   }
 
   private gitCommits(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1349,7 +1388,10 @@ export class GitHubFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
 
-    return renderer.renderSection('git-commits', renderer.renderList(items));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'git-commits', 'git-commits'),
+      renderer.renderList(items)
+    );
   }
 
   private configFiles(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1377,7 +1419,10 @@ export class GitHubFormatter extends BaseFormatter {
 
     if (subsections.length === 0) return null;
 
-    return renderer.renderSection('configuration-files', subsections.join('\n\n'));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'configuration-files', 'configuration-files'),
+      subsections.join('\n\n')
+    );
   }
 
   private documentation(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1409,7 +1454,10 @@ export class GitHubFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
 
-    return renderer.renderSection('documentation-verification', renderer.renderList(items));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'documentation', 'documentation-verification'),
+      renderer.renderList(items)
+    );
   }
 
   private postWork(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1425,7 +1473,7 @@ export class GitHubFormatter extends BaseFormatter {
     const content = postMatch.replace('## Post-Work Verification', '').trim();
     // Apply stripAllIndent to normalize content for Prettier compatibility
     return renderer.renderSection(
-      'post-work-verification',
+      this.sectionTitle(ast, renderer, 'post-work', 'post-work-verification'),
       `${intro}\n${this.stripAllIndent(content)}`
     );
   }
@@ -1456,7 +1504,10 @@ export class GitHubFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
 
-    return renderer.renderSection('donts', renderer.renderList(items));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'restrictions', 'donts'),
+      renderer.renderList(items)
+    );
   }
 
   private diagrams(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1489,14 +1540,17 @@ export class GitHubFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
 
-    return renderer.renderSection('diagrams', renderer.renderList(items));
+    return renderer.renderSection(
+      this.sectionTitle(ast, renderer, 'diagrams', 'diagrams'),
+      renderer.renderList(items)
+    );
   }
 
   /**
    * Render remaining @knowledge content not already consumed by
    * commands() (## Development Commands) or postWork() (## Post-Work Verification).
    */
-  private knowledgeContent(ast: Program, _renderer: ConventionRenderer): string | null {
+  private knowledgeContent(ast: Program, renderer: ConventionRenderer): string | null {
     const knowledge = this.findBlock(ast, 'knowledge');
     if (!knowledge) return null;
 
@@ -1528,11 +1582,20 @@ export class GitHubFormatter extends BaseFormatter {
     remaining = remaining.trim();
     if (!remaining) return null;
 
-    return this.stripAllIndent(remaining);
+    const content = this.stripAllIndent(remaining);
+    const title =
+      renderer.getConvention().name === 'xml'
+        ? undefined
+        : resolveSourceSectionTitle(ast, 'knowledge');
+    return title ? renderer.renderSection(title, content) : content;
   }
 
   private examples(ast: Program, renderer: ConventionRenderer): string | null {
-    return this.renderExamplesSection(ast, renderer, 'examples');
+    return this.renderExamplesSection(
+      ast,
+      renderer,
+      this.sectionTitle(ast, renderer, 'examples', 'examples')
+    );
   }
 
   // Helper methods

--- a/packages/formatters/src/index.ts
+++ b/packages/formatters/src/index.ts
@@ -84,6 +84,8 @@ export {
   normalizeSectionName,
 } from './section-registry.js';
 export type { SectionInfo } from './section-registry.js';
+export { resolveSectionTitle, resolveSourceSectionTitle } from './section-title-resolver.js';
+export type { SectionTitleOptions } from './section-title-resolver.js';
 
 /** @internal Parity Matrix for formatter consistency testing */
 export {

--- a/packages/formatters/src/markdown-instruction-formatter.ts
+++ b/packages/formatters/src/markdown-instruction-formatter.ts
@@ -9,6 +9,7 @@ import {
   serializeMcpServersToJsonString,
   serializeMcpServersToToml,
 } from './mcp-helpers.js';
+import { resolveSectionTitle, resolveSourceSectionTitle } from './section-title-resolver.js';
 
 /**
  * Configuration for a markdown-based command file.
@@ -72,22 +73,20 @@ export interface MarkdownAgentConfig {
  * Section name keys that can be customized via config.
  */
 export type SectionNameKey =
+  | 'project'
+  | 'techStack'
+  | 'architecture'
+  | 'context'
   | 'codeStandards'
   | 'gitCommits'
   | 'configFiles'
+  | 'commands'
   | 'postWork'
-  | 'restrictions';
-
-/**
- * Default section names used by most markdown formatters.
- */
-const DEFAULT_SECTION_NAMES: Record<SectionNameKey, string> = {
-  codeStandards: 'Code Style',
-  gitCommits: 'Git Commits',
-  configFiles: 'Config Files',
-  postWork: 'Post-Work Verification',
-  restrictions: 'Restrictions',
-};
+  | 'documentation'
+  | 'diagrams'
+  | 'knowledge'
+  | 'restrictions'
+  | 'examples';
 
 /**
  * Configuration for a markdown instruction formatter.
@@ -368,8 +367,24 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
   // Section Name Resolution
   // ============================================================
 
-  protected getSectionName(key: SectionNameKey): string {
-    return this.config.sectionNames?.[key] ?? DEFAULT_SECTION_NAMES[key];
+  protected getSectionName(ast: Program, key: SectionNameKey, defaultTitle?: string): string {
+    return resolveSectionTitle(ast, key, {
+      formatterTitles: this.config.sectionNames,
+      ...(defaultTitle ? { defaultTitle } : {}),
+    });
+  }
+
+  protected getRenderedSectionName(
+    ast: Program,
+    key: SectionNameKey,
+    renderer: ConventionRenderer,
+    defaultTitle?: string
+  ): string {
+    return resolveSectionTitle(ast, key, {
+      formatterTitles: this.config.sectionNames,
+      ...(defaultTitle ? { defaultTitle } : {}),
+      sourceOverrides: renderer.getConvention().name !== 'xml',
+    });
   }
 
   // ============================================================
@@ -672,8 +687,10 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
       text = this.extractText(identity.content);
     } else {
       const context = this.findBlock(ast, 'context');
-      if (context?.content.type === 'MixedContent' && context.content.text) {
-        text = context.content.text.value.trim();
+      const contextTitle = resolveSourceSectionTitle(ast, 'context');
+      const projectTitle = resolveSourceSectionTitle(ast, 'project');
+      if (!contextTitle && context && (context.content.type === 'MixedContent' || projectTitle)) {
+        text = this.extractText(context.content).trim();
       }
     }
 
@@ -691,7 +708,12 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
       .join('\n\n');
 
     const normalizedText = this.normalizeMarkdownForPrettier(cleanText);
-    return renderer.renderSection('Project', normalizedText) + '\n';
+    return (
+      renderer.renderSection(
+        this.getRenderedSectionName(ast, 'project', renderer),
+        normalizedText
+      ) + '\n'
+    );
   }
 
   protected techStack(ast: Program, renderer: ConventionRenderer): string | null {
@@ -699,7 +721,12 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     if (context) {
       const items = this.extractTechStackFromContext(context);
       if (items.length > 0) {
-        return renderer.renderSection('Tech Stack', items.join(', ')) + '\n';
+        return (
+          renderer.renderSection(
+            this.getRenderedSectionName(ast, 'techStack', renderer),
+            items.join(', ')
+          ) + '\n'
+        );
       }
     }
 
@@ -707,7 +734,12 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     if (standards) {
       const items = this.extractTechStackFromStandards(standards);
       if (items.length > 0) {
-        return renderer.renderSection('Tech Stack', items.join(', ')) + '\n';
+        return (
+          renderer.renderSection(
+            this.getRenderedSectionName(ast, 'techStack', renderer),
+            items.join(', ')
+          ) + '\n'
+        );
       }
     }
 
@@ -766,7 +798,12 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
 
     const content = archMatch.replace('## Architecture', '');
     const normalizedContent = this.normalizeMarkdownForPrettier(content);
-    return renderer.renderSection('Architecture', normalizedContent.trim()) + '\n';
+    return (
+      renderer.renderSection(
+        this.getRenderedSectionName(ast, 'architecture', renderer),
+        normalizedContent.trim()
+      ) + '\n'
+    );
   }
 
   /**
@@ -781,7 +818,7 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
    */
   protected context(ast: Program, renderer: ConventionRenderer): string | null {
     const identity = this.findBlock(ast, 'identity');
-    if (!identity) return null; // project() fallback handles @context text
+    if (!identity && !resolveSourceSectionTitle(ast, 'context')) return null;
 
     const contextBlock = this.findBlock(ast, 'context');
     if (!contextBlock) return null;
@@ -799,7 +836,12 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     // Downgrade "## " headings to "### " to avoid h2 collisions with formatter sections
     const downgradedText = remainingText.replace(/^(\s*)## /gm, '$1### ');
     const normalizedContent = this.normalizeMarkdownForPrettier(downgradedText);
-    return renderer.renderSection('Context', normalizedContent.trim()) + '\n';
+    return (
+      renderer.renderSection(
+        this.getRenderedSectionName(ast, 'context', renderer),
+        normalizedContent.trim()
+      ) + '\n'
+    );
   }
 
   protected codeStandards(ast: Program, renderer: ConventionRenderer): string | null {
@@ -815,7 +857,10 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection(this.getSectionName('codeStandards'), content) + '\n';
+    return (
+      renderer.renderSection(this.getRenderedSectionName(ast, 'codeStandards', renderer), content) +
+      '\n'
+    );
   }
 
   protected gitCommits(ast: Program, renderer: ConventionRenderer): string | null {
@@ -839,7 +884,10 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection(this.getSectionName('gitCommits'), content) + '\n';
+    return (
+      renderer.renderSection(this.getRenderedSectionName(ast, 'gitCommits', renderer), content) +
+      '\n'
+    );
   }
 
   protected configFiles(ast: Program, renderer: ConventionRenderer): string | null {
@@ -859,7 +907,10 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection(this.getSectionName('configFiles'), content) + '\n';
+    return (
+      renderer.renderSection(this.getRenderedSectionName(ast, 'configFiles', renderer), content) +
+      '\n'
+    );
   }
 
   protected commands(ast: Program, renderer: ConventionRenderer): string | null {
@@ -890,7 +941,9 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
       }
     }
 
-    return renderer.renderSection('Commands', content) + '\n';
+    return (
+      renderer.renderSection(this.getRenderedSectionName(ast, 'commands', renderer), content) + '\n'
+    );
   }
 
   protected postWork(ast: Program, renderer: ConventionRenderer): string | null {
@@ -903,7 +956,12 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
 
     const content = match.replace('## Post-Work Verification', '');
     const normalizedContent = this.normalizeMarkdownForPrettier(content);
-    return renderer.renderSection(this.getSectionName('postWork'), normalizedContent.trim()) + '\n';
+    return (
+      renderer.renderSection(
+        this.getRenderedSectionName(ast, 'postWork', renderer),
+        normalizedContent.trim()
+      ) + '\n'
+    );
   }
 
   protected documentation(ast: Program, renderer: ConventionRenderer): string | null {
@@ -928,7 +986,10 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection('Documentation', content) + '\n';
+    return (
+      renderer.renderSection(this.getRenderedSectionName(ast, 'documentation', renderer), content) +
+      '\n'
+    );
   }
 
   protected diagrams(ast: Program, renderer: ConventionRenderer): string | null {
@@ -950,7 +1011,9 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
 
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection('Diagrams', content) + '\n';
+    return (
+      renderer.renderSection(this.getRenderedSectionName(ast, 'diagrams', renderer), content) + '\n'
+    );
   }
 
   /**
@@ -958,7 +1021,11 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
    * Strips "## Development Commands" and "## Post-Work Verification" sub-sections
    * since those are already rendered by commands() and postWork().
    */
-  protected knowledgeContent(ast: Program, _renderer: ConventionRenderer): string | null {
+  protected knowledgeContent(
+    ast: Program,
+    renderer: ConventionRenderer,
+    includeResolvedTitle = true
+  ): string | null {
     const knowledge = this.findBlock(ast, 'knowledge');
     if (!knowledge) return null;
 
@@ -992,7 +1059,13 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     if (!remaining) return null;
 
     const normalizedContent = this.stripAllIndent(remaining);
-    return normalizedContent + '\n';
+    const title =
+      renderer.getConvention().name === 'xml'
+        ? undefined
+        : resolveSourceSectionTitle(ast, 'knowledge');
+    return includeResolvedTitle && title
+      ? renderer.renderSection(title, normalizedContent) + '\n'
+      : normalizedContent + '\n';
   }
 
   protected restrictions(ast: Program, renderer: ConventionRenderer): string | null {
@@ -1002,11 +1075,18 @@ export abstract class MarkdownInstructionFormatter extends BaseFormatter {
     const items = this.extractRestrictionsItems(block);
     if (items.length === 0) return null;
     const content = renderer.renderList(items);
-    return renderer.renderSection(this.getSectionName('restrictions'), content) + '\n';
+    return (
+      renderer.renderSection(this.getRenderedSectionName(ast, 'restrictions', renderer), content) +
+      '\n'
+    );
   }
 
   protected examples(ast: Program, renderer: ConventionRenderer): string | null {
-    return this.renderExamplesSection(ast, renderer);
+    return this.renderExamplesSection(
+      ast,
+      renderer,
+      this.getRenderedSectionName(ast, 'examples', renderer)
+    );
   }
 
   protected extractRestrictionsItems(block: Block): string[] {

--- a/packages/formatters/src/section-registry.ts
+++ b/packages/formatters/src/section-registry.ts
@@ -2,6 +2,9 @@
  * Registry of known sections that formatters can generate.
  * Used for parity testing and documentation.
  */
+import { SECTION_REGISTRY } from '@promptscript/core';
+
+export { SECTION_REGISTRY } from '@promptscript/core';
 
 /**
  * Section metadata for documentation and validation.
@@ -23,85 +26,13 @@ export interface SectionInfo {
  * All known sections that formatters should support.
  * This is the source of truth for section parity.
  */
-export const KNOWN_SECTIONS: SectionInfo[] = [
-  {
-    id: 'project',
-    name: 'Project',
-    description: 'Project identity and purpose',
-    sourceBlocks: ['identity'],
-    required: true,
-  },
-  {
-    id: 'tech-stack',
-    name: 'Tech Stack',
-    description: 'Languages, frameworks, and tools',
-    sourceBlocks: ['context'],
-    required: false,
-  },
-  {
-    id: 'architecture',
-    name: 'Architecture',
-    description: 'System structure and components',
-    sourceBlocks: ['context'],
-    required: false,
-  },
-  {
-    id: 'code-standards',
-    name: 'Code Standards',
-    description: 'TypeScript, naming, error handling standards',
-    sourceBlocks: ['standards'],
-    required: false,
-  },
-  {
-    id: 'commands',
-    name: 'Commands',
-    description: 'Development commands and shortcuts',
-    sourceBlocks: ['shortcuts', 'commands', 'knowledge'],
-    required: false,
-  },
-  {
-    id: 'git-commits',
-    name: 'Git Commits',
-    description: 'Commit message conventions',
-    sourceBlocks: ['standards'],
-    required: false,
-  },
-  {
-    id: 'configuration-files',
-    name: 'Configuration Files',
-    description: 'ESLint, Vite, and other config guidelines',
-    sourceBlocks: ['standards'],
-    required: false,
-  },
-  {
-    id: 'documentation',
-    name: 'Documentation',
-    description: 'Documentation verification guidelines',
-    sourceBlocks: ['standards'],
-    required: false,
-  },
-  {
-    id: 'post-work',
-    name: 'Post-Work Verification',
-    description: 'Commands to run after changes',
-    sourceBlocks: ['knowledge'],
-    required: false,
-  },
-  {
-    id: 'diagrams',
-    name: 'Diagrams',
-    description: 'Diagram format guidelines (Mermaid)',
-    sourceBlocks: ['standards'],
-    required: false,
-  },
-  {
-    id: 'restrictions',
-    name: 'Restrictions',
-    description: "Don'ts and forbidden practices",
-    sourceBlocks: ['restrictions'],
-    required: false,
-  },
-];
+export const KNOWN_SECTIONS: SectionInfo[] = SECTION_REGISTRY.map((section) => ({
+  id: section.id,
+  name: section.defaultTitle,
+  description: section.description,
+  sourceBlocks: [...section.sourceBlocks],
+  required: section.required,
+}));
 
 /**
  * Get section IDs that a formatter should generate given available source blocks.

--- a/packages/formatters/src/section-title-resolver.ts
+++ b/packages/formatters/src/section-title-resolver.ts
@@ -1,0 +1,79 @@
+import {
+  getPrimarySectionForBlock,
+  getSectionContract,
+  type PresentationEntry,
+  type Program,
+  type SectionContract,
+} from '@promptscript/core';
+
+export interface SectionTitleOptions {
+  readonly formatterTitles?: Readonly<Record<string, string | undefined>>;
+  readonly defaultTitle?: string;
+  readonly sourceOverrides?: boolean;
+}
+
+function presentationSectionId(blockName: string, entry: PresentationEntry): string | undefined {
+  if (entry.sectionId) return getSectionContract(entry.sectionId)?.id ?? entry.sectionId;
+  return getPrimarySectionForBlock(blockName)?.id;
+}
+
+function sourceTitle(ast: Program, section: SectionContract): string | undefined {
+  const owners = [section.primaryOwner, ...section.fallbackOwners];
+  for (const source of ['explicit', 'legacy'] as const) {
+    for (const owner of owners) {
+      const candidates = ast.blocks
+        .filter((block) => block.name === owner)
+        .flatMap((block) =>
+          (block.canonicalBody?.entries ?? []).filter(
+            (entry): entry is PresentationEntry =>
+              entry.type === 'PresentationEntry' &&
+              entry.source === source &&
+              presentationSectionId(block.name, entry) === section.id
+          )
+        );
+      const selected = candidates.at(-1);
+      if (selected) return selected.title;
+    }
+  }
+  return undefined;
+}
+
+export function resolveSourceSectionTitle(
+  ast: Program,
+  sectionIdOrAlias: string
+): string | undefined {
+  const section = getSectionContract(sectionIdOrAlias);
+  return section ? sourceTitle(ast, section) : undefined;
+}
+
+function configuredTitle(
+  section: SectionContract,
+  titles: Readonly<Record<string, string | undefined>> | undefined
+): string | undefined {
+  if (!titles) return undefined;
+  for (const key of [section.id, ...section.formatterAliases]) {
+    const title = titles[key];
+    if (title !== undefined) return title;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a generated section title without changing its output protocol.
+ */
+export function resolveSectionTitle(
+  ast: Program,
+  sectionIdOrAlias: string,
+  options: SectionTitleOptions = {}
+): string {
+  const section = getSectionContract(sectionIdOrAlias);
+  if (!section) {
+    return options.defaultTitle ?? sectionIdOrAlias;
+  }
+  return (
+    (options.sourceOverrides === false ? undefined : sourceTitle(ast, section)) ??
+    configuredTitle(section, options.formatterTitles) ??
+    options.defaultTitle ??
+    section.defaultTitle
+  );
+}

--- a/packages/parser/src/__tests__/parser.spec.ts
+++ b/packages/parser/src/__tests__/parser.spec.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse, parseOrThrow } from '../parse.js';
-import { ParseError } from '@promptscript/core';
+import { ParseError, SYNTAX_FEATURES } from '@promptscript/core';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -330,6 +330,136 @@ describe('parse', () => {
       expect(result.errors.length).toBeGreaterThan(0);
       expect(result.errors[0]?.message).toContain("'!' replace modifier cannot be combined");
       expect(result.ast).toBeNull();
+    });
+  });
+
+  describe('section header overrides', () => {
+    it('should parse primary and derived headers as ordered presentation entries', () => {
+      const result = parse(
+        `@meta { id: "test" syntax: "1.5.0" }
+@standards {
+  code: ["Use strict TypeScript"]
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+}`,
+        { filename: 'headers.prs' }
+      );
+
+      expect(result.errors).toHaveLength(0);
+      const standards = result.ast?.blocks[0];
+      expect(standards?.content).toMatchObject({
+        type: 'ObjectContent',
+        properties: { code: ['Use strict TypeScript'] },
+      });
+      expect(standards?.canonicalBody?.entries).toMatchObject([
+        { type: 'FieldEntry', name: 'code' },
+        {
+          type: 'PresentationEntry',
+          title: 'Coding Rules',
+          source: 'explicit',
+          loc: { file: 'headers.prs', line: 4, column: 3 },
+          titleLoc: { file: 'headers.prs', line: 4, column: 11 },
+        },
+        {
+          type: 'PresentationEntry',
+          sectionId: 'git-commits',
+          title: 'Commit Rules',
+          source: 'explicit',
+          sectionLoc: { file: 'headers.prs', line: 5, column: 11 },
+          titleLoc: { file: 'headers.prs', line: 5, column: 23 },
+        },
+      ]);
+      expect(result.ast?.syntaxFeatures).toEqual([
+        {
+          feature: 'section-header-override',
+          location: expect.objectContaining({ file: 'headers.prs', line: 4, column: 3 }),
+        },
+        {
+          feature: 'section-header-override',
+          location: expect.objectContaining({ file: 'headers.prs', line: 5, column: 3 }),
+        },
+      ]);
+    });
+
+    it('should preserve header fields as domain data', () => {
+      const result = parse(`
+        @standards {
+          header: "domain header"
+          headers: { authorization: "Bearer token" }
+        }
+      `);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.ast?.blocks[0]?.content).toMatchObject({
+        type: 'ObjectContent',
+        properties: {
+          header: 'domain header',
+          headers: { authorization: 'Bearer token' },
+        },
+      });
+      expect(result.ast?.blocks[0]?.canonicalBody?.entries).not.toContainEqual(
+        expect.objectContaining({ type: 'PresentationEntry' })
+      );
+    });
+
+    it('should opt registered text blocks into initial heading fallback at syntax 1.5.0', () => {
+      const current = parse(`
+        @meta { id: "current" syntax: "1.5.0" }
+        @identity {
+          """## Localized Project
+          Project details"""
+        }
+      `);
+      const legacy = parse(`
+        @meta { id: "legacy" syntax: "1.4.0" }
+        @identity {
+          """## Localized Project
+          Project details"""
+        }
+      `);
+
+      expect(current.errors).toHaveLength(0);
+      expect(current.ast?.blocks[0]?.canonicalBody?.entries).toMatchObject([
+        {
+          type: 'PresentationEntry',
+          title: 'Localized Project',
+          source: 'legacy',
+        },
+        { type: 'TextEntry', text: '          Project details' },
+      ]);
+      expect(current.ast?.blocks[0]?.content).toMatchObject({
+        type: 'TextContent',
+        value: '          Project details',
+      });
+      expect(current.ast?.syntaxFeatures).toContainEqual(
+        expect.objectContaining({
+          feature: SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE,
+        })
+      );
+      expect(legacy.ast?.blocks[0]?.canonicalBody?.entries).toMatchObject([
+        {
+          type: 'TextEntry',
+          text: '## Localized Project\n          Project details',
+        },
+      ]);
+    });
+
+    it('should preserve initial headings in unregistered custom blocks', () => {
+      const result = parse(`
+        @meta { id: "custom" syntax: "1.5.0" }
+        @custom {
+          """## Domain Heading
+          Domain details"""
+        }
+      `);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.ast?.blocks[0]?.canonicalBody?.entries).toMatchObject([
+        {
+          type: 'TextEntry',
+          text: '## Domain Heading\n          Domain details',
+        },
+      ]);
     });
   });
 

--- a/packages/parser/src/grammar/parser.ts
+++ b/packages/parser/src/grammar/parser.ts
@@ -144,7 +144,7 @@ export class PromptScriptParser extends CstParser {
 
   /**
    * blockContent
-   *   : (TextBlock | restrictionItem | inlineUse | field)*
+   *   : (TextBlock | restrictionItem | inlineUse | headerDirective | field)*
    */
   private blockContent = this.RULE('blockContent', () => {
     this.MANY(() =>
@@ -152,6 +152,10 @@ export class PromptScriptParser extends CstParser {
         { ALT: () => this.CONSUME(TextBlock) },
         { ALT: () => this.SUBRULE(this.restrictionItem) },
         { ALT: () => this.SUBRULE(this.inlineUse), GATE: () => this.isInlineUseAhead() },
+        {
+          ALT: () => this.SUBRULE(this.headerDirective),
+          GATE: () => this.isHeaderDirectiveAhead(),
+        },
         { ALT: () => this.SUBRULE(this.field) },
       ])
     );
@@ -176,6 +180,17 @@ export class PromptScriptParser extends CstParser {
       this.CONSUME(Into);
       this.CONSUME(StringLiteral);
     });
+  });
+
+  /**
+   * headerDirective
+   *   : '@' 'header' Identifier? StringLiteral
+   */
+  private headerDirective = this.RULE('headerDirective', () => {
+    this.CONSUME(At);
+    this.CONSUME(Identifier);
+    this.OPTION(() => this.CONSUME2(Identifier));
+    this.CONSUME(StringLiteral);
   });
 
   /**
@@ -246,6 +261,13 @@ export class PromptScriptParser extends CstParser {
     if (!first || first.tokenType?.name !== 'At') return false;
     const second = this.LA(2);
     return second?.tokenType?.name === 'Use';
+  }
+
+  private isHeaderDirectiveAhead(): boolean {
+    const first = this.LA(1);
+    if (!first || first.tokenType?.name !== 'At') return false;
+    const second = this.LA(2);
+    return second?.tokenType?.name === 'Identifier' && second.image === 'header';
   }
 
   /**

--- a/packages/parser/src/grammar/visitor.ts
+++ b/packages/parser/src/grammar/visitor.ts
@@ -9,6 +9,7 @@ import type {
   CanonicalExtendBlock,
   CanonicalProgram,
   FieldEntry,
+  PresentationEntry,
   ProgramOperation,
   MetaBlock,
   InheritDeclaration,
@@ -20,6 +21,7 @@ import type {
   TextContent,
   TypeExpression,
   SourceLocation,
+  SyntaxFeatureUsage,
   ParamArgument,
   ParamDefinition,
   ParamType,
@@ -32,6 +34,8 @@ import {
   createCanonicalExtendBlock,
   createCanonicalProgram,
   createValueNode,
+  normalizeLegacyHeadingEntries,
+  SYNTAX_FEATURES,
 } from '@promptscript/core';
 
 // ============================================================
@@ -97,6 +101,13 @@ interface BlockContentCstCtx {
   field?: CstNode[];
   restrictionItem?: CstNode[];
   inlineUse?: CstNode[];
+  headerDirective?: CstNode[];
+}
+
+interface HeaderDirectiveCstCtx {
+  At: IToken[];
+  Identifier: IToken[];
+  StringLiteral: IToken[];
 }
 
 interface RestrictionItemCstCtx {
@@ -252,6 +263,8 @@ class PromptScriptVisitor extends BaseVisitor {
   private diagnostics: VisitorDiagnostic[] = [];
   private fieldCache = new Map<string, ParsedField>();
   private directBlockFields = new Set<string>();
+  private syntaxFeatures: SyntaxFeatureUsage[] = [];
+  private syntaxVersion: string | undefined;
 
   constructor() {
     super();
@@ -334,6 +347,10 @@ class PromptScriptVisitor extends BaseVisitor {
     this.filename = filename;
     this.fieldCache.clear();
     this.directBlockFields.clear();
+    this.syntaxFeatures = [];
+    const meta = ctx.metaBlock ? (this.visit(ctx.metaBlock[0]!) as MetaBlock) : undefined;
+    this.syntaxVersion =
+      typeof meta?.fields['syntax'] === 'string' ? meta.fields['syntax'] : undefined;
     const sourceLayerId = filename;
     const declarations = [
       ...(ctx.inheritDecl ?? []),
@@ -391,8 +408,9 @@ class PromptScriptVisitor extends BaseVisitor {
     }
 
     return createCanonicalProgram({
-      meta: ctx.metaBlock ? this.visit(ctx.metaBlock[0]!) : undefined,
+      meta,
       operations,
+      syntaxFeatures: this.syntaxFeatures,
       loc: { file: this.filename, line: 1, column: 1, offset: 0 },
     });
   }
@@ -496,11 +514,58 @@ class PromptScriptVisitor extends BaseVisitor {
   }
 
   /**
+   * headerDirective → PresentationEntry
+   */
+  headerDirective(ctx: HeaderDirectiveCstCtx): PresentationEntry {
+    const directiveLoc = this.loc(ctx.At[0]!);
+    const sectionToken = ctx.Identifier[1];
+    const titleToken = ctx.StringLiteral[0]!;
+    this.syntaxFeatures.push({
+      feature: SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE,
+      location: directiveLoc,
+    });
+    return {
+      type: 'PresentationEntry',
+      ...(sectionToken
+        ? {
+            sectionId: sectionToken.image,
+            sectionLoc: this.loc(sectionToken),
+          }
+        : {}),
+      title: this.parseStringLiteral(titleToken.image),
+      source: 'explicit',
+      loc: directiveLoc,
+      titleLoc: this.loc(titleToken),
+    };
+  }
+
+  private normalizeLegacyHeading(
+    blockName: string,
+    entries: readonly BlockEntry[]
+  ): readonly BlockEntry[] {
+    const normalized = normalizeLegacyHeadingEntries(blockName, entries, this.syntaxVersion);
+    if (normalized !== entries) {
+      const presentation = normalized.find(
+        (entry): entry is PresentationEntry =>
+          entry.type === 'PresentationEntry' && entry.source === 'legacy'
+      );
+      if (presentation) {
+        this.syntaxFeatures.push({
+          feature: SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE,
+          location: presentation.loc,
+        });
+      }
+    }
+    return normalized;
+  }
+
+  /**
    * block → CanonicalBlock
    */
   block(ctx: BlockCstCtx): CanonicalBlock {
     const name = ctx.Identifier[0]!.image;
     const { body, replacements } = this.visit(ctx.blockContent[0]!) as ParsedBlockContent;
+    const entries = this.normalizeLegacyHeading(name, body.entries);
     for (const replacement of replacements) {
       this.diagnostics.push({
         message: "The '!' replace modifier is only valid inside @extend.",
@@ -509,7 +574,7 @@ class PromptScriptVisitor extends BaseVisitor {
     }
     return createCanonicalBlock(
       name,
-      createBlockBody(body.entries, this.loc(ctx.LBrace[0]!)),
+      createBlockBody(entries, this.loc(ctx.LBrace[0]!)),
       this.loc(ctx.At[0]!)
     );
   }
@@ -520,9 +585,12 @@ class PromptScriptVisitor extends BaseVisitor {
   extendBlock(ctx: ExtendBlockCstCtx): CanonicalExtendBlock {
     const targetPath = this.visit(ctx.dotPath[0]!) as string;
     const { body, replacements } = this.visit(ctx.blockContent[0]!) as ParsedBlockContent;
+    const entries = targetPath.includes('.')
+      ? body.entries
+      : this.normalizeLegacyHeading(targetPath, body.entries);
     return createCanonicalExtendBlock(
       targetPath,
-      createBlockBody(body.entries, this.loc(ctx.LBrace[0]!)),
+      createBlockBody(entries, this.loc(ctx.LBrace[0]!)),
       replacements,
       this.loc(ctx.At[0]!)
     );
@@ -592,6 +660,14 @@ class PromptScriptVisitor extends BaseVisitor {
           declaration,
           loc: declaration.loc,
         },
+      });
+    }
+
+    for (const node of ctx.headerDirective ?? []) {
+      const entry = this.visit(node) as PresentationEntry;
+      entries.push({
+        offset: entry.loc.offset ?? 0,
+        entry,
       });
     }
 

--- a/packages/playground/src/utils/prs-language.ts
+++ b/packages/playground/src/utils/prs-language.ts
@@ -3,10 +3,10 @@
  */
 
 import type * as Monaco from 'monaco-editor';
-import { BLOCK_TYPES } from '@promptscript/core';
+import { BLOCK_TYPES, CONTEXTUAL_DIRECTIVES } from '@promptscript/core';
 
 export const PRS_LANGUAGE_ID = 'promptscript';
-const CONTROL_DIRECTIVES = ['@meta', '@inherit', '@extend', '@use'];
+const CONTROL_DIRECTIVES = ['@meta', '@inherit', '@extend', '@use', ...CONTEXTUAL_DIRECTIVES];
 const BLOCK_DIRECTIVES = BLOCK_TYPES.map((blockType) => `@${blockType}`);
 
 /**
@@ -284,6 +284,14 @@ export function createPrsCompletionProvider(
           insertText: '@use $1',
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           documentation: 'Import and merge directives from another file',
+          range,
+        },
+        {
+          label: '@header',
+          kind: monaco.languages.CompletionItemKind.Keyword,
+          insertText: '@header "$1"',
+          insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          documentation: 'Override a generated section title inside a block',
           range,
         },
         {

--- a/packages/resolver/src/__tests__/section-header-overrides.spec.ts
+++ b/packages/resolver/src/__tests__/section-header-overrides.spec.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SYNTAX_FEATURES, type Block, type PresentationEntry } from '@promptscript/core';
+import { parseOrThrow } from '@promptscript/parser';
+import { applyExtends } from '../extensions.js';
+import { Resolver } from '../resolver.js';
+
+const testDirectories: string[] = [];
+
+async function createTestDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'prs-section-headers-'));
+  testDirectories.push(directory);
+  return directory;
+}
+
+function headers(blocks: Block[], blockName: string): PresentationEntry[] {
+  const block = blocks.find((candidate) => candidate.name === blockName);
+  return (block?.canonicalBody?.entries ?? []).filter(
+    (entry): entry is PresentationEntry => entry.type === 'PresentationEntry'
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(
+    testDirectories.splice(0).map((directory) => rm(directory, { recursive: true }))
+  );
+});
+
+describe('section header override resolution', () => {
+  it('should let inherited child headers override parent headers', async () => {
+    const directory = await createTestDirectory();
+    const basePath = join(directory, 'base.prs');
+    const projectPath = join(directory, 'project.prs');
+    await writeFile(
+      basePath,
+      `@meta { id: "base" syntax: "1.5.0" }
+@standards {
+  @header "Base Rules"
+  code: ["Base content"]
+}`
+    );
+    await writeFile(
+      projectPath,
+      `@meta { id: "project" syntax: "1.5.0" }
+@inherit ./base
+@standards {
+  @header "Project Rules"
+  testing: ["Project content"]
+}`
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(projectPath);
+
+    expect(result.errors).toEqual([]);
+    expect(headers(result.ast!.blocks, 'standards')).toMatchObject([
+      { title: 'Project Rules', source: 'explicit' },
+    ]);
+  });
+
+  it('should preserve imported source precedence for section headers', async () => {
+    const directory = await createTestDirectory();
+    const sourcePath = join(directory, 'source.prs');
+    const projectPath = join(directory, 'project.prs');
+    await writeFile(
+      sourcePath,
+      `@meta { id: "source" syntax: "1.5.0" }
+@standards {
+  @header "Imported Rules"
+  code: ["Imported content"]
+}`
+    );
+    await writeFile(
+      projectPath,
+      `@meta { id: "project" syntax: "1.5.0" }
+@use ./source
+@standards {
+  @header "Local Rules"
+  testing: ["Local content"]
+}`
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(projectPath);
+
+    expect(result.errors).toEqual([]);
+    expect(headers(result.ast!.blocks, 'standards')).toMatchObject([
+      { title: 'Imported Rules', source: 'explicit' },
+    ]);
+  });
+
+  it('should apply the latest root extension header independently per section', () => {
+    const ast = parseOrThrow(`
+      @meta { id: "extend" syntax: "1.5.0" }
+      @standards {
+        @header code-standards "Base Rules"
+        @header git-commits "Base Commits"
+        code: ["Base content"]
+      }
+      @extend standards {
+        @header "First Rules"
+      }
+      @extend standards {
+        @header code-standards "Final Rules"
+        @header git-commits "Final Commits"
+      }
+    `);
+
+    const result = applyExtends(ast);
+
+    expect(headers(result.blocks, 'standards')).toMatchObject([
+      { sectionId: 'code-standards', title: 'Final Rules' },
+      { sectionId: 'git-commits', title: 'Final Commits' },
+    ]);
+  });
+
+  it('should normalize legacy headings in root extensions', () => {
+    const ast = parseOrThrow(`
+      @meta { id: "extend-legacy" syntax: "1.5.0" }
+      @standards {
+        """## Base Rules
+        Base content"""
+      }
+      @extend standards {
+        """## Extended Rules
+        Extended content"""
+      }
+    `);
+
+    const result = applyExtends(ast);
+    const standards = result.blocks.find((block) => block.name === 'standards');
+
+    expect(headers(result.blocks, 'standards')).toMatchObject([
+      { title: 'Extended Rules', source: 'legacy' },
+    ]);
+    expect(standards?.content).toMatchObject({
+      type: 'TextContent',
+      value: expect.stringContaining('Base content'),
+    });
+    expect(standards?.content).toMatchObject({
+      value: expect.stringContaining('Extended content'),
+    });
+  });
+
+  it('should retain transitive syntax feature usage', async () => {
+    const directory = await createTestDirectory();
+    const sourcePath = join(directory, 'source.prs');
+    const projectPath = join(directory, 'project.prs');
+    await writeFile(
+      sourcePath,
+      `@meta { id: "source" syntax: "1.4.0" }
+@standards {
+  @header "Imported Rules"
+  code: ["Imported content"]
+}`
+    );
+    await writeFile(
+      projectPath,
+      `@meta { id: "project" syntax: "1.4.0" }
+@use ./source`
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(projectPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.ast?.syntaxFeatures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          feature: SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE,
+          location: expect.objectContaining({ file: sourcePath }),
+        }),
+      ])
+    );
+  });
+});

--- a/packages/resolver/src/extensions.ts
+++ b/packages/resolver/src/extensions.ts
@@ -277,7 +277,8 @@ function mergeExtension(
         ext.canonicalBody,
         baseContent,
         extensionContent,
-        content
+        content,
+        block.name
       ),
     };
   }

--- a/packages/validator/src/__tests__/rules-coverage.spec.ts
+++ b/packages/validator/src/__tests__/rules-coverage.spec.ts
@@ -73,7 +73,7 @@ function createTextBlock(name: string, text: string, loc?: SourceLocation): Bloc
 describe('rules/index.ts coverage', () => {
   describe('allRules', () => {
     it('should contain all validation rules', () => {
-      expect(allRules).toHaveLength(36);
+      expect(allRules).toHaveLength(37);
       expect(allRules.map((r) => r.id)).toEqual([
         'PS001',
         'PS002',
@@ -106,6 +106,7 @@ describe('rules/index.ts coverage', () => {
         'PS034',
         'PS035',
         'PS036',
+        'PS037',
         'PS010',
         'PS011',
         'PS012',

--- a/packages/validator/src/__tests__/rules/syntax-version-compat.spec.ts
+++ b/packages/validator/src/__tests__/rules/syntax-version-compat.spec.ts
@@ -25,8 +25,10 @@ function makeAst(syntaxVersion: string, blockNames: string[] = []): Program {
   };
 }
 
-function validate(ast: Program): { message: string; suggestion?: string }[] {
-  const messages: { message: string; suggestion?: string }[] = [];
+function validate(
+  ast: Program
+): { message: string; suggestion?: string; location?: SourceLocation }[] {
+  const messages: { message: string; suggestion?: string; location?: SourceLocation }[] = [];
   syntaxVersionCompat.validate({
     ast,
     report: (msg) => messages.push(msg),
@@ -56,7 +58,7 @@ describe('PS018: syntax-version-compat', () => {
     const messages = validate(makeAst('1.5.7'));
     expect(messages).toHaveLength(1);
     expect(messages[0]!.message).toContain('Unknown syntax version "1.5.7"');
-    expect(messages[0]!.message).toContain('1.4.0');
+    expect(messages[0]!.message).toContain('1.5.0');
   });
 
   it('should warn when block requires higher version', () => {
@@ -148,5 +150,24 @@ describe('PS018: syntax-version-compat', () => {
     ];
 
     expect(validate(ast)).toHaveLength(0);
+  });
+
+  it('should report section header overrides at their exact usage location', () => {
+    const ast = makeAst('1.4.0');
+    const usageLoc = { file: 'headers.prs', line: 7, column: 5, offset: 82 };
+    ast.syntaxFeatures = [
+      {
+        feature: 'section-header-override',
+        location: usageLoc,
+      },
+    ];
+
+    const messages = validate(ast);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      message: expect.stringContaining('requires syntax >= 1.5.0'),
+      location: usageLoc,
+    });
   });
 });

--- a/packages/validator/src/__tests__/rules/valid-section-headers.spec.ts
+++ b/packages/validator/src/__tests__/rules/valid-section-headers.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBlockBody,
+  type PresentationEntry,
+  type Program,
+  type SourceLocation,
+} from '@promptscript/core';
+import { validSectionHeaders } from '../../rules/valid-section-headers.js';
+
+const loc: SourceLocation = { file: 'headers.prs', line: 3, column: 3, offset: 42 };
+
+function header(title: string, sectionId?: string): PresentationEntry {
+  return {
+    type: 'PresentationEntry',
+    ...(sectionId ? { sectionId, sectionLoc: loc } : {}),
+    title,
+    source: 'explicit',
+    loc,
+    titleLoc: loc,
+  };
+}
+
+function makeAst(blockName: string, entries: PresentationEntry[]): Program {
+  return {
+    type: 'Program',
+    loc,
+    meta: {
+      type: 'MetaBlock',
+      loc,
+      fields: { id: 'test', syntax: '1.5.0' },
+    },
+    blocks: [
+      {
+        type: 'Block',
+        name: blockName,
+        content: { type: 'ObjectContent', properties: {}, loc },
+        canonicalBody: createBlockBody(entries, loc),
+        loc,
+      },
+    ],
+    extends: [],
+    uses: [],
+  };
+}
+
+function validate(ast: Program): { message: string; location?: SourceLocation }[] {
+  const messages: { message: string; location?: SourceLocation }[] = [];
+  validSectionHeaders.validate({
+    ast,
+    report: (message) => messages.push(message),
+    config: {},
+  });
+  return messages;
+}
+
+describe('PS037: valid-section-headers', () => {
+  it('should accept primary and owned derived section overrides', () => {
+    const messages = validate(
+      makeAst('standards', [header('Coding Rules'), header('Commit Rules', 'git-commits')])
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should reject multiline section titles', () => {
+    const messages = validate(makeAst('standards', [header('Rules\n## Injected')]));
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        message: 'Section header title must fit on one line.',
+        location: loc,
+      }),
+    ]);
+  });
+
+  it('should reject invalid titles, keys, owners, and duplicates', () => {
+    const messages = validate(
+      makeAst('identity', [
+        header(''),
+        header('Unknown', 'missing'),
+        header('Commit Rules', 'git-commits'),
+        header('First'),
+        header('Second'),
+      ])
+    );
+
+    expect(messages.map((message) => message.message)).toEqual([
+      'Section header title must be a non-empty string.',
+      'Unknown section key "missing".',
+      'Section "git-commits" is not owned by @identity.',
+      'Duplicate section header override for "project".',
+      'Duplicate section header override for "project".',
+    ]);
+    for (const message of messages) {
+      expect(message.location).toEqual(loc);
+    }
+  });
+
+  it('should reject primary overrides in custom blocks and nested extensions', () => {
+    const customMessages = validate(makeAst('custom', [header('Custom')]));
+    const nested = makeAst('standards', []);
+    nested.blocks = [];
+    nested.extends = [
+      {
+        type: 'ExtendBlock',
+        targetPath: 'standards.code',
+        content: { type: 'ObjectContent', properties: {}, loc },
+        canonicalBody: createBlockBody([header('Nested')], loc),
+        loc,
+      },
+    ];
+
+    expect(customMessages[0]?.message).toContain('does not own a primary');
+    expect(validate(nested)[0]?.message).toContain('root block extension');
+  });
+
+  it('should ignore normalized legacy heading entries', () => {
+    const ast = makeAst('identity', [{ ...header('Legacy'), source: 'legacy' }]);
+
+    expect(validate(ast)).toHaveLength(0);
+  });
+});

--- a/packages/validator/src/__tests__/walker.spec.ts
+++ b/packages/validator/src/__tests__/walker.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Program, SourceLocation } from '@promptscript/core';
+import { createBlockBody, type Program, type SourceLocation } from '@promptscript/core';
 import { walkText, walkBlocks, walkUses, hasContent, offsetLocation } from '../walker.js';
 
 /**
@@ -149,6 +149,44 @@ describe('walker', () => {
       walkText(ast, (text) => texts.push(text));
 
       expect(texts).toEqual(['Extended content']);
+    });
+
+    it('should walk presentation titles at their exact locations', () => {
+      const visited: Array<{ text: string; loc: SourceLocation }> = [];
+      const titleLoc: SourceLocation = { file: 'test.prs', line: 4, column: 11 };
+      const ast = createTestProgram({
+        blocks: [
+          {
+            type: 'Block',
+            name: 'standards',
+            loc: defaultLoc,
+            content: {
+              type: 'ObjectContent',
+              properties: {},
+              loc: defaultLoc,
+            },
+            canonicalBody: createBlockBody(
+              [
+                {
+                  type: 'PresentationEntry',
+                  title: 'Security-sensitive title',
+                  source: 'explicit',
+                  loc: defaultLoc,
+                  titleLoc,
+                },
+              ],
+              defaultLoc
+            ),
+          },
+        ],
+      });
+
+      walkText(ast, (text, loc) => visited.push({ text, loc }));
+
+      expect(visited).toContainEqual({
+        text: 'Security-sensitive title',
+        loc: titleLoc,
+      });
     });
 
     it('should walk nested text content', () => {

--- a/packages/validator/src/rules/index.ts
+++ b/packages/validator/src/rules/index.ts
@@ -36,6 +36,7 @@ import { validAgentConfig } from './valid-agent-config.js';
 import { validHooks } from './valid-hooks.js';
 import { validMcpServers } from './valid-mcp-servers.js';
 import { validPlugins } from './valid-plugins.js';
+import { validSectionHeaders } from './valid-section-headers.js';
 
 // Re-export all rules
 export { requiredMetaId, requiredMetaSyntax } from './required-meta.js';
@@ -103,6 +104,7 @@ export { validAgentConfig } from './valid-agent-config.js';
 export { validHooks } from './valid-hooks.js';
 export { validMcpServers } from './valid-mcp-servers.js';
 export { validPlugins } from './valid-plugins.js';
+export { validSectionHeaders } from './valid-section-headers.js';
 
 /**
  * All validation rules in the order they should be executed.
@@ -169,6 +171,8 @@ export const allRules: ValidationRule[] = [
   validMcpServers,
   // Valid plugins (PS036)
   validPlugins,
+  // Valid section header overrides (PS037)
+  validSectionHeaders,
   // Security rules (PS010, PS011, PS012, PS013, PS014)
   suspiciousUrls,
   authorityInjection,

--- a/packages/validator/src/rules/syntax-version-compat.ts
+++ b/packages/validator/src/rules/syntax-version-compat.ts
@@ -54,7 +54,7 @@ export const syntaxVersionCompat: ValidationRule = {
 
       ctx.report({
         message: `Syntax feature "${usage.feature}" requires syntax >= ${minVersion}, but the resolved program declares "${syntax}".`,
-        location: meta.loc ?? ctx.ast.loc,
+        location: usage.location,
         suggestion: 'Use "prs validate --fix" to update the syntax version.',
       });
     }

--- a/packages/validator/src/rules/valid-section-headers.ts
+++ b/packages/validator/src/rules/valid-section-headers.ts
@@ -1,0 +1,97 @@
+import {
+  SECTION_REGISTRY,
+  blockOwnsSection,
+  getPrimarySectionForBlock,
+  type PresentationEntry,
+} from '@promptscript/core';
+import type { ValidationRule } from '../types.js';
+import { getBlockName, walkBlocks } from '../walker.js';
+
+/**
+ * PS037: Validate contextual section header overrides.
+ */
+export const validSectionHeaders: ValidationRule = {
+  id: 'PS037',
+  name: 'valid-section-headers',
+  description: 'Validate contextual section header overrides',
+  defaultSeverity: 'error',
+  validate: (ctx) => {
+    walkBlocks(ctx.ast, (block) => {
+      const entries = (block.canonicalBody?.entries ?? []).filter(
+        (entry): entry is PresentationEntry => entry.type === 'PresentationEntry'
+      );
+      if (entries.length === 0) return;
+
+      const blockName = getBlockName(block);
+      const nestedExtension = block.type === 'ExtendBlock' && block.targetPath.includes('.');
+      const seen = new Set<string>();
+
+      for (const entry of entries) {
+        if (entry.source !== 'explicit') continue;
+
+        if (typeof entry.title !== 'string' || entry.title.trim().length === 0) {
+          ctx.report({
+            message: 'Section header title must be a non-empty string.',
+            location: entry.titleLoc,
+          });
+        } else if (/[\r\n\u2028\u2029]/.test(entry.title)) {
+          ctx.report({
+            message: 'Section header title must fit on one line.',
+            location: entry.titleLoc,
+          });
+        }
+
+        if (nestedExtension) {
+          ctx.report({
+            message: '@header can only target a root block extension.',
+            location: entry.loc,
+            suggestion: `Use @extend ${blockName} with @header instead.`,
+          });
+          continue;
+        }
+
+        let sectionId: string | undefined;
+        if (entry.sectionId) {
+          const section = SECTION_REGISTRY.find((candidate) => candidate.id === entry.sectionId);
+          if (!section) {
+            ctx.report({
+              message: `Unknown section key "${entry.sectionId}".`,
+              location: entry.sectionLoc ?? entry.loc,
+              suggestion: `Known section keys: ${SECTION_REGISTRY.map((candidate) => candidate.id).join(', ')}.`,
+            });
+            continue;
+          }
+          if (!blockOwnsSection(blockName, section.id)) {
+            ctx.report({
+              message: `Section "${section.id}" is not owned by @${blockName}.`,
+              location: entry.sectionLoc ?? entry.loc,
+              suggestion: `Move the override to one of: ${section.sourceBlocks.map((owner) => `@${owner}`).join(', ')}.`,
+            });
+            continue;
+          }
+          sectionId = section.id;
+        } else {
+          const primary = getPrimarySectionForBlock(blockName);
+          if (!primary) {
+            ctx.report({
+              message: `Block @${blockName} does not own a primary generated section.`,
+              location: entry.loc,
+              suggestion: 'Use @header <section-key> only in a registered owner block.',
+            });
+            continue;
+          }
+          sectionId = primary.id;
+        }
+
+        if (seen.has(sectionId)) {
+          ctx.report({
+            message: `Duplicate section header override for "${sectionId}".`,
+            location: entry.sectionLoc ?? entry.loc,
+            suggestion: 'Keep one override for each generated section in a block.',
+          });
+        }
+        seen.add(sectionId);
+      }
+    });
+  },
+};

--- a/packages/validator/src/walker.ts
+++ b/packages/validator/src/walker.ts
@@ -44,11 +44,21 @@ export function walkText(ast: Program, callback: TextCallback, options?: WalkTex
   // Walk blocks
   for (const block of ast.blocks) {
     walkBlockContent(block.content, block.loc, callback, exclude);
+    walkPresentationTitles(block, callback);
   }
 
   // Walk extend blocks
   for (const ext of ast.extends) {
     walkBlockContent(ext.content, ext.loc, callback, exclude);
+    walkPresentationTitles(ext, callback);
+  }
+}
+
+function walkPresentationTitles(block: Block | ExtendBlock, callback: TextCallback): void {
+  for (const entry of block.canonicalBody?.entries ?? []) {
+    if (entry.type === 'PresentationEntry') {
+      callback(entry.title, entry.titleLoc);
+    }
   }
 }
 

--- a/scripts/check-grammar.mts
+++ b/scripts/check-grammar.mts
@@ -11,6 +11,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { BLOCK_TYPES } from '../packages/core/src/types/constants.js';
+import { CONTEXTUAL_DIRECTIVES } from '../packages/core/src/section-registry.js';
 // Uses .js extension per swc-node convention (see validate-docs-examples.mts for reference)
 import { allTokens } from '../packages/parser/src/lexer/tokens.js';
 import {
@@ -263,10 +264,11 @@ for (const token of allTokens) {
 }
 
 const expectedBlockDirectives = BLOCK_TYPES.map((blockType) => `@${blockType}`);
+const expectedContextualDirectives = [...CONTEXTUAL_DIRECTIVES];
 const monacoDirectives = new Set(prsLanguageDefinition.directives as string[]);
-for (const directive of expectedBlockDirectives) {
+for (const directive of [...expectedBlockDirectives, ...expectedContextualDirectives]) {
   if (!monacoDirectives.has(directive)) {
-    syncErrors.push(`Monaco grammar is missing block directive ${directive}`);
+    syncErrors.push(`Monaco grammar is missing directive ${directive}`);
   }
 }
 
@@ -289,6 +291,20 @@ if (!pygmentsBlockMatch) {
   }
 }
 
+const pygmentsContextualMatch = pygmentsSource.match(/CONTEXTUAL_DIRECTIVES = \(([\s\S]*?)\)\n\n/);
+if (!pygmentsContextualMatch) {
+  syncErrors.push('Pygments lexer does not expose CONTEXTUAL_DIRECTIVES');
+} else {
+  const pygmentsContextual = new Set(
+    [...pygmentsContextualMatch[1]!.matchAll(/"([^"]+)"/g)].map((match) => `@${match[1]!}`)
+  );
+  for (const directive of expectedContextualDirectives) {
+    if (!pygmentsContextual.has(directive)) {
+      syncErrors.push(`Pygments lexer is missing contextual directive ${directive}`);
+    }
+  }
+}
+
 const textMateBlockPattern = grammar.repository?.['block-directive']?.match;
 if (!textMateBlockPattern) {
   syncErrors.push('TextMate grammar does not define block-directive.match');
@@ -297,6 +313,18 @@ if (!textMateBlockPattern) {
   for (const directive of expectedBlockDirectives) {
     if (!blockRegex.test(directive)) {
       syncErrors.push(`TextMate grammar does not match block directive ${directive}`);
+    }
+  }
+}
+
+const textMateControlPattern = grammar.repository?.['control-directive']?.match;
+if (!textMateControlPattern) {
+  syncErrors.push('TextMate grammar does not define control-directive.match');
+} else {
+  const controlRegex = new RegExp(`^(?:${textMateControlPattern})$`);
+  for (const directive of expectedContextualDirectives) {
+    if (!controlRegex.test(directive)) {
+      syncErrors.push(`TextMate grammar does not match contextual directive ${directive}`);
     }
   }
 }

--- a/skills/promptscript/SKILL.md
+++ b/skills/promptscript/SKILL.md
@@ -991,6 +991,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.2.0` | Adds `@examples` (few-shot input/output pairs)                                                                          |
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
+| `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
 
 ### Block Version Requirements
 
@@ -1005,11 +1006,37 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
+Generated section title overrides with `@header` require syntax `1.5.0`.
+
+### Generated Section Headers
+
+Use `@header` inside a registered owner block to rename human-readable output
+sections without changing filenames, frontmatter, XML tags, or structured keys:
+
+```promptscript
+@meta { id: "localized" syntax: "1.5.0" }
+
+@standards {
+  @header "Coding Rules"
+  @header git-commits "Commit Rules"
+  code: ["Use strict TypeScript"]
+}
+```
+
+- `@header "Title"` targets the block's primary section.
+- `@header <section-key> "Title"` targets an owned derived section.
+- Titles must be non-empty, single-line strings.
+- Source overrides take precedence over formatter configuration and target defaults.
+- Child inheritance, imported source, and the latest root extension take precedence.
+- An initial `## Heading` in a registered text-only primary owner is a syntax
+  `1.5.0` compatibility fallback. Explicit `@header` metadata wins.
+- Ordinary `header` and `headers` fields remain domain data.
 
 ### Validation Rules
 
 - **PS018 (`syntax-version-compat`)**: warns when resolved blocks or syntax features require a higher version than declared. Requirements from inheritance, imports, and skill composition are included. Suggestion: run `prs validate --fix`.
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
+- **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).


### PR DESCRIPTION
## Summary

- add syntax 1.5 contextual `@header` directives and canonical presentation metadata
- validate ownership, duplicates, titles, syntax compatibility, and inherited feature usage
- apply source-defined titles consistently across human-readable formatter sections while preserving content and protocol identifiers
- support legacy initial headings for registered text-only sections and deterministic merge precedence
- update highlighters, PromptScript skills, language docs, browser behavior, CLI fixes, and snapshots

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:validate:check`

Closes #331
