### PR TITLE
feat(formatters): support target hook executables

### DIFF
--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -38,8 +38,8 @@ The `@hooks` block requires syntax `1.4.0`:
 
 ### Target-specific behavior
 
-Keep the portable event and command as the default, then override only the
-fields that differ on a host:
+Keep a portable executable as the default, then override only the fields that
+differ on a host. A target can replace the executable with its own `command`:
 
 ```promptscript
 @hooks {
@@ -50,6 +50,7 @@ fields that differ on a host:
     targets: {
       factory: {
         matcher: "Execute"
+        command: ["node", ".promptscript/scripts/check-factory.mjs", "--strict mode"]
       }
       vscode: {
         matcher: "run_in_terminal"
@@ -62,10 +63,13 @@ fields that differ on a host:
 }
 ```
 
-Supported override fields are `event`, `matcher`, `timeoutMs`,
-`statusMessage`, `continueOnFailure`, `enabled`, and `cwd`. Overrides are
-validated against known target names and do not change the portable source
-definition used by other targets.
+Supported override fields are `event`, `command`, `script`, `matcher`,
+`timeoutMs`, `statusMessage`, `continueOnFailure`, `enabled`, and `cwd`.
+Defining one of `command` or `script` replaces the base executable for that
+target only. Defining neither inherits the base executable, while defining both
+is rejected. Target commands and scripts use the same interpolation, path,
+interpreter, and argument validation as the base hook. A disabled target
+override emits no hook.
 
 ### Portable Events
 
@@ -137,6 +141,24 @@ Each hook requires exactly one of `command` or `script`. A portable script:
   `ruby`, `php`, `perl`, `bash`, `sh`, `zsh`, `pwsh`, or `powershell`.
 - Preserves every value in `args` as one argument, including spaces and shell
   metacharacters.
+
+A target override can select a different repository script while retaining the
+base event and other options:
+
+```promptscript
+targets: {
+  github: {
+    script: {
+      path: ".promptscript/scripts/validate-github.py"
+      interpreter: "python3"
+      args: ["--strict mode"]
+    }
+  }
+}
+```
+
+Enabled target-only scripts are checked by both Node and browser compilers.
+Scripts attached only to disabled target overrides are not required or emitted.
 
 The Node compiler validates the real filesystem. The browser compiler performs
 the equivalent check against its virtual filesystem. For entries outside

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -1313,18 +1313,18 @@ Portable events:
 
 Each hook entry is an object with:
 
-| Field               | Required | Type     | Description                                                                                              |
-| ------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------- |
-| `event`             | Yes      | string   | Portable event name (see above)                                                                          |
-| `command`           | One of   | string[] | Non-empty source argument array                                                                          |
-| `script`            | One of   | object   | Repository-local script descriptor                                                                       |
-| `cwd`               | No       | string   | `"project"` or a forward-slash path relative to project root                                             |
-| `matcher`           | No       | string   | Target-native tool name matcher pattern                                                                  |
-| `timeoutMs`         | No       | number   | Timeout in ms (100-600000)                                                                               |
-| `statusMessage`     | No       | string   | Status message shown during execution                                                                    |
-| `continueOnFailure` | No       | boolean  | Whether to continue if hook fails                                                                        |
-| `enabled`           | No       | boolean  | Whether the hook is enabled (default: true)                                                              |
-| `targets`           | No       | object   | Target-specific overrides for event, matcher, timeout, statusMessage, continueOnFailure, cwd, or enabled |
+| Field               | Required | Type     | Description                                                                        |
+| ------------------- | -------- | -------- | ---------------------------------------------------------------------------------- |
+| `event`             | Yes      | string   | Portable event name (see above)                                                    |
+| `command`           | One of   | string[] | Non-empty source argument array                                                    |
+| `script`            | One of   | object   | Repository-local script descriptor                                                 |
+| `cwd`               | No       | string   | `"project"` or a forward-slash path relative to project root                       |
+| `matcher`           | No       | string   | Target-native tool name matcher pattern                                            |
+| `timeoutMs`         | No       | number   | Timeout in ms (100-600000)                                                         |
+| `statusMessage`     | No       | string   | Status message shown during execution                                              |
+| `continueOnFailure` | No       | boolean  | Whether to continue if hook fails                                                  |
+| `enabled`           | No       | boolean  | Whether the hook is enabled (default: true)                                        |
+| `targets`           | No       | object   | Target-specific overrides, including an optional replacement `command` or `script` |
 
 Exactly one of `command` or `script` is required. A `script` object contains:
 
@@ -1362,8 +1362,8 @@ Target overrides use the target name as the key:
 
 ```promptscript
 targets: {
-  factory: { matcher: "Execute" }
-  vscode: { matcher: "run_in_terminal" }
+  factory: { matcher: "Execute" command: ["node", "check-factory.mjs"] }
+  vscode: { script: { path: ".promptscript/scripts/check.py" interpreter: "python3" } }
   github: { enabled: false }
 }
 ```
@@ -2170,3 +2170,17 @@ initial `## Heading` as a compatibility fallback:
 The formatter emits that heading once and preserves the remaining body. Explicit
 `@header` metadata always wins over this fallback. Syntax `1.4.x` and earlier
 keep the heading as ordinary body text, so existing output remains unchanged.
+
+## Hook Target Executable Overrides
+
+An `@hooks` target override supports `event`, `command`, `script`, `matcher`,
+`timeoutMs`, `statusMessage`, `continueOnFailure`, `enabled`, and `cwd`. A
+target may define either `command` or `script` to replace the base executable
+for that target. It inherits the base executable when neither field is present,
+and PS034 rejects overrides that define both.
+
+Replacement executables use the same command interpolation, script path,
+interpreter, and argument validation as base executables. Enabled target
+scripts are included in Node and browser compiler resource validation.
+Disabled target overrides emit no hook and do not require their script
+resource.

--- a/packages/browser-compiler/src/__tests__/hook-script-validator.spec.ts
+++ b/packages/browser-compiler/src/__tests__/hook-script-validator.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { Program, SourceLocation } from '@promptscript/core';
+import type { Program, SourceLocation, Value } from '@promptscript/core';
 import { validateBrowserHookScriptResources } from '../hook-script-validator.js';
 import { VirtualFileSystem } from '../virtual-fs.js';
 
 const loc: SourceLocation = { file: 'workspace/.promptscript/project.prs', line: 1, column: 1 };
-function makeProgram(enabled = true, scriptPath = '.promptscript/scripts/check.mjs'): Program {
+function makeHookProgram(hook: Record<string, Value>): Program {
   return {
     type: 'Program',
     blocks: [
@@ -14,14 +14,7 @@ function makeProgram(enabled = true, scriptPath = '.promptscript/scripts/check.m
         content: {
           type: 'ObjectContent',
           properties: {
-            check: {
-              event: 'post-tool-use',
-              script: {
-                path: scriptPath,
-                interpreter: 'node',
-              },
-              enabled,
-            },
+            check: hook,
           },
           loc,
         },
@@ -32,6 +25,17 @@ function makeProgram(enabled = true, scriptPath = '.promptscript/scripts/check.m
     extends: [],
     loc,
   };
+}
+
+function makeProgram(enabled = true, scriptPath = '.promptscript/scripts/check.mjs'): Program {
+  return makeHookProgram({
+    event: 'post-tool-use',
+    script: {
+      path: scriptPath,
+      interpreter: 'node',
+    },
+    enabled,
+  });
 }
 
 describe('browser hook script resource validation', () => {
@@ -116,6 +120,91 @@ describe('browser hook script resource validation', () => {
         'workspace/.promptscript/project.prs'
       )
     ).toEqual([]);
+  });
+
+  it('reports a missing target-only virtual script', () => {
+    const fs = new VirtualFileSystem({
+      'workspace/.promptscript/project.prs': '',
+    });
+
+    expect(
+      validateBrowserHookScriptResources(
+        makeHookProgram({
+          event: 'post-tool-use',
+          command: ['node', 'base.mjs'],
+          targets: {
+            factory: {
+              script: {
+                path: '.promptscript/scripts/missing-target.mjs',
+                interpreter: 'node',
+              },
+            },
+          },
+        }),
+        fs,
+        'workspace/.promptscript/project.prs'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        code: 'PS2001',
+        message: 'Hook "check" script not found: .promptscript/scripts/missing-target.mjs',
+      }),
+    ]);
+  });
+
+  it('ignores virtual target scripts for disabled overrides', () => {
+    const fs = new VirtualFileSystem({
+      'workspace/.promptscript/project.prs': '',
+    });
+
+    expect(
+      validateBrowserHookScriptResources(
+        makeHookProgram({
+          event: 'post-tool-use',
+          command: ['node', 'base.mjs'],
+          targets: {
+            factory: {
+              enabled: false,
+              script: {
+                path: '.promptscript/scripts/missing-target.mjs',
+                interpreter: 'node',
+              },
+            },
+          },
+        }),
+        fs,
+        'workspace/.promptscript/project.prs'
+      )
+    ).toEqual([]);
+  });
+
+  it('validates inherited virtual scripts for re-enabled targets', () => {
+    const fs = new VirtualFileSystem({
+      'workspace/.promptscript/project.prs': '',
+    });
+
+    expect(
+      validateBrowserHookScriptResources(
+        makeHookProgram({
+          event: 'post-tool-use',
+          enabled: false,
+          script: {
+            path: '.promptscript/scripts/missing-inherited.mjs',
+            interpreter: 'node',
+          },
+          targets: {
+            factory: { enabled: true },
+          },
+        }),
+        fs,
+        'workspace/.promptscript/project.prs'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        code: 'PS2001',
+        message: 'Hook "check" script not found: .promptscript/scripts/missing-inherited.mjs',
+      }),
+    ]);
   });
 
   it('uses an explicit project root for custom entry layouts', () => {

--- a/packages/browser-compiler/src/hook-script-validator.ts
+++ b/packages/browser-compiler/src/hook-script-validator.ts
@@ -1,5 +1,5 @@
 import type { Program, SourceLocation } from '@promptscript/core';
-import { extractHooks } from '@promptscript/formatters';
+import { extractHooks, getEnabledHookScriptResources } from '@promptscript/formatters';
 import type { VirtualFileSystem } from './virtual-fs.js';
 
 export interface BrowserHookScriptError {
@@ -59,24 +59,25 @@ export function validateBrowserHookScriptResources(
   const projectPrefix = getProjectPrefix(entryPath, projectRoot);
   const errors: BrowserHookScriptError[] = [];
   for (const hook of extractHooks(hooksBlock)) {
-    if (hook.enabled === false || !hook.script) continue;
-    if (!isSafeHookScriptPath(hook.script.path, projectPrefix)) {
-      errors.push({
-        name: 'ResolveError',
-        code: 'PS1003',
-        message: `Hook "${hook.id}" script resolves outside ".promptscript/scripts/": ${hook.script.path}`,
-        location: hooksBlock.loc,
-      });
-      continue;
-    }
-    const scriptPath = projectPrefix ? `${projectPrefix}/${hook.script.path}` : hook.script.path;
-    if (!fs.exists(scriptPath)) {
-      errors.push({
-        name: 'FileNotFoundError',
-        code: 'PS2001',
-        message: `Hook "${hook.id}" script not found: ${hook.script.path}`,
-        location: hooksBlock.loc,
-      });
+    for (const script of getEnabledHookScriptResources(hook)) {
+      if (!isSafeHookScriptPath(script.path, projectPrefix)) {
+        errors.push({
+          name: 'ResolveError',
+          code: 'PS1003',
+          message: `Hook "${hook.id}" script resolves outside ".promptscript/scripts/": ${script.path}`,
+          location: hooksBlock.loc,
+        });
+        continue;
+      }
+      const scriptPath = projectPrefix ? `${projectPrefix}/${script.path}` : script.path;
+      if (!fs.exists(scriptPath)) {
+        errors.push({
+          name: 'FileNotFoundError',
+          code: 'PS2001',
+          message: `Hook "${hook.id}" script not found: ${script.path}`,
+          location: hooksBlock.loc,
+        });
+      }
     }
   }
 

--- a/packages/compiler/src/__tests__/hook-script-validator.spec.ts
+++ b/packages/compiler/src/__tests__/hook-script-validator.spec.ts
@@ -2,12 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtemp, mkdir, rm, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import type { Program, SourceLocation } from '@promptscript/core';
+import type { Program, SourceLocation, Value } from '@promptscript/core';
 import { inferProjectRoot, validateHookScriptResources } from '../hook-script-validator.js';
 
 const loc: SourceLocation = { file: '.promptscript/project.prs', line: 1, column: 1 };
 
-function makeProgram(scriptPath: string, enabled = true): Program {
+function makeHookProgram(hook: Record<string, Value>): Program {
   return {
     type: 'Program',
     blocks: [
@@ -17,14 +17,7 @@ function makeProgram(scriptPath: string, enabled = true): Program {
         content: {
           type: 'ObjectContent',
           properties: {
-            check: {
-              event: 'post-tool-use',
-              script: {
-                path: scriptPath,
-                interpreter: 'node',
-              },
-              enabled,
-            },
+            check: hook,
           },
           loc,
         },
@@ -35,6 +28,17 @@ function makeProgram(scriptPath: string, enabled = true): Program {
     extends: [],
     loc,
   };
+}
+
+function makeProgram(scriptPath: string, enabled = true): Program {
+  return makeHookProgram({
+    event: 'post-tool-use',
+    script: {
+      path: scriptPath,
+      interpreter: 'node',
+    },
+    enabled,
+  });
 }
 
 describe('hook script resource validation', () => {
@@ -108,6 +112,76 @@ describe('hook script resource validation', () => {
         projectRoot
       )
     ).resolves.toEqual([]);
+  });
+
+  it('reports a missing target-only script', async () => {
+    const errors = await validateHookScriptResources(
+      makeHookProgram({
+        event: 'post-tool-use',
+        command: ['node', 'base.mjs'],
+        targets: {
+          factory: {
+            script: {
+              path: '.promptscript/scripts/missing-target.mjs',
+              interpreter: 'node',
+            },
+          },
+        },
+      }),
+      projectRoot
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        code: 'PS2001',
+        message: 'Hook "check" script not found: .promptscript/scripts/missing-target.mjs',
+      }),
+    ]);
+  });
+
+  it('ignores target scripts for disabled overrides', async () => {
+    await expect(
+      validateHookScriptResources(
+        makeHookProgram({
+          event: 'post-tool-use',
+          command: ['node', 'base.mjs'],
+          targets: {
+            factory: {
+              enabled: false,
+              script: {
+                path: '.promptscript/scripts/missing-target.mjs',
+                interpreter: 'node',
+              },
+            },
+          },
+        }),
+        projectRoot
+      )
+    ).resolves.toEqual([]);
+  });
+
+  it('validates inherited scripts for re-enabled targets', async () => {
+    const errors = await validateHookScriptResources(
+      makeHookProgram({
+        event: 'post-tool-use',
+        enabled: false,
+        script: {
+          path: '.promptscript/scripts/missing-inherited.mjs',
+          interpreter: 'node',
+        },
+        targets: {
+          factory: { enabled: true },
+        },
+      }),
+      projectRoot
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        code: 'PS2001',
+        message: 'Hook "check" script not found: .promptscript/scripts/missing-inherited.mjs',
+      }),
+    ]);
   });
 
   it('rejects a script symlink that escapes the scripts directory', async () => {

--- a/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
+++ b/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
@@ -104,6 +104,101 @@ describe('Hook target smoke tests', () => {
     expect(result.outputs.has('.windsurf/hooks.json')).toBe(true);
   });
 
+  it('compiles target executable overrides to each native contract', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-hook-overrides-'));
+    directories.push(directory);
+    mkdirSync(join(directory, '.promptscript', 'scripts'), { recursive: true });
+    writeFileSync(
+      join(directory, '.promptscript', 'scripts', 'github check.py'),
+      'raise SystemExit(0)\n'
+    );
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "hook-target-overrides"
+  syntax: "1.4.0"
+}
+
+@hooks {
+  check: {
+    event: "pre-tool-use"
+    command: ["node", "base.mjs"]
+    targets: {
+      factory: {
+        command: ["node", "factory check.mjs", "--strict mode"]
+      }
+      github: {
+        script: {
+          path: ".promptscript/scripts/github check.py"
+          interpreter: "python3"
+          args: ["--strict mode"]
+        }
+      }
+      vscode: {
+        command: ["node", "VS Code check.mjs", "--strict mode"]
+      }
+    }
+  }
+}
+`
+    );
+
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [
+        { name: 'factory', config: { version: 'full' } },
+        { name: 'github', config: { version: 'full' } },
+      ],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(result.outputs.get('.factory/hooks.json')!.content)).toEqual({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '.*',
+            hooks: [
+              {
+                type: 'command',
+                command: "node 'factory check.mjs' '--strict mode' # promptscript-generated:check",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(JSON.parse(result.outputs.get('.github/hooks/promptscript.json')!.content)).toEqual({
+      version: 1,
+      hooks: {
+        preToolUse: [
+          {
+            type: 'command',
+            bash: "python3 '.promptscript/scripts/github check.py' '--strict mode' # promptscript-generated:check",
+            powershell:
+              "& 'py' '-3' '.promptscript/scripts/github check.py' '--strict mode' # promptscript-generated:check",
+            cwd: '.',
+          },
+        ],
+      },
+    });
+    expect(
+      JSON.parse(result.outputs.get('.github/hooks/promptscript-vscode.json')!.content)
+    ).toEqual({
+      hooks: {
+        PreToolUse: [
+          {
+            type: 'command',
+            command: "node 'VS Code check.mjs' '--strict mode' # promptscript-generated:check",
+            windows: "& 'node' 'VS Code check.mjs' '--strict mode' # promptscript-generated:check",
+          },
+        ],
+      },
+    });
+  });
+
   it('runs a repository-local script from project root when invoked from a nested directory', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'promptscript hook project '));
     directories.push(directory);
@@ -185,10 +280,12 @@ describe('Hook target smoke tests', () => {
     const result = await compiler.compile(entryPath);
 
     expect(result.success).toBe(true);
-    expect(result.warnings.map((warning) => warning.message)).toEqual([
-      'Hook "validate" requests cwd "project", which cursor cannot guarantee and will ignore.',
-      'Hook "validate" requests cwd "project", which codex cannot guarantee and will ignore.',
-    ]);
+    expect(result.warnings.map((warning) => warning.message)).toEqual(
+      expect.arrayContaining([
+        'Hook "validate" requests cwd "project", which cursor cannot guarantee and will ignore.',
+        'Hook "validate" requests cwd "project", which codex cannot guarantee and will ignore.',
+      ])
+    );
     const claude = JSON.parse(result.outputs.get('.claude/settings.json')!.content) as {
       hooks: { PostToolUse: Array<{ hooks: Array<{ command: string }> }> };
     };

--- a/packages/compiler/src/hook-script-validator.ts
+++ b/packages/compiler/src/hook-script-validator.ts
@@ -1,7 +1,7 @@
 import { lstat, realpath } from 'fs/promises';
 import { dirname, isAbsolute, relative, resolve, sep } from 'path';
 import type { Program } from '@promptscript/core';
-import { extractHooks } from '@promptscript/formatters';
+import { extractHooks, getEnabledHookScriptResources } from '@promptscript/formatters';
 import type { CompileError } from './types.js';
 
 function isInside(root: string, candidate: string): boolean {
@@ -53,50 +53,51 @@ export async function validateHookScriptResources(
   }
 
   for (const hook of extractHooks(hooksBlock)) {
-    if (hook.enabled === false || !hook.script) continue;
-    const scriptPath = resolve(projectRoot, hook.script.path);
+    for (const script of getEnabledHookScriptResources(hook)) {
+      const scriptPath = resolve(projectRoot, script.path);
 
-    try {
-      const scriptInfo = await lstat(scriptPath);
-      const resolvedScriptPath = await realpath(scriptPath);
-      const resolvedScriptInfo = scriptInfo.isSymbolicLink()
-        ? await lstat(resolvedScriptPath)
-        : scriptInfo;
-      if (!resolvedScriptInfo.isFile()) {
+      try {
+        const scriptInfo = await lstat(scriptPath);
+        const resolvedScriptPath = await realpath(scriptPath);
+        const resolvedScriptInfo = scriptInfo.isSymbolicLink()
+          ? await lstat(resolvedScriptPath)
+          : scriptInfo;
+        if (!resolvedScriptInfo.isFile()) {
+          errors.push({
+            name: 'ResolveError',
+            code: 'PS1003',
+            message: `Hook "${hook.id}" script is not a file: ${script.path}`,
+            location: hooksBlock.loc,
+          });
+          continue;
+        }
+
+        if (
+          !isInside(realProjectRoot, realScriptsRoot) ||
+          !isInside(realScriptsRoot, resolvedScriptPath)
+        ) {
+          errors.push({
+            name: 'ResolveError',
+            code: 'PS1003',
+            message: `Hook "${hook.id}" script resolves outside ".promptscript/scripts/": ${script.path}`,
+            location: hooksBlock.loc,
+          });
+        }
+      } catch (error) {
+        const code =
+          typeof error === 'object' && error !== null && 'code' in error
+            ? String(error.code)
+            : undefined;
         errors.push({
-          name: 'ResolveError',
-          code: 'PS1003',
-          message: `Hook "${hook.id}" script is not a file: ${hook.script.path}`,
+          name: 'FileNotFoundError',
+          code: code === 'ENOENT' ? 'PS2001' : 'PS1003',
+          message:
+            code === 'ENOENT'
+              ? `Hook "${hook.id}" script not found: ${script.path}`
+              : `Hook "${hook.id}" script cannot be read: ${script.path}`,
           location: hooksBlock.loc,
         });
-        continue;
       }
-
-      if (
-        !isInside(realProjectRoot, realScriptsRoot) ||
-        !isInside(realScriptsRoot, resolvedScriptPath)
-      ) {
-        errors.push({
-          name: 'ResolveError',
-          code: 'PS1003',
-          message: `Hook "${hook.id}" script resolves outside ".promptscript/scripts/": ${hook.script.path}`,
-          location: hooksBlock.loc,
-        });
-      }
-    } catch (error) {
-      const code =
-        typeof error === 'object' && error !== null && 'code' in error
-          ? String(error.code)
-          : undefined;
-      errors.push({
-        name: 'FileNotFoundError',
-        code: code === 'ENOENT' ? 'PS2001' : 'PS1003',
-        message:
-          code === 'ENOENT'
-            ? `Hook "${hook.id}" script not found: ${hook.script.path}`
-            : `Hook "${hook.id}" script cannot be read: ${hook.script.path}`,
-        location: hooksBlock.loc,
-      });
     }
   }
 

--- a/packages/formatters/src/__tests__/hook-adapters.spec.ts
+++ b/packages/formatters/src/__tests__/hook-adapters.spec.ts
@@ -11,6 +11,7 @@ import {
   generateGrokHooks,
   generateVSCodeHooks,
   generateWindsurfHooks,
+  getEnabledHookScriptResources,
   getHookCompatibilityWarnings,
   mapEvent,
   convertTimeout,
@@ -416,9 +417,100 @@ describe('hook-adapters', () => {
         },
       });
     });
+
+    it('should extract command and script target overrides', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          check: {
+            event: 'post-tool-use',
+            command: ['node', 'base.mjs'],
+            targets: {
+              factory: {
+                command: ['node', 'factory check.mjs', '--strict mode'],
+              },
+              github: {
+                script: {
+                  path: '.promptscript/scripts/github check.py',
+                  interpreter: 'python3',
+                  args: ['--strict mode'],
+                },
+              },
+            },
+          },
+        })
+      );
+
+      expect(hooks[0]!.targets?.factory?.command).toEqual([
+        'node',
+        'factory check.mjs',
+        '--strict mode',
+      ]);
+      expect(hooks[0]!.targets?.github?.script).toEqual({
+        path: '.promptscript/scripts/github check.py',
+        interpreter: 'python3',
+        args: ['--strict mode'],
+      });
+    });
   });
 
   describe('generateFactoryHooks', () => {
+    it('should inherit the base executable when a target does not replace it', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          check: {
+            event: 'pre-tool-use',
+            command: ['node', 'base hook.mjs'],
+            targets: {
+              factory: { matcher: 'Edit' },
+            },
+          },
+        })
+      );
+
+      expect(generateFactoryHooks(hooks)['PreToolUse']![0]).toEqual({
+        matcher: 'Edit',
+        hooks: [
+          {
+            type: 'command',
+            command: "node 'base hook.mjs' # promptscript-generated:check",
+          },
+        ],
+      });
+    });
+
+    it('should replace a base script with a target command', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          check: {
+            event: 'pre-tool-use',
+            script: {
+              path: '.promptscript/scripts/base.py',
+              interpreter: 'python3',
+            },
+            targets: {
+              factory: {
+                command: ['node', 'factory check.mjs', '--strict mode'],
+              },
+            },
+          },
+        })
+      );
+
+      expect(generateFactoryHooks(hooks)).toEqual({
+        PreToolUse: [
+          {
+            matcher: '.*',
+            hooks: [
+              {
+                type: 'command',
+                command: "node 'factory check.mjs' '--strict mode' # promptscript-generated:check",
+              },
+            ],
+          },
+        ],
+      });
+    });
+
     it('should generate enabled hooks with Factory options', () => {
       const hooks = extractHooks(
         makeHooksBlock({
@@ -513,6 +605,19 @@ describe('hook-adapters', () => {
         ])
       ).toEqual({});
     });
+
+    it('should omit a hook disabled for Factory', () => {
+      expect(
+        generateFactoryHooks([
+          {
+            id: 'disabled',
+            event: 'pre-tool-use',
+            command: ['echo', 'base'],
+            targets: { factory: { command: ['echo', 'factory'], enabled: false } },
+          },
+        ])
+      ).toEqual({});
+    });
   });
 
   describe('generateVSCodeHooks', () => {
@@ -526,6 +631,7 @@ describe('hook-adapters', () => {
             timeoutMs: 5000,
             targets: {
               vscode: {
+                command: ['node', 'VS Code hook.mjs', '--label=hello world'],
                 matcher: 'run_in_terminal',
                 timeoutMs: 15000,
               },
@@ -538,8 +644,10 @@ describe('hook-adapters', () => {
         PreToolUse: [
           {
             type: 'command',
-            command: 'prs hook pre-edit # promptscript-generated:terminal',
-            windows: "& 'prs' 'hook' 'pre-edit' # promptscript-generated:terminal",
+            command:
+              "node 'VS Code hook.mjs' '--label=hello world' # promptscript-generated:terminal",
+            windows:
+              "& 'node' 'VS Code hook.mjs' '--label=hello world' # promptscript-generated:terminal",
             matcher: 'run_in_terminal',
             timeout: 15,
           },
@@ -587,6 +695,38 @@ describe('hook-adapters', () => {
   });
 
   describe('generateGitHubHooks', () => {
+    it('should replace a base command with a target script on Unix and Windows', () => {
+      const hooks = extractHooks(
+        makeHooksBlock({
+          check: {
+            event: 'pre-tool-use',
+            command: ['node', 'base.mjs'],
+            targets: {
+              github: {
+                script: {
+                  path: '.promptscript/scripts/GitHub check.py',
+                  interpreter: 'python3',
+                  args: ['--label=hello world'],
+                },
+              },
+            },
+          },
+        })
+      );
+
+      expect(generateGitHubHooks(hooks)).toEqual({
+        preToolUse: [
+          {
+            type: 'command',
+            bash: "python3 '.promptscript/scripts/GitHub check.py' '--label=hello world' # promptscript-generated:check",
+            powershell:
+              "& 'py' '-3' '.promptscript/scripts/GitHub check.py' '--label=hello world' # promptscript-generated:check",
+            cwd: '.',
+          },
+        ],
+      });
+    });
+
     it('should generate current versioned repository hook entries', () => {
       const hooks = extractHooks(
         makeHooksBlock({
@@ -695,6 +835,68 @@ describe('hook-adapters', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('getEnabledHookScriptResources', () => {
+    it('should include effective base and target scripts without duplicates', () => {
+      const hook: HookDefinition = {
+        id: 'check',
+        event: 'pre-tool-use',
+        script: {
+          path: '.promptscript/scripts/base.mjs',
+          interpreter: 'node',
+          args: [],
+        },
+        targets: {
+          factory: {
+            matcher: 'Edit',
+          },
+          github: {
+            script: {
+              path: '.promptscript/scripts/github.py',
+              interpreter: 'python3',
+              args: [],
+            },
+          },
+          vscode: {
+            command: ['node', 'vscode.mjs'],
+          },
+        },
+      };
+
+      expect(getEnabledHookScriptResources(hook).map((script) => script.path)).toEqual([
+        '.promptscript/scripts/base.mjs',
+        '.promptscript/scripts/github.py',
+      ]);
+    });
+
+    it('should include inherited scripts for re-enabled targets only', () => {
+      const hook: HookDefinition = {
+        id: 'check',
+        event: 'pre-tool-use',
+        enabled: false,
+        script: {
+          path: '.promptscript/scripts/base.mjs',
+          interpreter: 'node',
+          args: [],
+        },
+        targets: {
+          factory: { enabled: true },
+          github: {
+            enabled: false,
+            script: {
+              path: '.promptscript/scripts/disabled.py',
+              interpreter: 'python3',
+              args: [],
+            },
+          },
+        },
+      };
+
+      expect(getEnabledHookScriptResources(hook).map((script) => script.path)).toEqual([
+        '.promptscript/scripts/base.mjs',
+      ]);
     });
   });
 

--- a/packages/formatters/src/hook-adapters.ts
+++ b/packages/formatters/src/hook-adapters.ts
@@ -32,6 +32,8 @@ export type HookTarget =
 export interface HookTargetOverride {
   event?: PortableHookEvent;
   matcher?: string;
+  command?: string[];
+  script?: HookScriptDefinition;
   timeoutMs?: number;
   statusMessage?: string;
   continueOnFailure?: boolean;
@@ -233,6 +235,29 @@ function serializeNativeCwdScriptCommand(
   return `${invocation} ${HOOK_OWNERSHIP_MARKER}:${hook.id.replace(/[^A-Za-z0-9._-]/g, '-')}`;
 }
 
+function extractHookCommand(value: Value | undefined): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const command = value.filter((argument): argument is string => typeof argument === 'string');
+  return command.length > 0 ? command : undefined;
+}
+
+function extractHookScript(value: Value | undefined): HookScriptDefinition | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+
+  const script = value as Record<string, Value>;
+  const path = script['path'];
+  const interpreter = script['interpreter'];
+  const args = script['args'];
+  if (typeof path !== 'string' || typeof interpreter !== 'string') return undefined;
+  return {
+    path,
+    interpreter: interpreter as PortableHookInterpreter,
+    args: Array.isArray(args)
+      ? args.filter((argument): argument is string => typeof argument === 'string')
+      : [],
+  };
+}
+
 /**
  * Extract hook definitions from a parsed @hooks block.
  */
@@ -256,30 +281,11 @@ export function extractHooks(hooksBlock: {
       event: event as PortableHookEvent,
     };
 
-    const command = obj['command'];
-    if (Array.isArray(command)) {
-      const args = command.filter((c): c is string => typeof c === 'string');
-      // Ignore command arrays that filter to nothing - they would emit a bare
-      // ownership marker with no executable command. PS034 already rejects them.
-      if (args.length > 0) hook.command = args;
-    }
+    const command = extractHookCommand(obj['command']);
+    if (command) hook.command = command;
 
-    const script = obj['script'];
-    if (typeof script === 'object' && script !== null && !Array.isArray(script)) {
-      const scriptObject = script as Record<string, Value>;
-      const path = scriptObject['path'];
-      const interpreter = scriptObject['interpreter'];
-      const args = scriptObject['args'];
-      if (typeof path === 'string' && typeof interpreter === 'string') {
-        hook.script = {
-          path,
-          interpreter: interpreter as PortableHookInterpreter,
-          args: Array.isArray(args)
-            ? args.filter((arg): arg is string => typeof arg === 'string')
-            : [],
-        };
-      }
-    }
+    const script = extractHookScript(obj['script']);
+    if (script) hook.script = script;
 
     if (!hook.command && !hook.script) continue;
 
@@ -312,6 +318,10 @@ export function extractHooks(hooksBlock: {
           targetOverride.event = override['event'] as PortableHookEvent;
         }
         if (typeof override['matcher'] === 'string') targetOverride.matcher = override['matcher'];
+        const targetCommand = extractHookCommand(override['command']);
+        if (targetCommand) targetOverride.command = targetCommand;
+        const targetScript = extractHookScript(override['script']);
+        if (targetScript) targetOverride.script = targetScript;
         if (typeof override['timeoutMs'] === 'number') {
           targetOverride.timeoutMs = override['timeoutMs'];
         }
@@ -341,8 +351,27 @@ export function applyHookTargetOverrides(
   return hooks.map((hook) => {
     const override = hook.targets?.[target];
     if (!override) return hook;
-    return { ...hook, ...override, targets: hook.targets };
+    const merged = { ...hook, ...override, targets: hook.targets };
+    if (override.command) delete merged.script;
+    if (override.script) delete merged.command;
+    return merged;
   });
+}
+
+export function getEnabledHookScriptResources(hook: HookDefinition): HookScriptDefinition[] {
+  const resources = new Map<string, HookScriptDefinition>();
+  const addScript = (candidate: HookDefinition): void => {
+    if (candidate.enabled !== false && candidate.script) {
+      resources.set(candidate.script.path, candidate.script);
+    }
+  };
+
+  addScript(hook);
+  for (const target of Object.keys(hook.targets ?? {}) as HookTarget[]) {
+    const effectiveHook = applyHookTargetOverrides([hook], target)[0];
+    if (effectiveHook) addScript(effectiveHook);
+  }
+  return [...resources.values()];
 }
 
 /**

--- a/packages/formatters/src/index.ts
+++ b/packages/formatters/src/index.ts
@@ -142,6 +142,7 @@ export {
   generateVSCodeHooks,
   generateGrokHooks,
   applyHookTargetOverrides,
+  getEnabledHookScriptResources,
   generateWindsurfHooks,
   getHookCompatibilityWarnings,
   mapEvent,

--- a/packages/validator/src/__tests__/rules/valid-hooks.spec.ts
+++ b/packages/validator/src/__tests__/rules/valid-hooks.spec.ts
@@ -617,14 +617,83 @@ describe('PS034: valid-hooks', () => {
           event: 'pre-tool-use',
           command: ['prs', 'hook'],
           targets: {
-            factory: { matcher: 'Execute' },
-            vscode: { matcher: 'run_in_terminal', timeoutMs: 15000 },
+            factory: {
+              matcher: 'Execute',
+              command: ['node', 'factory hook.mjs', '--strict mode'],
+            },
+            vscode: {
+              matcher: 'run_in_terminal',
+              timeoutMs: 15000,
+              script: {
+                path: '.promptscript/scripts/vscode.py',
+                interpreter: 'python3',
+                args: ['--strict mode'],
+              },
+            },
           },
         },
       })
     );
 
     expect(messages).toHaveLength(0);
+  });
+
+  it('should reject invalid target executable overrides', () => {
+    const messages = validate(
+      makeAst({
+        check: {
+          event: 'pre-tool-use',
+          command: ['node', 'base.mjs'],
+          targets: {
+            factory: {
+              command: ['node', 'factory.mjs'],
+              script: {
+                path: '.promptscript/scripts/factory.mjs',
+                interpreter: 'node',
+              },
+            },
+            vscode: { command: [] },
+            github: { command: ['node', '$(unsafe)'] },
+            gemini: { command: [' '] },
+            windsurf: { command: 'node hook.mjs' as unknown as Value },
+            grok: { script: 'python3 hook.py' as unknown as Value },
+            claude: {
+              script: {
+                path: '../unsafe.py',
+                interpreter: 'python3',
+              },
+            },
+            cursor: {
+              script: {
+                path: '.promptscript/scripts/cursor.py',
+                interpreter: 'custom-runtime',
+              },
+            },
+            codex: {
+              script: {
+                path: '.promptscript/scripts/codex.py',
+                interpreter: 'python3',
+                args: [1],
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(messages.map((message) => message.message)).toEqual(
+      expect.arrayContaining([
+        'Hook "check": target override "factory" command and script are mutually exclusive',
+        'Hook "check": target override "vscode": command must not be empty',
+        'Hook "check": target override "github": shell interpolation is forbidden in command arguments',
+        'Hook "check": target override "gemini": command executable must not be empty',
+        'Hook "check": target override "windsurf": command must be an array',
+        'Hook "check": target override "grok" script must be an object',
+        'Hook "check": target override "claude": script path must be a safe file under ".promptscript/scripts/"',
+        'Hook "check": target override "cursor": script interpreter is required and must be portable',
+        'Hook "check": target override "codex": script args must be an array of strings',
+      ])
+    );
   });
 
   it('should reject unknown target override fields and targets', () => {

--- a/packages/validator/src/rules/valid-hooks.ts
+++ b/packages/validator/src/rules/valid-hooks.ts
@@ -37,6 +37,8 @@ const HOOK_FIELDS = new Set([
 const SCRIPT_FIELDS = new Set(['path', 'interpreter', 'args']);
 const TARGET_OVERRIDE_FIELDS = new Set([
   'event',
+  'command',
+  'script',
   'matcher',
   'timeoutMs',
   'statusMessage',
@@ -150,45 +152,7 @@ export const validHooks: ValidationRule = {
           severity: 'error',
         });
       } else if (command !== undefined) {
-        if (!Array.isArray(command)) {
-          ctx.report({
-            message: `Hook "${hookId}": command must be an array`,
-            location: hooksBlock.loc,
-            severity: 'error',
-          });
-        } else if (command.length === 0) {
-          ctx.report({
-            message: `Hook "${hookId}": command must not be empty`,
-            location: hooksBlock.loc,
-            severity: 'error',
-          });
-        } else {
-          if (typeof command[0] === 'string' && command[0].trim().length === 0) {
-            ctx.report({
-              message: `Hook "${hookId}": command executable must not be empty`,
-              location: hooksBlock.loc,
-              severity: 'error',
-            });
-          }
-          for (const arg of command) {
-            if (typeof arg !== 'string') {
-              ctx.report({
-                message: `Hook "${hookId}": command arguments must be strings`,
-                location: hooksBlock.loc,
-                severity: 'error',
-              });
-              break;
-            }
-            if (arg.includes('$(') || arg.includes('`') || arg.includes('${')) {
-              ctx.report({
-                message: `Hook "${hookId}": shell interpolation is forbidden in command arguments`,
-                location: hooksBlock.loc,
-                suggestion: 'Use explicit argument passing instead of shell interpolation',
-                severity: 'error',
-              });
-            }
-          }
-        }
+        validateCommand(hookId, command, hooksBlock.loc, ctx.report);
       } else if (typeof script !== 'object' || script === null || Array.isArray(script)) {
         ctx.report({
           message: `Hook "${hookId}": script must be an object`,
@@ -332,6 +296,28 @@ function validateTargetOverrides(
       }
     }
 
+    const command = override['command'];
+    const script = override['script'];
+    if (command !== undefined && script !== undefined) {
+      report({
+        message: `Hook "${hookId}": target override "${target}" command and script are mutually exclusive`,
+        location,
+        severity: 'error',
+      });
+    } else if (command !== undefined) {
+      validateCommand(hookId, command, location, report, target);
+    } else if (script !== undefined) {
+      if (typeof script !== 'object' || script === null || Array.isArray(script)) {
+        report({
+          message: `Hook "${hookId}": target override "${target}" script must be an object`,
+          location,
+          severity: 'error',
+        });
+      } else {
+        validateScript(hookId, script as Record<string, Value>, location, report, target);
+      }
+    }
+
     const event = override['event'];
     if (event !== undefined && (typeof event !== 'string' || !VALID_HOOK_EVENTS.has(event))) {
       report({
@@ -409,16 +395,69 @@ function validateTargetOverrides(
   }
 }
 
+function validateCommand(
+  hookId: string,
+  command: Value,
+  location: SourceLocation,
+  report: RuleContext['report'],
+  target?: string
+): void {
+  const subject = target ? `Hook "${hookId}": target override "${target}"` : `Hook "${hookId}"`;
+  if (!Array.isArray(command)) {
+    report({
+      message: `${subject}: command must be an array`,
+      location,
+      severity: 'error',
+    });
+    return;
+  }
+  if (command.length === 0) {
+    report({
+      message: `${subject}: command must not be empty`,
+      location,
+      severity: 'error',
+    });
+    return;
+  }
+  if (typeof command[0] === 'string' && command[0].trim().length === 0) {
+    report({
+      message: `${subject}: command executable must not be empty`,
+      location,
+      severity: 'error',
+    });
+  }
+  for (const argument of command) {
+    if (typeof argument !== 'string') {
+      report({
+        message: `${subject}: command arguments must be strings`,
+        location,
+        severity: 'error',
+      });
+      break;
+    }
+    if (argument.includes('$(') || argument.includes('`') || argument.includes('${')) {
+      report({
+        message: `${subject}: shell interpolation is forbidden in command arguments`,
+        location,
+        suggestion: 'Use explicit argument passing instead of shell interpolation',
+        severity: 'error',
+      });
+    }
+  }
+}
+
 function validateScript(
   hookId: string,
   script: Record<string, Value>,
   location: SourceLocation,
-  report: RuleContext['report']
+  report: RuleContext['report'],
+  target?: string
 ): void {
+  const subject = target ? `Hook "${hookId}": target override "${target}"` : `Hook "${hookId}"`;
   for (const field of Object.keys(script)) {
     if (!SCRIPT_FIELDS.has(field)) {
       report({
-        message: `Hook "${hookId}": unknown script field "${field}"`,
+        message: `${subject}: unknown script field "${field}"`,
         location,
         severity: 'error',
       });
@@ -428,7 +467,7 @@ function validateScript(
   const path = script['path'];
   if (typeof path !== 'string' || !isPortableHookScriptPath(path)) {
     report({
-      message: `Hook "${hookId}": script path must be a safe file under ".promptscript/scripts/"`,
+      message: `${subject}: script path must be a safe file under ".promptscript/scripts/"`,
       location,
       severity: 'error',
     });
@@ -437,7 +476,7 @@ function validateScript(
   const interpreter = script['interpreter'];
   if (typeof interpreter !== 'string' || !isPortableHookInterpreter(interpreter)) {
     report({
-      message: `Hook "${hookId}": script interpreter is required and must be portable`,
+      message: `${subject}: script interpreter is required and must be portable`,
       location,
       suggestion:
         'Use python3, python, node, deno, bun, ruby, php, perl, bash, sh, zsh, pwsh, or powershell',
@@ -448,7 +487,7 @@ function validateScript(
   const args = script['args'];
   if (args !== undefined && (!Array.isArray(args) || args.some((arg) => typeof arg !== 'string'))) {
     report({
-      message: `Hook "${hookId}": script args must be an array of strings`,
+      message: `${subject}: script args must be an array of strings`,
       location,
       severity: 'error',
     });


### PR DESCRIPTION
## Summary
- allow hook target overrides to replace the base executable with `command` or `script`
- inherit the base executable when a target does not define one, and omit disabled targets
- validate target commands, scripts, and enabled script resources in Node and browser compilers
- preserve Unix and PowerShell argument boundaries plus ownership markers
- document the target override contract and add focused native-output coverage

## Validation
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:validate:check`
- `pnpm docs:build`

Closes #343
