### PR TITLE
feat(cli): migrate legacy Factory hooks

### DIFF
--- a/.claude/skills/promptscript/SKILL.md
+++ b/.claude/skills/promptscript/SKILL.md
@@ -547,6 +547,11 @@ fully owned generated hook file and prunes directories left empty. `prs hooks in
 migrates unambiguous legacy hooks from `.factory/settings.json`; ambiguous
 entries remain for manual review.
 
+Factory compilation performs the same migration when `.factory/hooks.json` is
+absent. Use `prs compile --dry-run` to preview the changes or
+`--no-migrate-factory-hooks` to keep warning-only behavior. Unknown events,
+malformed entries, and mixed ownership abort without a partial migration.
+
 `@hooks` compilation is separate from `prs hooks install`. The latter installs
 auto-compilation and generated-output protection for supported AI tools. Copilot VS
 Code Agent hooks use `promptscript-vscode.json`; GitHub Copilot repository hooks use

--- a/.promptscript/skills/promptscript/SKILL.md
+++ b/.promptscript/skills/promptscript/SKILL.md
@@ -547,6 +547,11 @@ fully owned generated hook file and prunes directories left empty. `prs hooks in
 migrates unambiguous legacy hooks from `.factory/settings.json`; ambiguous
 entries remain for manual review.
 
+Factory compilation performs the same migration when `.factory/hooks.json` is
+absent. Use `prs compile --dry-run` to preview the changes or
+`--no-migrate-factory-hooks` to keep warning-only behavior. Unknown events,
+malformed entries, and mixed ownership abort without a partial migration.
+
 `@hooks` compilation is separate from `prs hooks install`. The latter installs
 auto-compilation and generated-output protection for supported AI tools. Copilot VS
 Code Agent hooks use `promptscript-vscode.json`; GitHub Copilot repository hooks use

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -405,7 +405,10 @@ This CLI feature is separate from the language-level `@hooks` block.
 For Copilot, `.github/hooks/promptscript-vscode.json` configures VS Code Agent
 Hooks; it is not the GitHub repository hook file generated from `@hooks`.
 Factory CLI installation uses `.factory/hooks.json` and migrates unambiguous
-legacy entries from `.factory/settings.json`.
+legacy entries from `.factory/settings.json`. Factory compilation performs the
+same migration when the canonical file is absent. Use `prs compile --dry-run`
+to preview the change or `--no-migrate-factory-hooks` to retain warning-only
+behavior.
 
 ## Commands and Workflows
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -17,9 +17,10 @@ contract, not the GitHub repository hook contract.
 Notes for compiled `@hooks` output:
 
 - **Legacy Factory settings** - before 1.16, `@hooks` could land in `.factory/settings.json`.
-  `prs compile` warns (`PS4002`) when `.factory/hooks.json` is absent and that file still
-  contains a non-PromptScript-owned `hooks` key, because only then does the stale section
-  reactivate via Factory's fallback to `settings.json`.
+  When `.factory/hooks.json` is absent, `prs compile` moves unambiguous hooks to the canonical
+  file and preserves unrelated settings. Migration is all-or-nothing for unknown events,
+  malformed entries, and mixed ownership. Use `--dry-run` to preview both file changes, or
+  `--no-migrate-factory-hooks` to retain warning-only `PS4002` behavior.
 - **Matcher portability** - `matcher` filters by target-native tool names (Factory `Execute`,
   GitHub Copilot tool names, Claude `Edit|Write`). A matcher that works on one target may match
   nothing on another. See [@hooks](../reference/language.md#hooks).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -229,30 +229,38 @@ prs compile [options]
 
 **Options:**
 
-| Option                  | Description                                             |
-| ----------------------- | ------------------------------------------------------- |
-| `-b, --build <name>`    | Compile a named build profile from config               |
-| `--all-builds`          | Compile all named build profiles in deterministic order |
-| `-t, --target <target>` | Compile to specific target                              |
-| `-f, --format <format>` | Output format (alias for `--target`)                    |
-| `-a, --all`             | Compile to all configured targets                       |
-| `-w, --watch`           | Watch mode for continuous compilation                   |
-| `-o, --output <dir>`    | Override output directory                               |
-| `--dry-run`             | Preview changes without writing                         |
-| `--registry <path>`     | Override the configured registry path                   |
-| `-c, --config <path>`   | Path to config file                                     |
-| `--force`               | Force overwrite existing files without prompts          |
-| `--strict`              | Treat output path conflicts as errors                   |
-| `--ignore-hashes`       | Skip reference integrity hash verification              |
-| `--cwd <dir>`           | Set the project working directory                       |
-| `--verbose`             | Show detailed compilation progress                      |
-| `--debug`               | Show debug information (includes verbose)               |
+| Option                       | Description                                             |
+| ---------------------------- | ------------------------------------------------------- |
+| `-b, --build <name>`         | Compile a named build profile from config               |
+| `--all-builds`               | Compile all named build profiles in deterministic order |
+| `-t, --target <target>`      | Compile to specific target                              |
+| `-f, --format <format>`      | Output format (alias for `--target`)                    |
+| `-a, --all`                  | Compile to all configured targets                       |
+| `-w, --watch`                | Watch mode for continuous compilation                   |
+| `-o, --output <dir>`         | Override output directory                               |
+| `--dry-run`                  | Preview changes without writing                         |
+| `--no-migrate-factory-hooks` | Warn instead of migrating legacy Factory settings hooks |
+| `--registry <path>`          | Override the configured registry path                   |
+| `-c, --config <path>`        | Path to config file                                     |
+| `--force`                    | Force overwrite existing files without prompts          |
+| `--strict`                   | Treat output path conflicts as errors                   |
+| `--ignore-hashes`            | Skip reference integrity hash verification              |
+| `--cwd <dir>`                | Set the project working directory                       |
+| `--verbose`                  | Show detailed compilation progress                      |
+| `--debug`                    | Show debug information (includes verbose)               |
 
 `--all-builds` and `--build` are mutually exclusive. `--all-builds` compiles every named profile in `config.builds` in sorted key order, reports failures per profile, and uses one watcher for the full build set when combined with `--watch`.
 
 Paths passed through `--config`, `--registry`, and `--output` are resolved relative to `--cwd` (or the current project directory). Watch mode honors the configured `watch.include`, `watch.exclude`, `watch.debounce`, and `watch.clearScreen` settings. Added, changed, and removed matching files all trigger compilation, and rebuilds are serialized.
 
 The `output.overwrite` setting provides the configuration equivalent of `--force`. A configured `output.header` is added to generated Markdown after PromptScript metadata (and after YAML frontmatter when present) so generated-file detection and frontmatter remain valid.
+
+When compiling the Factory target and `.factory/hooks.json` is absent,
+`prs compile` migrates unambiguous hooks from `.factory/settings.json` before
+writing generated output. `--dry-run` reports the planned canonical and legacy
+file changes without writing. `--no-migrate-factory-hooks` keeps the legacy
+file unchanged and reports `PS4002` instead. Unknown events, malformed entries,
+and mixed ownership abort migration without a partial write.
 
 **Examples:**
 

--- a/docs/reference/cli/hooks.md
+++ b/docs/reference/cli/hooks.md
@@ -88,6 +88,12 @@ legacy `.factory/settings.json` `hooks` section. Unrelated settings are
 preserved. The command refuses partial migrations when it finds unknown event
 names or ambiguous entries, so those entries can be reviewed manually.
 
+The Factory compile target performs the same migration automatically when
+`.factory/hooks.json` does not exist. Use `prs compile --dry-run` to preview it
+or `prs compile --no-migrate-factory-hooks` to keep warning-only behavior.
+`prs hooks install factory` remains available for explicit installation and
+migration.
+
 ---
 
 ### uninstall

--- a/docs/reference/formatters/factory.md
+++ b/docs/reference/formatters/factory.md
@@ -92,11 +92,13 @@ description: PromptScript output format for Factory AI
 - Split rules require the `multifile` or `full` output version
 
 PromptScript versions before 1.16 could place language-level hooks in
-`.factory/settings.json`. `prs hooks install factory` copies unambiguous legacy
-entries into `.factory/hooks.json`, preserves unrelated settings, and refuses
-partial migrations when event names or entries are ambiguous. `prs compile`
-reports a `PS4002` warning while the fallback file still contains a
-non-PromptScript-owned `hooks` key and `.factory/hooks.json` is absent.
+`.factory/settings.json`. When `.factory/hooks.json` is absent, `prs compile`
+moves unambiguous legacy entries into the canonical file, preserves unrelated
+settings, and refuses partial migrations when event names, handlers, or
+ownership are ambiguous. `--dry-run` previews the migration, while
+`--no-migrate-factory-hooks` leaves the fallback unchanged and reports
+`PS4002`. `prs hooks install factory` remains available for explicit migration
+and hook installation.
 
 ## Split Rules
 

--- a/packages/cli/skills/promptscript/SKILL.md
+++ b/packages/cli/skills/promptscript/SKILL.md
@@ -547,6 +547,11 @@ fully owned generated hook file and prunes directories left empty. `prs hooks in
 migrates unambiguous legacy hooks from `.factory/settings.json`; ambiguous
 entries remain for manual review.
 
+Factory compilation performs the same migration when `.factory/hooks.json` is
+absent. Use `prs compile --dry-run` to preview the changes or
+`--no-migrate-factory-hooks` to keep warning-only behavior. Unknown events,
+malformed entries, and mixed ownership abort without a partial migration.
+
 `@hooks` compilation is separate from `prs hooks install`. The latter installs
 auto-compilation and generated-output protection for supported AI tools. Copilot VS
 Code Agent hooks use `promptscript-vscode.json`; GitHub Copilot repository hooks use

--- a/packages/cli/src/__tests__/compile-factory-migration.integration.spec.ts
+++ b/packages/cli/src/__tests__/compile-factory-migration.integration.spec.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { compileCommand } from '../commands/compile.js';
+
+const directories: string[] = [];
+
+async function createProject(settingsContent: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'promptscript-factory-migration-'));
+  directories.push(directory);
+  await mkdir(join(directory, '.promptscript'), { recursive: true });
+  await mkdir(join(directory, '.factory'), { recursive: true });
+  await writeFile(
+    join(directory, 'promptscript.yaml'),
+    `version: '1'
+project:
+  id: factory-migration
+targets:
+  - factory:
+      version: full
+`
+  );
+  await writeFile(
+    join(directory, '.promptscript', 'project.prs'),
+    `@meta {
+  id: "factory-migration"
+  syntax: "1.4.0"
+}
+
+@identity {
+  name: "Factory migration"
+}
+
+@hooks {
+  check: {
+    event: "pre-tool-use"
+    command: ["node", "check.mjs"]
+  }
+}
+`
+  );
+  await writeFile(join(directory, '.factory', 'settings.json'), settingsContent);
+  return directory;
+}
+
+function legacySettings(): Record<string, unknown> {
+  return {
+    permissions: { allow: ['Read'] },
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: 'Execute',
+          hooks: [{ type: 'command', command: 'audit' }],
+        },
+        {
+          hooks: [
+            {
+              type: 'command',
+              command: 'node check.mjs # promptscript-generated:check',
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe('compile Factory hook migration', () => {
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    for (const directory of directories.splice(0)) {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates user hooks, preserves settings, deduplicates owned hooks, and reruns safely', async () => {
+    const directory = await createProject(JSON.stringify(legacySettings(), null, 2));
+
+    await compileCommand({ cwd: directory });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(
+      JSON.parse(await readFile(join(directory, '.factory', 'settings.json'), 'utf-8'))
+    ).toEqual({
+      permissions: { allow: ['Read'] },
+    });
+    const firstCanonical = await readFile(join(directory, '.factory', 'hooks.json'), 'utf-8');
+    const parsed = JSON.parse(firstCanonical) as {
+      hooks: { PreToolUse: Array<{ hooks: Array<{ command: string }> }> };
+    };
+    expect(
+      parsed.hooks.PreToolUse.flatMap((entry) => entry.hooks).filter(
+        (handler) => handler.command === 'audit'
+      )
+    ).toHaveLength(1);
+    expect(
+      parsed.hooks.PreToolUse.flatMap((entry) => entry.hooks).filter((handler) =>
+        handler.command.endsWith('# promptscript-generated:check')
+      )
+    ).toHaveLength(1);
+
+    await compileCommand({ cwd: directory });
+
+    const secondCanonical = JSON.parse(
+      await readFile(join(directory, '.factory', 'hooks.json'), 'utf-8')
+    ) as typeof parsed;
+    expect(
+      secondCanonical.hooks.PreToolUse.flatMap((entry) => entry.hooks).filter(
+        (handler) => handler.command === 'audit'
+      )
+    ).toHaveLength(1);
+  });
+
+  it('does not partially write when a legacy event is ambiguous', async () => {
+    const settings = {
+      hooks: {
+        UnknownEvent: [{ hooks: [{ type: 'command', command: 'audit' }] }],
+      },
+    };
+    const content = JSON.stringify(settings, null, 2);
+    const directory = await createProject(content);
+
+    await compileCommand({ cwd: directory });
+
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(directory, '.factory', 'hooks.json'))).toBe(false);
+    expect(await readFile(join(directory, '.factory', 'settings.json'), 'utf-8')).toBe(content);
+  });
+
+  it('does not partially write malformed legacy settings', async () => {
+    const directory = await createProject('{');
+
+    await compileCommand({ cwd: directory });
+
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(directory, '.factory', 'hooks.json'))).toBe(false);
+    expect(await readFile(join(directory, '.factory', 'settings.json'), 'utf-8')).toBe('{');
+  });
+
+  it('keeps warning-only behavior when migration is disabled', async () => {
+    const content = JSON.stringify(legacySettings(), null, 2);
+    const directory = await createProject(content);
+
+    await compileCommand({ cwd: directory, migrateFactoryHooks: false });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(await readFile(join(directory, '.factory', 'settings.json'), 'utf-8')).toBe(content);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -110,6 +110,10 @@ program
   .option('-w, --watch', 'Watch mode')
   .option('-o, --output <dir>', 'Output directory')
   .option('--dry-run', 'Preview changes')
+  .option(
+    '--no-migrate-factory-hooks',
+    'Warn instead of migrating legacy .factory/settings.json hooks'
+  )
   .option('--registry <path>', 'Registry path (overrides config)')
   .option('-c, --config <path>', 'Path to custom config file')
   .option('--force', 'Force overwrite existing files without prompts')
@@ -126,6 +130,10 @@ program
   .option('-w, --watch', 'Watch mode')
   .option('-o, --output <dir>', 'Output directory')
   .option('--dry-run', 'Preview changes')
+  .option(
+    '--no-migrate-factory-hooks',
+    'Warn instead of migrating legacy .factory/settings.json hooks'
+  )
   .option('--registry <path>', 'Registry path (overrides config)')
   .option('-c, --config <path>', 'Path to custom config file')
   .option('--force', 'Force overwrite existing files without prompts')

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -26,6 +26,7 @@ const {
   mockCleanupManagedOutputs,
   mockRewriteHookOutputIfUnchanged,
   mockRemoveHookOutputIfUnchanged,
+  mockIsTTY,
   mockSpinner,
   mockSpinnerStart,
   mockWatch,
@@ -46,6 +47,7 @@ const {
   const mockCleanupManagedOutputs = vi.fn();
   const mockRewriteHookOutputIfUnchanged = vi.fn();
   const mockRemoveHookOutputIfUnchanged = vi.fn();
+  const mockIsTTY = vi.fn();
   const mockSpinnerStart = vi.fn();
   const mockWatch = vi.fn();
   const mockWatcherOn = vi.fn();
@@ -73,6 +75,7 @@ const {
     mockCleanupManagedOutputs,
     mockRewriteHookOutputIfUnchanged,
     mockRemoveHookOutputIfUnchanged,
+    mockIsTTY,
     mockSpinner,
     mockSpinnerStart,
     mockWatch,
@@ -133,6 +136,7 @@ vi.mock('../../output/console.js', () => ({
     stats: vi.fn(),
     dryRun: mockDryRun,
     warn: mockWarn,
+    skipped: vi.fn(),
   },
   isVerbose: vi.fn().mockReturnValue(false),
   isDebug: vi.fn().mockReturnValue(false),
@@ -154,7 +158,7 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('../../output/pager.js', () => ({
-  isTTY: vi.fn().mockReturnValue(false),
+  isTTY: (...args: unknown[]) => mockIsTTY(...args),
 }));
 
 vi.mock('chokidar', () => ({
@@ -219,6 +223,7 @@ describe('compile command - createCliLogger warn path', () => {
     mockCleanupManagedOutputs.mockResolvedValue({ removed: [], removedDirectories: [] });
     mockRewriteHookOutputIfUnchanged.mockResolvedValue(true);
     mockRemoveHookOutputIfUnchanged.mockResolvedValue(true);
+    mockIsTTY.mockReturnValue(false);
 
     mockCompile.mockResolvedValue({
       success: true,
@@ -496,6 +501,53 @@ describe('compile command - createCliLogger warn path', () => {
 
     expect(mockRemoveHookOutputIfUnchanged).not.toHaveBeenCalled();
     expect(mockError).toHaveBeenCalledWith(expect.stringContaining('partial migration'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should cancel migration when a concurrent canonical file is skipped', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    const legacyContent = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            hooks: [{ type: 'command', command: 'audit' }],
+          },
+        ],
+      },
+    });
+    let hooksReads = 0;
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/hooks.json')) {
+        hooksReads++;
+        if (hooksReads === 1) {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        }
+        return '{"hooks":{}}';
+      }
+      if (String(path).endsWith('.factory/settings.json')) return legacyContent;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    mockExistsSync.mockImplementation((path: string) => {
+      const value = String(path);
+      return (
+        value.includes('project.prs') ||
+        value.endsWith('promptscript.yaml') ||
+        value.endsWith('.factory/hooks.json')
+      );
+    });
+    mockIsTTY.mockReturnValue(true);
+    vi.mocked(mockServices.prompts.select).mockResolvedValue('no');
+
+    await compileCommand({ cwd: '/mock/project' }, mockServices);
+
+    expect(mockRewriteHookOutputIfUnchanged).not.toHaveBeenCalled();
+    expect(mockCleanupManagedOutputs).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('migration was cancelled before')
+    );
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -24,6 +24,8 @@ const {
   mockMuted,
   mockDryRun,
   mockCleanupManagedOutputs,
+  mockRewriteHookOutputIfUnchanged,
+  mockRemoveHookOutputIfUnchanged,
   mockSpinner,
   mockSpinnerStart,
   mockWatch,
@@ -42,6 +44,8 @@ const {
   const mockMuted = vi.fn();
   const mockDryRun = vi.fn();
   const mockCleanupManagedOutputs = vi.fn();
+  const mockRewriteHookOutputIfUnchanged = vi.fn();
+  const mockRemoveHookOutputIfUnchanged = vi.fn();
   const mockSpinnerStart = vi.fn();
   const mockWatch = vi.fn();
   const mockWatcherOn = vi.fn();
@@ -67,6 +71,8 @@ const {
     mockMuted,
     mockDryRun,
     mockCleanupManagedOutputs,
+    mockRewriteHookOutputIfUnchanged,
+    mockRemoveHookOutputIfUnchanged,
     mockSpinner,
     mockSpinnerStart,
     mockWatch,
@@ -116,6 +122,7 @@ vi.mock('../../output/console.js', () => ({
   createSpinner: vi.fn().mockReturnValue(mockSpinner),
   ConsoleOutput: {
     success: vi.fn(),
+    unchanged: vi.fn(),
     error: mockError,
     muted: mockMuted,
     newline: vi.fn(),
@@ -168,7 +175,8 @@ vi.mock('../../utils/managed-output-cleanup.js', async (importOriginal) => {
     mergePromptScriptCodexConfig: vi.fn().mockReturnValue(undefined),
     mergePromptScriptHookOutput: vi.fn().mockReturnValue(undefined),
     removePromptScriptOwnedCodexHooks: vi.fn().mockReturnValue(undefined),
-    rewriteHookOutputIfUnchanged: vi.fn().mockResolvedValue(true),
+    rewriteHookOutputIfUnchanged: (...args: unknown[]) => mockRewriteHookOutputIfUnchanged(...args),
+    removeHookOutputIfUnchanged: (...args: unknown[]) => mockRemoveHookOutputIfUnchanged(...args),
     createHookOutputSafely: vi.fn(async (path: string, _root: string, content: string) => {
       await mockWriteFile(path, content, 'utf-8');
       return true;
@@ -209,6 +217,8 @@ describe('compile command - createCliLogger warn path', () => {
     mockMkdir.mockResolvedValue(undefined);
     mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
     mockCleanupManagedOutputs.mockResolvedValue({ removed: [], removedDirectories: [] });
+    mockRewriteHookOutputIfUnchanged.mockResolvedValue(true);
+    mockRemoveHookOutputIfUnchanged.mockResolvedValue(true);
 
     mockCompile.mockResolvedValue({
       success: true,
@@ -349,7 +359,261 @@ describe('compile command - createCliLogger warn path', () => {
     );
   });
 
-  it('should warn about legacy hooks in .factory/settings.json for factory targets', async () => {
+  it('should migrate legacy Factory hooks into generated canonical output', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    const legacyContent = JSON.stringify({
+      permissions: { allow: ['Read'] },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Execute',
+            hooks: [{ type: 'command', command: 'audit' }],
+          },
+        ],
+      },
+    });
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/settings.json')) return legacyContent;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    mockCompile.mockResolvedValue({
+      success: true,
+      outputs: new Map([
+        [
+          '.factory/hooks.json',
+          {
+            path: '.factory/hooks.json',
+            content: JSON.stringify({
+              hooks: {
+                PreToolUse: [
+                  {
+                    hooks: [
+                      {
+                        type: 'command',
+                        command: 'node check.mjs # promptscript-generated:check',
+                      },
+                    ],
+                  },
+                ],
+              },
+            }),
+          },
+        ],
+      ]),
+      stats: { totalTime: 10, resolveTime: 5, validateTime: 3, formatTime: 2 },
+      warnings: [],
+      errors: [],
+    });
+
+    await compileCommand({ cwd: '/mock/project' }, mockServices);
+
+    const canonicalWrite = mockWriteFile.mock.calls.find(([path]) =>
+      String(path).endsWith('.factory/hooks.json')
+    );
+    const canonical = JSON.parse(String(canonicalWrite?.[1])) as {
+      hooks: { PreToolUse: unknown[] };
+    };
+    expect(canonical.hooks.PreToolUse).toHaveLength(2);
+    expect(mockRewriteHookOutputIfUnchanged).toHaveBeenCalledWith(
+      '/mock/project/.factory/settings.json',
+      '/mock/project',
+      legacyContent,
+      JSON.stringify({ permissions: { allow: ['Read'] } }, null, 2) + '\n'
+    );
+    expect(mockWarning).not.toHaveBeenCalledWith(expect.stringContaining('PS4002'));
+  });
+
+  it('should roll back canonical hooks when legacy settings change before commit', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/settings.json')) {
+        return JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              {
+                hooks: [{ type: 'command', command: 'audit' }],
+              },
+            ],
+          },
+        });
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    mockRewriteHookOutputIfUnchanged.mockResolvedValue(false);
+
+    await compileCommand({ cwd: '/mock/project' }, mockServices);
+
+    expect(mockRemoveHookOutputIfUnchanged).toHaveBeenCalledWith(
+      '/mock/project/.factory/hooks.json',
+      '/mock/project',
+      expect.stringContaining('"command": "audit"')
+    );
+    expect(mockCleanupManagedOutputs).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('was rolled back'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should not delete a canonical file created concurrently', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    const entry = {
+      hooks: [{ type: 'command', command: 'audit' }],
+    };
+    const canonicalContent = JSON.stringify({ hooks: { PreToolUse: [entry] } }, null, 2) + '\n';
+    let hooksReads = 0;
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/hooks.json')) {
+        hooksReads++;
+        if (hooksReads === 1) {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        }
+        return canonicalContent;
+      }
+      if (String(path).endsWith('.factory/settings.json')) {
+        return JSON.stringify({ hooks: { PreToolUse: [entry] } });
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    mockExistsSync.mockImplementation((path: string) => {
+      const value = String(path);
+      return (
+        value.includes('project.prs') ||
+        value.endsWith('promptscript.yaml') ||
+        value.endsWith('.factory/hooks.json')
+      );
+    });
+    mockRewriteHookOutputIfUnchanged.mockResolvedValue(false);
+
+    await compileCommand({ cwd: '/mock/project' }, mockServices);
+
+    expect(mockRemoveHookOutputIfUnchanged).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('partial migration'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should restore legacy settings when canonical hooks change during commit', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    const legacyContent = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            hooks: [{ type: 'command', command: 'audit' }],
+          },
+        ],
+      },
+    });
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/settings.json')) return legacyContent;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    mockRewriteHookOutputIfUnchanged
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await compileCommand({ cwd: '/mock/project' }, mockServices);
+
+    expect(mockRewriteHookOutputIfUnchanged).toHaveBeenNthCalledWith(
+      3,
+      '/mock/project/.factory/settings.json',
+      '/mock/project',
+      '{}\n',
+      legacyContent
+    );
+    expect(mockCleanupManagedOutputs).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('legacy settings were restored')
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should preview legacy Factory migration without writing', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/settings.json')) {
+        return JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              {
+                hooks: [{ type: 'command', command: 'audit' }],
+              },
+            ],
+          },
+        });
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    await compileCommand({ cwd: '/mock/project', dryRun: true }, mockServices);
+
+    expect(mockDryRun).toHaveBeenCalledWith(
+      expect.stringContaining('Would migrate 1 legacy Factory hook(s)')
+    );
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockRewriteHookOutputIfUnchanged).not.toHaveBeenCalled();
+  });
+
+  it('should abort before writing when legacy Factory hooks are ambiguous', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/settings.json')) {
+        return JSON.stringify({
+          hooks: {
+            unknownEvent: [{ hooks: [{ type: 'command', command: 'audit' }] }],
+          },
+        });
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    await compileCommand({ cwd: '/mock/project' }, mockServices);
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockCleanupManagedOutputs).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot migrate legacy Factory hooks safely')
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should abort before writing when legacy Factory settings are malformed', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['factory'],
+      registry: { path: './registry' },
+    });
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('.factory/settings.json')) return '{';
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    await compileCommand({ cwd: '/mock/project' }, mockServices);
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockCleanupManagedOutputs).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse Factory hooks file')
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should warn about installed legacy hooks when compile migration is disabled', async () => {
     // Arrange
     mockLoadConfig.mockResolvedValue({
       targets: ['factory'],
@@ -357,13 +621,13 @@ describe('compile command - createCliLogger warn path', () => {
     });
     mockReadFile.mockImplementation(async (path: string) => {
       if (String(path).endsWith('.factory/settings.json')) {
-        return '{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"old-cmd"}]}]}}';
+        return '{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"prs hook pre-edit"}]}]}}';
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
 
     // Act
-    await compileCommand({ cwd: '/mock/project' }, mockServices);
+    await compileCommand({ cwd: '/mock/project', migrateFactoryHooks: false }, mockServices);
 
     // Assert
     expect(mockWarning).toHaveBeenCalledWith(expect.stringContaining('PS4002'));

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -34,10 +34,15 @@ import {
   isPromptScriptOwnedHookOutput,
   mergePromptScriptCodexConfig,
   mergePromptScriptHookOutput,
+  removeHookOutputIfUnchanged,
   removePromptScriptOwnedCodexHooks,
   rewriteHookOutputIfUnchanged,
 } from '../utils/managed-output-cleanup.js';
-import { detectLegacyFactorySettingsHooks } from '../utils/legacy-factory-hooks.js';
+import {
+  detectLegacyFactorySettingsHooks,
+  planLegacyFactoryHooksMigration,
+  type LegacyFactoryMigrationPlan,
+} from '../utils/legacy-factory-hooks.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -304,8 +309,96 @@ function resolveUniversalDir(
  */
 interface WriteResult {
   written: string[];
+  created: string[];
   skipped: string[];
   unchanged: string[];
+}
+
+async function prepareLegacyFactoryMigration(
+  outputs: Map<string, FormatterOutput>,
+  outputRoot: string
+): Promise<LegacyFactoryMigrationPlan | undefined> {
+  const factoryOutput = outputs.get('.factory/hooks.json');
+  const plan = await planLegacyFactoryHooksMigration(outputRoot, factoryOutput?.content);
+  if (!plan) return undefined;
+  if (plan.migration.ambiguous.length > 0) {
+    throw new Error(
+      `Cannot migrate legacy Factory hooks safely. Review these entries in ${plan.settingsPath}: ` +
+        plan.migration.ambiguous.join(', ')
+    );
+  }
+  if (!plan.migration.changed) return undefined;
+
+  const content = JSON.stringify(plan.migration.canonical, null, 2) + '\n';
+  if (factoryOutput) {
+    factoryOutput.content = content;
+  } else {
+    outputs.set('.factory/hooks.json', {
+      path: '.factory/hooks.json',
+      content,
+    });
+  }
+  return plan;
+}
+
+async function finishLegacyFactoryMigration(
+  plan: LegacyFactoryMigrationPlan,
+  outputRoot: string,
+  dryRun: boolean | undefined,
+  canonicalCreated: boolean
+): Promise<void> {
+  const action =
+    plan.migration.migrated > 0
+      ? `migrate ${plan.migration.migrated} legacy Factory hook(s)`
+      : 'remove legacy PromptScript-owned Factory hooks';
+  if (dryRun) {
+    ConsoleOutput.dryRun(`Would ${action} from ${plan.settingsPath} to ${plan.hooksPath}`);
+    return;
+  }
+
+  const content = JSON.stringify(plan.migration.legacy, null, 2) + '\n';
+  const rewritten = await rewriteHookOutputIfUnchanged(
+    plan.settingsPath,
+    outputRoot,
+    plan.expectedSettingsContent,
+    content
+  );
+  if (!rewritten) {
+    const canonicalContent = JSON.stringify(plan.migration.canonical, null, 2) + '\n';
+    const rolledBack =
+      canonicalCreated &&
+      (await removeHookOutputIfUnchanged(plan.hooksPath, outputRoot, canonicalContent));
+    throw new Error(
+      `Legacy Factory settings changed during compilation. ` +
+        (rolledBack
+          ? 'The canonical migration output was rolled back. '
+          : `Review ${plan.hooksPath} for a partial migration. `) +
+        `Review ${plan.settingsPath} and rerun.`
+    );
+  }
+  const canonicalContent = JSON.stringify(plan.migration.canonical, null, 2) + '\n';
+  const canonicalVerified = await rewriteHookOutputIfUnchanged(
+    plan.hooksPath,
+    outputRoot,
+    canonicalContent,
+    canonicalContent
+  );
+  if (!canonicalVerified) {
+    const settingsRestored = await rewriteHookOutputIfUnchanged(
+      plan.settingsPath,
+      outputRoot,
+      content,
+      plan.expectedSettingsContent
+    );
+    throw new Error(
+      `Canonical Factory hooks changed during migration. ` +
+        (settingsRestored
+          ? 'The legacy settings were restored. '
+          : `Review ${plan.settingsPath} for a partial migration. `) +
+        `Review ${plan.hooksPath} and rerun.`
+    );
+  }
+  ConsoleOutput.success(`${action[0]!.toUpperCase()}${action.slice(1)}`);
 }
 
 /**
@@ -330,7 +423,7 @@ async function writeOutputs(
   _config: PromptScriptConfig,
   services: CliServices
 ): Promise<WriteResult> {
-  const result: WriteResult = { written: [], skipped: [], unchanged: [] };
+  const result: WriteResult = { written: [], created: [], skipped: [], unchanged: [] };
   let overwriteAll = false;
   const conflicts: string[] = [];
   const targetErrors: string[] = [];
@@ -516,6 +609,7 @@ async function writeOutputs(
       if (await safeCreate(output, outputPath, desiredContent)) {
         ConsoleOutput.success(outputPath);
         result.written.push(outputPath);
+        result.created.push(outputPath);
       }
       continue;
     }
@@ -872,7 +966,30 @@ async function compileCommandWithResult(
     };
     applyConfiguredHeader(result.outputs, config.output?.header);
     await postFormatWithPrettier(result.outputs, projectRoot, logger);
+    const hasFactoryTarget = targets.some((target) => target.name === 'factory');
+    const migrateFactoryHooks = options.migrateFactoryHooks !== false;
+    const legacyMigration =
+      hasFactoryTarget && migrateFactoryHooks
+        ? await prepareLegacyFactoryMigration(result.outputs, effectiveOptions.output)
+        : undefined;
+    const legacySettingsPath =
+      hasFactoryTarget && !migrateFactoryHooks
+        ? await detectLegacyFactorySettingsHooks(effectiveOptions.output, true)
+        : undefined;
     const writeResult = await writeOutputs(result.outputs, effectiveOptions, config, services);
+    if (legacyMigration) {
+      if (writeResult.skipped.includes(legacyMigration.hooksPath)) {
+        throw new Error(
+          `Legacy Factory migration was cancelled before ${legacyMigration.hooksPath} was written.`
+        );
+      }
+      await finishLegacyFactoryMigration(
+        legacyMigration,
+        effectiveOptions.output,
+        options.dryRun,
+        writeResult.created.includes(legacyMigration.hooksPath)
+      );
+    }
     const cleanupResult = await cleanupManagedOutputs(result.outputs, {
       outputRoot: effectiveOptions.output,
       dryRun: options.dryRun,
@@ -891,10 +1008,6 @@ async function compileCommandWithResult(
         ConsoleOutput.muted(`Removed empty managed directory: ${removedDirectory}`);
       }
     }
-    const legacySettingsPath = targets.some((target) => target.name === 'factory')
-      ? await detectLegacyFactorySettingsHooks(effectiveOptions.output)
-      : undefined;
-
     // Report success only after every output and cleanup step completed, so a
     // write-phase failure never follows a "Compilation successful" line.
     spinner.succeed('Compilation successful');

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -72,6 +72,8 @@ export interface CompileOptions {
   output?: string;
   /** Preview changes without writing files */
   dryRun?: boolean;
+  /** Migrate unambiguous legacy Factory settings hooks during compilation */
+  migrateFactoryHooks?: boolean;
   /** Registry path or URL (overrides config) */
   registry?: string;
   /** Path to custom config file */

--- a/packages/cli/src/utils/__tests__/legacy-factory-hooks.spec.ts
+++ b/packages/cli/src/utils/__tests__/legacy-factory-hooks.spec.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   detectLegacyFactorySettingsHooks,
   migrateLegacyFactoryHooks,
+  planLegacyFactoryHooksMigration,
 } from '../legacy-factory-hooks.js';
 
 describe('migrateLegacyFactoryHooks', () => {
@@ -26,6 +27,7 @@ describe('migrateLegacyFactoryHooks', () => {
           preToolUse: [
             {
               matcher: 'Execute',
+              commandRegex: '^git ',
               hooks: [{ type: 'command', command: 'audit' }],
             },
           ],
@@ -41,7 +43,11 @@ describe('migrateLegacyFactoryHooks', () => {
       hooks: {
         PreToolUse: [
           { matcher: 'Read', hooks: [] },
-          { matcher: 'Execute', hooks: [{ type: 'command', command: 'audit' }] },
+          {
+            matcher: 'Execute',
+            commandRegex: '^git ',
+            hooks: [{ type: 'command', command: 'audit' }],
+          },
         ],
       },
     });
@@ -145,6 +151,43 @@ describe('migrateLegacyFactoryHooks', () => {
     expect(result.canonical).toEqual({ hooks: {} });
   });
 
+  it('preserves installed hooks when compile migration requests it', () => {
+    const installed = {
+      hooks: [{ type: 'command', command: 'prs hook pre-edit' }],
+    };
+    const result = migrateLegacyFactoryHooks(
+      { hooks: { PreToolUse: [installed] } },
+      {},
+      { preserveInstalledHooks: true, rejectMixedOwnership: true }
+    );
+
+    expect(result.ambiguous).toEqual([]);
+    expect(result.legacy).toEqual({});
+    expect(result.canonical).toEqual({ hooks: { PreToolUse: [installed] } });
+  });
+
+  it('rejects mixed ownership for compile migration', () => {
+    const result = migrateLegacyFactoryHooks(
+      {
+        hooks: {
+          PreToolUse: [
+            {
+              hooks: [
+                { type: 'command', command: 'prs hook pre-edit' },
+                { type: 'command', command: 'audit' },
+              ],
+            },
+          ],
+        },
+      },
+      {},
+      { preserveInstalledHooks: true, rejectMixedOwnership: true }
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.ambiguous).toEqual(['hooks.PreToolUse[0]']);
+  });
+
   it.each([
     [{ hooks: 'not-an-object' }, {}, ['hooks']],
     [{ hooks: {} }, { hooks: [] }, ['canonical.hooks']],
@@ -235,6 +278,57 @@ describe('migrateLegacyFactoryHooks', () => {
     expect(result.changed).toBe(false);
     expect(result.ambiguous).toEqual(['hooks.PreToolUse[0]']);
   });
+
+  it.each([
+    { type: 'prompt', command: 'audit' },
+    { type: 'command', command: 'audit', metadata: true },
+    { type: 'command', command: '' },
+    { type: 'command', command: 'audit', timeout: 'fast' },
+    { type: 'command', command: 'audit', statusMessage: 42 },
+  ])('refuses malformed command handlers: %j', (handler) => {
+    const result = migrateLegacyFactoryHooks({ hooks: { PreToolUse: [{ hooks: [handler] }] } }, {});
+
+    expect(result.changed).toBe(false);
+    expect(result.ambiguous).toEqual(['hooks.PreToolUse[0]']);
+  });
+
+  it('refuses a non-string matcher', () => {
+    const result = migrateLegacyFactoryHooks(
+      {
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 42,
+              hooks: [{ type: 'command', command: 'audit' }],
+            },
+          ],
+        },
+      },
+      {}
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.ambiguous).toEqual(['hooks.PreToolUse[0]']);
+  });
+
+  it('refuses a non-string command regex', () => {
+    const result = migrateLegacyFactoryHooks(
+      {
+        hooks: {
+          PreToolUse: [
+            {
+              commandRegex: 42,
+              hooks: [{ type: 'command', command: 'audit' }],
+            },
+          ],
+        },
+      },
+      {}
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.ambiguous).toEqual(['hooks.PreToolUse[0]']);
+  });
 });
 
 describe('detectLegacyFactorySettingsHooks', () => {
@@ -267,9 +361,109 @@ describe('detectLegacyFactorySettingsHooks', () => {
         })
       );
       await expect(detectLegacyFactorySettingsHooks(root)).resolves.toBeUndefined();
+      await expect(detectLegacyFactorySettingsHooks(root, true)).resolves.toBe(settingsPath);
+
+      await writeFile(
+        settingsPath,
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              {
+                hooks: [
+                  { type: 'command', command: 'prs hook pre-edit' },
+                  { type: 'command', command: 'audit' },
+                ],
+              },
+            ],
+          },
+        })
+      );
+      await expect(detectLegacyFactorySettingsHooks(root)).resolves.toBe(settingsPath);
 
       await writeFile(hooksPath, '{}');
       await expect(detectLegacyFactorySettingsHooks(root)).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('planLegacyFactoryHooksMigration', () => {
+  it('merges legacy hooks with generated canonical hooks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'promptscript-legacy-plan-'));
+    const settingsPath = join(root, '.factory', 'settings.json');
+    await mkdir(join(root, '.factory'), { recursive: true });
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        permissions: { allow: ['Read'] },
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Execute',
+              hooks: [{ type: 'command', command: 'audit' }],
+            },
+          ],
+        },
+      })
+    );
+
+    try {
+      const plan = await planLegacyFactoryHooksMigration(
+        root,
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: 'node check.mjs # promptscript-generated:check',
+                  },
+                ],
+              },
+            ],
+          },
+        })
+      );
+
+      expect(plan?.migration).toMatchObject({
+        migrated: 1,
+        ambiguous: [],
+        legacy: { permissions: { allow: ['Read'] } },
+      });
+      const hooks = plan?.migration.canonical['hooks'] as Record<string, unknown[]>;
+      expect(hooks['PreToolUse']).toHaveLength(2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not plan migration when canonical hooks already exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'promptscript-legacy-plan-'));
+    await mkdir(join(root, '.factory'), { recursive: true });
+    await writeFile(
+      join(root, '.factory', 'settings.json'),
+      JSON.stringify({ hooks: { PreToolUse: [] } })
+    );
+    await writeFile(join(root, '.factory', 'hooks.json'), '{}');
+
+    try {
+      await expect(planLegacyFactoryHooksMigration(root)).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects malformed legacy settings JSON', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'promptscript-legacy-plan-'));
+    await mkdir(join(root, '.factory'), { recursive: true });
+    await writeFile(join(root, '.factory', 'settings.json'), '{');
+
+    try {
+      await expect(planLegacyFactoryHooksMigration(root)).rejects.toThrow(
+        'Failed to parse Factory hooks file'
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/cli/src/utils/__tests__/legacy-factory-hooks.spec.ts
+++ b/packages/cli/src/utils/__tests__/legacy-factory-hooks.spec.ts
@@ -166,6 +166,19 @@ describe('migrateLegacyFactoryHooks', () => {
     expect(result.canonical).toEqual({ hooks: { PreToolUse: [installed] } });
   });
 
+  it('preserves direct installed command entries for compile migration', () => {
+    const installed = { type: 'command', command: 'prs hook pre-edit' };
+    const result = migrateLegacyFactoryHooks(
+      { hooks: { PreToolUse: [installed] } },
+      {},
+      { preserveInstalledHooks: true, rejectMixedOwnership: true }
+    );
+
+    expect(result.ambiguous).toEqual([]);
+    expect(result.legacy).toEqual({});
+    expect(result.canonical).toEqual({ hooks: { PreToolUse: [installed] } });
+  });
+
   it('rejects mixed ownership for compile migration', () => {
     const result = migrateLegacyFactoryHooks(
       {
@@ -464,6 +477,19 @@ describe('planLegacyFactoryHooksMigration', () => {
       await expect(planLegacyFactoryHooksMigration(root)).rejects.toThrow(
         'Failed to parse Factory hooks file'
       );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates legacy settings read failures', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'promptscript-legacy-plan-'));
+    await mkdir(join(root, '.factory', 'settings.json'), { recursive: true });
+
+    try {
+      await expect(planLegacyFactoryHooksMigration(root)).rejects.toMatchObject({
+        code: expect.not.stringMatching(/^ENOENT$/),
+      });
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/cli/src/utils/__tests__/managed-output-cleanup.spec.ts
+++ b/packages/cli/src/utils/__tests__/managed-output-cleanup.spec.ts
@@ -13,6 +13,7 @@ import {
   mergePromptScriptHookOutput,
   removePromptScriptOwnedCodexHooks,
   removePromptScriptOwnedHooks,
+  removeHookOutputIfUnchanged,
   removeIfUnchanged,
   rewriteHookOutputIfUnchanged,
 } from '../managed-output-cleanup.js';
@@ -537,6 +538,9 @@ command = "echo owned # promptscript-generated:owned"
     await expect(
       rewriteHookOutputIfUnchanged(join(project, '.claude', 'settings.json'), project, 'old', 'new')
     ).resolves.toBe(false);
+    await expect(
+      removeHookOutputIfUnchanged(join(project, '.claude', 'settings.json'), project, 'old')
+    ).resolves.toBe(false);
     await expect(readFile(file, 'utf-8')).resolves.toBe('old');
   });
 
@@ -561,6 +565,18 @@ command = "echo owned # promptscript-generated:owned"
     ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('should remove a hook output only when its content is unchanged', async () => {
+    const project = await createTemporaryDirectory('promptscript-remove-hook-output-');
+    const file = join(project, '.factory', 'hooks.json');
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, 'expected');
+
+    await expect(removeHookOutputIfUnchanged(file, project, 'different')).resolves.toBe(false);
+    await expect(readFile(file, 'utf-8')).resolves.toBe('expected');
+    await expect(removeHookOutputIfUnchanged(file, project, 'expected')).resolves.toBe(true);
+    await expect(readFile(file, 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('should return false when guarded child processes cannot start', async () => {
     const project = await createTemporaryDirectory('promptscript-hook-child-');
     const file = join(project, 'settings.json');
@@ -575,6 +591,7 @@ command = "echo owned # promptscript-generated:owned"
       await expect(
         createHookOutputSafely(join(project, 'nested', 'hooks.json'), project, 'new')
       ).resolves.toBe(false);
+      await expect(removeHookOutputIfUnchanged(file, project, 'old')).resolves.toBe(false);
     } finally {
       process.execPath = originalExecPath;
     }
@@ -589,6 +606,7 @@ command = "echo owned # promptscript-generated:owned"
     await expect(rewriteHookOutputIfUnchanged(outsideFile, project, 'old', 'new')).resolves.toBe(
       false
     );
+    await expect(removeHookOutputIfUnchanged(outsideFile, project, 'old')).resolves.toBe(false);
     await expect(createHookOutputSafely(join(outside, 'new.json'), project, 'new')).resolves.toBe(
       false
     );

--- a/packages/cli/src/utils/__tests__/managed-output-cleanup.spec.ts
+++ b/packages/cli/src/utils/__tests__/managed-output-cleanup.spec.ts
@@ -597,6 +597,19 @@ command = "echo owned # promptscript-generated:owned"
     }
   });
 
+  it('should handle closed child stdin for rejected large writes', async () => {
+    const project = await createTemporaryDirectory('promptscript-hook-stdin-');
+    const file = join(project, 'settings.json');
+    const content = 'x'.repeat(4 * 1024 * 1024);
+    await writeFile(file, 'old');
+
+    await expect(rewriteHookOutputIfUnchanged(file, project, 'different', content)).resolves.toBe(
+      false
+    );
+    await expect(createHookOutputSafely(file, project, content)).resolves.toBe(false);
+    await expect(readFile(file, 'utf-8')).resolves.toBe('old');
+  });
+
   it('should reject hook rewrites and creations outside the output root', async () => {
     const project = await createTemporaryDirectory('promptscript-hook-root-');
     const outside = await createTemporaryDirectory('promptscript-hook-outside-');

--- a/packages/cli/src/utils/legacy-factory-hooks.ts
+++ b/packages/cli/src/utils/legacy-factory-hooks.ts
@@ -381,36 +381,20 @@ function isCommandObject(value: unknown): boolean {
 
 function isGeneratedCommandObject(value: unknown): boolean {
   const object = getObject(value);
-  if (!object) return false;
-  if (typeof object['command'] === 'string') {
-    return (
-      isCommandObject(object) &&
-      /# promptscript-generated:[A-Za-z0-9._-]+\s*$/.test(object['command'])
-    );
-  }
-  const handlers = object['hooks'];
   return (
-    Array.isArray(handlers) &&
-    handlers.length > 0 &&
-    handlers.every((handler) => isGeneratedCommandObject(handler))
+    typeof object?.['command'] === 'string' &&
+    isCommandObject(object) &&
+    /# promptscript-generated:[A-Za-z0-9._-]+\s*$/.test(object['command'])
   );
 }
 
 function isInstalledCommandObject(value: unknown): boolean {
   const object = getObject(value);
-  if (!object) return false;
-  if (typeof object['command'] === 'string') {
-    return (
-      isCommandObject(object) &&
-      !isGeneratedCommandObject(object) &&
-      isPromptScriptHookCommand(object['command'])
-    );
-  }
-  const handlers = object['hooks'];
   return (
-    Array.isArray(handlers) &&
-    handlers.length > 0 &&
-    handlers.every((handler) => isInstalledCommandObject(handler))
+    typeof object?.['command'] === 'string' &&
+    isCommandObject(object) &&
+    !isGeneratedCommandObject(object) &&
+    isPromptScriptHookCommand(object['command'])
   );
 }
 

--- a/packages/cli/src/utils/legacy-factory-hooks.ts
+++ b/packages/cli/src/utils/legacy-factory-hooks.ts
@@ -10,6 +10,18 @@ export interface LegacyFactoryMigrationResult {
   changed: boolean;
 }
 
+export interface LegacyFactoryMigrationOptions {
+  preserveInstalledHooks?: boolean;
+  rejectMixedOwnership?: boolean;
+}
+
+export interface LegacyFactoryMigrationPlan {
+  settingsPath: string;
+  hooksPath: string;
+  expectedSettingsContent: string;
+  migration: LegacyFactoryMigrationResult;
+}
+
 const LEGACY_EVENT_NAMES: Readonly<Record<string, string>> = {
   PreToolUse: 'PreToolUse',
   preToolUse: 'PreToolUse',
@@ -27,7 +39,7 @@ const LEGACY_EVENT_NAMES: Readonly<Record<string, string>> = {
   Stop: 'Stop',
   stop: 'Stop',
 };
-const LEGACY_ENTRY_FIELDS = new Set(['matcher', 'hooks']);
+const LEGACY_ENTRY_FIELDS = new Set(['matcher', 'commandRegex', 'hooks']);
 const LEGACY_HANDLER_FIELDS = new Set(['type', 'command', 'timeout', 'statusMessage']);
 
 /**
@@ -45,7 +57,8 @@ const LEGACY_HANDLER_FIELDS = new Set(['type', 'command', 'timeout', 'statusMess
  * actually take effect), or undefined when there is nothing to migrate.
  */
 export async function detectLegacyFactorySettingsHooks(
-  outputRoot: string
+  outputRoot: string,
+  includeOwned = false
 ): Promise<string | undefined> {
   const hooksPath = resolve(outputRoot, '.factory', 'hooks.json');
   try {
@@ -78,7 +91,10 @@ export async function detectLegacyFactorySettingsHooks(
   if (!Object.prototype.hasOwnProperty.call(parsed, 'hooks')) {
     return undefined;
   }
-  if (hasOnlyOwnedLegacyFactoryHooks((parsed as Record<string, unknown>)['hooks'])) {
+  if (
+    !includeOwned &&
+    hasOnlyOwnedLegacyFactoryHooks((parsed as Record<string, unknown>)['hooks'])
+  ) {
     return undefined;
   }
 
@@ -128,7 +144,8 @@ function hasOnlyOwnedLegacyFactoryHooks(value: unknown): boolean {
  */
 export function migrateLegacyFactoryHooks(
   legacy: Record<string, unknown>,
-  canonical: Record<string, unknown>
+  canonical: Record<string, unknown>,
+  options: LegacyFactoryMigrationOptions = {}
 ): LegacyFactoryMigrationResult {
   const legacyHooksValue = legacy['hooks'];
   if (legacyHooksValue === undefined) {
@@ -183,7 +200,7 @@ export function migrateLegacyFactoryHooks(
     }
 
     for (const [index, entry] of entries.entries()) {
-      const migration = splitLegacyEntry(entry);
+      const migration = splitLegacyEntry(entry, options);
       if (migration.ambiguous) {
         ambiguous.push(`hooks.${eventName}[${index}]`);
         continue;
@@ -228,26 +245,95 @@ export function migrateLegacyFactoryHooks(
   };
 }
 
-function splitLegacyEntry(entry: unknown): { userEntry?: unknown; ambiguous: boolean } {
+export async function planLegacyFactoryHooksMigration(
+  outputRoot: string,
+  generatedCanonicalContent?: string
+): Promise<LegacyFactoryMigrationPlan | undefined> {
+  const hooksPath = resolve(outputRoot, '.factory', 'hooks.json');
+  try {
+    await readFile(hooksPath, 'utf-8');
+    return undefined;
+  } catch (error) {
+    if (!isFileNotFound(error)) throw error;
+  }
+
+  const settingsPath = resolve(outputRoot, '.factory', 'settings.json');
+  let expectedSettingsContent: string;
+  try {
+    expectedSettingsContent = await readFile(settingsPath, 'utf-8');
+  } catch (error) {
+    if (isFileNotFound(error)) return undefined;
+    throw error;
+  }
+
+  const legacy = parseJsonObject(expectedSettingsContent, settingsPath);
+  if (!Object.prototype.hasOwnProperty.call(legacy, 'hooks')) return undefined;
+  const canonical =
+    generatedCanonicalContent === undefined
+      ? {}
+      : parseJsonObject(generatedCanonicalContent, 'generated .factory/hooks.json');
+  const migration = migrateLegacyFactoryHooks(legacy, canonical, {
+    preserveInstalledHooks: true,
+    rejectMixedOwnership: true,
+  });
+  return {
+    settingsPath,
+    hooksPath,
+    expectedSettingsContent,
+    migration,
+  };
+}
+
+function splitLegacyEntry(
+  entry: unknown,
+  options: LegacyFactoryMigrationOptions
+): { userEntry?: unknown; ambiguous: boolean } {
   const object = getObject(entry);
   if (!object) return { ambiguous: true };
 
   const handlers = object['hooks'];
   if (!Array.isArray(handlers)) {
-    return isOwnedCommandObject(object) ? { ambiguous: false } : { ambiguous: true };
+    if (isGeneratedCommandObject(object)) return { ambiguous: false };
+    if (options.preserveInstalledHooks && isInstalledCommandObject(object)) {
+      return { userEntry: object, ambiguous: false };
+    }
+    return isInstalledCommandObject(object) ? { ambiguous: false } : { ambiguous: true };
   }
   if (!hasOnlyFields(object, LEGACY_ENTRY_FIELDS)) return { ambiguous: true };
+  if (object['matcher'] !== undefined && typeof object['matcher'] !== 'string') {
+    return { ambiguous: true };
+  }
+  if (object['commandRegex'] !== undefined && typeof object['commandRegex'] !== 'string') {
+    return { ambiguous: true };
+  }
   if (handlers.length === 0) return { ambiguous: true };
 
-  const userHandlers = handlers.filter((handler) => !isOwnedCommandObject(handler));
-  const hasAmbiguousHandler = handlers.some(
-    (handler) => !isOwnedCommandObject(handler) && !isCommandObject(handler)
+  const generatedHandlers = handlers.filter(isGeneratedCommandObject);
+  const installedHandlers = handlers.filter(isInstalledCommandObject);
+  const userHandlers = handlers.filter(
+    (handler) =>
+      !isGeneratedCommandObject(handler) &&
+      !isInstalledCommandObject(handler) &&
+      isCommandObject(handler)
   );
+  const hasAmbiguousHandler = handlers.some((handler) => !isCommandObject(handler));
   if (hasAmbiguousHandler) return { ambiguous: true };
-  if (userHandlers.length === 0) return { ambiguous: false };
+  if (
+    options.rejectMixedOwnership &&
+    ((generatedHandlers.length > 0 && installedHandlers.length + userHandlers.length > 0) ||
+      (installedHandlers.length > 0 && userHandlers.length > 0))
+  ) {
+    return { ambiguous: true };
+  }
+  const migratedHandlers = handlers.filter(
+    (handler) =>
+      userHandlers.includes(handler) ||
+      (options.preserveInstalledHooks && installedHandlers.includes(handler))
+  );
+  if (migratedHandlers.length === 0) return { ambiguous: false };
 
   return {
-    userEntry: { ...object, hooks: userHandlers },
+    userEntry: { ...object, hooks: migratedHandlers },
     ambiguous: false,
   };
 }
@@ -277,18 +363,46 @@ function stableSerialize(value: unknown): string {
 
 function isCommandObject(value: unknown): boolean {
   const object = getObject(value);
-  return object !== undefined && typeof object['command'] === 'string';
+  if (
+    !object ||
+    object['type'] !== 'command' ||
+    typeof object['command'] !== 'string' ||
+    object['command'].trim().length === 0 ||
+    !hasOnlyFields(object, LEGACY_HANDLER_FIELDS)
+  ) {
+    return false;
+  }
+  const timeout = object['timeout'];
+  if (timeout !== undefined && (typeof timeout !== 'number' || !Number.isFinite(timeout))) {
+    return false;
+  }
+  return object['statusMessage'] === undefined || typeof object['statusMessage'] === 'string';
 }
 
-function isOwnedCommandObject(value: unknown): boolean {
+function isGeneratedCommandObject(value: unknown): boolean {
   const object = getObject(value);
   if (!object) return false;
   if (typeof object['command'] === 'string') {
-    if (object['type'] !== 'command' || !hasOnlyFields(object, LEGACY_HANDLER_FIELDS)) {
-      return false;
-    }
     return (
-      /# promptscript-generated:[A-Za-z0-9._-]+\s*$/.test(object['command']) ||
+      isCommandObject(object) &&
+      /# promptscript-generated:[A-Za-z0-9._-]+\s*$/.test(object['command'])
+    );
+  }
+  const handlers = object['hooks'];
+  return (
+    Array.isArray(handlers) &&
+    handlers.length > 0 &&
+    handlers.every((handler) => isGeneratedCommandObject(handler))
+  );
+}
+
+function isInstalledCommandObject(value: unknown): boolean {
+  const object = getObject(value);
+  if (!object) return false;
+  if (typeof object['command'] === 'string') {
+    return (
+      isCommandObject(object) &&
+      !isGeneratedCommandObject(object) &&
       isPromptScriptHookCommand(object['command'])
     );
   }
@@ -296,7 +410,28 @@ function isOwnedCommandObject(value: unknown): boolean {
   return (
     Array.isArray(handlers) &&
     handlers.length > 0 &&
-    handlers.every((handler) => isOwnedCommandObject(handler))
+    handlers.every((handler) => isInstalledCommandObject(handler))
+  );
+}
+
+function parseJsonObject(content: string, path: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    const object = getObject(parsed);
+    if (!object) throw new Error('expected a JSON object');
+    return object;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse Factory hooks file ${path}: ${message}`, { cause: error });
+  }
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    String(error.code) === 'ENOENT'
   );
 }
 

--- a/packages/cli/src/utils/managed-output-cleanup.ts
+++ b/packages/cli/src/utils/managed-output-cleanup.ts
@@ -38,8 +38,10 @@ const OWNED_COMMAND_FIELDS = new Set([
   'working_directory',
 ]);
 const GUARDED_UNLINK_SCRIPT = String.raw`
+const crypto = require('node:crypto');
 const fs = require('node:fs');
-const [name, directoryDev, directoryIno, fileDev, fileIno] = process.argv.slice(1);
+const [name, directoryDev, directoryIno, fileDev, fileIno, expectedHash] =
+  process.argv.slice(1);
 const skip = () => process.stdout.write('skipped');
 if (!name || name === '.' || name === '..' || name.includes('/') || name.includes('\\')) {
   skip();
@@ -68,6 +70,14 @@ if (
 ) {
   skip();
   process.exit(0);
+}
+if (expectedHash) {
+  const current = fs.readFileSync(name);
+  const currentHash = crypto.createHash('sha256').update(current).digest('hex');
+  if (currentHash !== expectedHash) {
+    skip();
+    process.exit(0);
+  }
 }
 fs.unlinkSync(name);
 process.stdout.write('removed');
@@ -547,6 +557,31 @@ export async function createHookOutputSafely(
   }
 }
 
+export async function removeHookOutputIfUnchanged(
+  file: string,
+  outputRoot: string,
+  expectedContent: string
+): Promise<boolean> {
+  const root = resolve(outputRoot);
+  const candidate = resolve(file);
+  if (!isWithin(root, candidate)) return false;
+
+  const fileStat = await safeLstat(candidate);
+  if (!fileStat?.isFile() || fileStat.isSymbolicLink()) return false;
+  const guards = await openAncestorDirectories(root, candidate);
+  if (!guards) return false;
+  try {
+    if (!(await directoryGuardsMatch(guards))) return false;
+    const directory = dirname(candidate);
+    const directoryStat = await safeLstat(directory);
+    if (!directoryStat?.isDirectory() || directoryStat.isSymbolicLink()) return false;
+
+    return guardedUnlink(directory, basename(candidate), directoryStat, fileStat, expectedContent);
+  } finally {
+    await closeDirectoryGuards(guards);
+  }
+}
+
 async function guardedRewrite(
   directory: string,
   name: string,
@@ -588,6 +623,9 @@ async function guardedRewrite(
     child.on('close', (code) => {
       resolveResult(code === 0 && stdout === 'rewritten');
     });
+    child.stdin.on('error', () => {
+      resolveResult(false);
+    });
     child.stdin.end(content);
   });
 }
@@ -627,6 +665,9 @@ async function guardedCreate(
     });
     child.on('close', (code) => {
       resolveResult(code === 0 && stdout === 'created');
+    });
+    child.stdin.on('error', () => {
+      resolveResult(false);
     });
     child.stdin.end(content);
   });
@@ -689,8 +730,13 @@ async function guardedUnlink(
   directory: string,
   name: string,
   directoryStat: FileIdentity,
-  fileStat: FileIdentity
+  fileStat: FileIdentity,
+  expectedContent?: string
 ): Promise<boolean> {
+  const expectedHash =
+    expectedContent === undefined
+      ? undefined
+      : createHash('sha256').update(expectedContent).digest('hex');
   try {
     const result = await execFileAsync(
       process.execPath,
@@ -703,6 +749,7 @@ async function guardedUnlink(
         String(directoryStat.ino),
         String(fileStat.dev),
         String(fileStat.ino),
+        ...(expectedHash === undefined ? [] : [expectedHash]),
       ],
       {
         cwd: directory,
@@ -716,6 +763,7 @@ async function guardedUnlink(
     // binaries or restricted spawn environments) fall back to an in-process
     // guarded unlink that re-verifies the file identity immediately before
     // removing it.
+    if (expectedContent !== undefined) return false;
     return removeIfUnchanged(resolve(directory, name), fileStat);
   }
 }

--- a/skills/promptscript/SKILL.md
+++ b/skills/promptscript/SKILL.md
@@ -547,6 +547,11 @@ fully owned generated hook file and prunes directories left empty. `prs hooks in
 migrates unambiguous legacy hooks from `.factory/settings.json`; ambiguous
 entries remain for manual review.
 
+Factory compilation performs the same migration when `.factory/hooks.json` is
+absent. Use `prs compile --dry-run` to preview the changes or
+`--no-migrate-factory-hooks` to keep warning-only behavior. Unknown events,
+malformed entries, and mixed ownership abort without a partial migration.
+
 `@hooks` compilation is separate from `prs hooks install`. The latter installs
 auto-compilation and generated-output protection for supported AI tools. Copilot VS
 Code Agent hooks use `promptscript-vscode.json`; GitHub Copilot repository hooks use


### PR DESCRIPTION
## Summary
- migrate unambiguous legacy Factory settings hooks during compilation when the canonical file is absent
- preserve user settings, installed hooks, argument order, and generated ownership without duplicates
- reject malformed, unknown, mixed-ownership, and ambiguous entries before writing
- guard both migration files against concurrent changes and roll back safely when a commit cannot complete
- support dry-run planning and `--no-migrate-factory-hooks` warning-only behavior
- retain `prs hooks install factory` compatibility and update CLI, formatter, automation, guide, and skill documentation

## Validation
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` (1546 tests)
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:validate:check`
- `pnpm docs:build`

Closes #344
