### PR TITLE
feat(formatters): add terminal command hook event

### DIFF
--- a/.claude/skills/promptscript/SKILL.md
+++ b/.claude/skills/promptscript/SKILL.md
@@ -496,15 +496,16 @@ Portable lifecycle hooks. Requires syntax `1.4.0`. Each hook needs exactly one o
 
 Portable events:
 
-| Event            | Meaning                  |
-| ---------------- | ------------------------ |
-| `pre-tool-use`   | Before a tool invocation |
-| `post-tool-use`  | After a tool invocation  |
-| `session-start`  | Agent session start      |
-| `setup`          | Session setup            |
-| `subagent-start` | Subagent start           |
-| `notification`   | Agent notification       |
-| `stop`           | Agent stop               |
+| Event                  | Meaning                   |
+| ---------------------- | ------------------------- |
+| `pre-terminal-command` | Before a terminal command |
+| `pre-tool-use`         | Before a tool invocation  |
+| `post-tool-use`        | After a tool invocation   |
+| `session-start`        | Agent session start       |
+| `setup`                | Session setup             |
+| `subagent-start`       | Subagent start            |
+| `notification`         | Agent notification        |
+| `stop`                 | Agent stop                |
 
 `command` is a non-empty string array. Shell interpolation (`$()`, backticks,
 `${...}`) is forbidden. `script` requires:
@@ -520,6 +521,12 @@ Portable events:
 paths relative to project root. Hook config file location does not set command cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
+
+`pre-terminal-command` supplies native defaults: Factory `Execute`, Claude and
+Codex `Bash`, Windsurf `pre_run_command`, Cursor `run_terminal_cmd`, Gemini
+`run_shell_command`, and VS Code `run_in_terminal`. Override a native tool name
+with `targets.<name>.matcher`. Cursor, Gemini, and VS Code report best-effort
+`PS4002` warnings. GitHub and Grok omit the event with `PS4002`.
 
 Target overrides may change `event`, `matcher`, `timeoutMs`, `statusMessage`,
 `continueOnFailure`, `enabled`, or `cwd`. Native hook files are emitted only in

--- a/.promptscript/skills/promptscript/SKILL.md
+++ b/.promptscript/skills/promptscript/SKILL.md
@@ -496,15 +496,16 @@ Portable lifecycle hooks. Requires syntax `1.4.0`. Each hook needs exactly one o
 
 Portable events:
 
-| Event            | Meaning                  |
-| ---------------- | ------------------------ |
-| `pre-tool-use`   | Before a tool invocation |
-| `post-tool-use`  | After a tool invocation  |
-| `session-start`  | Agent session start      |
-| `setup`          | Session setup            |
-| `subagent-start` | Subagent start           |
-| `notification`   | Agent notification       |
-| `stop`           | Agent stop               |
+| Event                  | Meaning                   |
+| ---------------------- | ------------------------- |
+| `pre-terminal-command` | Before a terminal command |
+| `pre-tool-use`         | Before a tool invocation  |
+| `post-tool-use`        | After a tool invocation   |
+| `session-start`        | Agent session start       |
+| `setup`                | Session setup             |
+| `subagent-start`       | Subagent start            |
+| `notification`         | Agent notification        |
+| `stop`                 | Agent stop                |
 
 `command` is a non-empty string array. Shell interpolation (`$()`, backticks,
 `${...}`) is forbidden. `script` requires:
@@ -520,6 +521,12 @@ Portable events:
 paths relative to project root. Hook config file location does not set command cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
+
+`pre-terminal-command` supplies native defaults: Factory `Execute`, Claude and
+Codex `Bash`, Windsurf `pre_run_command`, Cursor `run_terminal_cmd`, Gemini
+`run_shell_command`, and VS Code `run_in_terminal`. Override a native tool name
+with `targets.<name>.matcher`. Cursor, Gemini, and VS Code report best-effort
+`PS4002` warnings. GitHub and Grok omit the event with `PS4002`.
 
 Target overrides may change `event`, `matcher`, `timeoutMs`, `statusMessage`,
 `continueOnFailure`, `enabled`, or `cwd`. Native hook files are emitted only in

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -44,16 +44,14 @@ differ on a host. A target can replace the executable with its own `command`:
 ```promptscript
 @hooks {
   terminal-policy: {
-    event: "pre-tool-use"
+    event: "pre-terminal-command"
     command: ["node", ".promptscript/scripts/check-terminal.mjs"]
-    matcher: "Bash"
     targets: {
       factory: {
-        matcher: "Execute"
         command: ["node", ".promptscript/scripts/check-factory.mjs", "--strict mode"]
       }
       vscode: {
-        matcher: "run_in_terminal"
+        matcher: "custom_terminal_tool"
       }
       github: {
         enabled: false
@@ -73,15 +71,16 @@ override emits no hook.
 
 ### Portable Events
 
-| Event            | Purpose                              |
-| ---------------- | ------------------------------------ |
-| `pre-tool-use`   | Run before a tool invocation         |
-| `post-tool-use`  | Run after a tool invocation          |
-| `session-start`  | Initialize an agent session          |
-| `setup`          | Run setup behavior at session start  |
-| `subagent-start` | Prepare delegated agent work         |
-| `notification`   | React to target notifications        |
-| `stop`           | Run final checks when an agent stops |
+| Event                  | Purpose                              |
+| ---------------------- | ------------------------------------ |
+| `pre-terminal-command` | Run before a terminal command        |
+| `pre-tool-use`         | Run before a tool invocation         |
+| `post-tool-use`        | Run after a tool invocation          |
+| `session-start`        | Initialize an agent session          |
+| `setup`                | Run setup behavior at session start  |
+| `subagent-start`       | Prepare delegated agent work         |
+| `notification`         | React to target notifications        |
+| `stop`                 | Run final checks when an agent stops |
 
 Formatters map portable event names to target-native hook systems. Eight
 built-in targets emit project-level lifecycle hooks, with a separate compatible
@@ -105,6 +104,11 @@ Claude, Cursor, and Grok support only `full`. `simple` mode reports `PS4002`
 when hooks are enabled because it cannot emit additional files. Target adapters
 also report `PS4002` when an event, matcher, `statusMessage`, or
 `continueOnFailure` value has no native equivalent.
+
+`pre-terminal-command` supplies deterministic native defaults instead of
+requiring one portable matcher to use several host vocabularies. A target
+override can replace the default through `matcher` when a host exposes a
+different terminal tool name.
 
 Every native adapter adds a trailing
 `# promptscript-generated:<hook-id>` shell comment to generated commands.
@@ -250,21 +254,21 @@ silently incomplete Windows command.
 ### Hook Capability Matrix
 
 All 48 built-in targets have an explicit lifecycle-hook classification. `All`
-means all seven portable events; `watch` means `prs compile --watch`.
+means all eight portable events; `watch` means `prs compile --watch`.
 
 | Target         | Status       | Config path                       | Portable events                                  | Command format                 | Timeout       | Project root               | Fallback                  |
 | -------------- | ------------ | --------------------------------- | ------------------------------------------------ | ------------------------------ | ------------- | -------------------------- | ------------------------- |
-| `github`       | Native       | `.github/hooks/promptscript.json` | All                                              | JSON with Bash and PowerShell  | seconds       | Native `cwd`               | Use `multifile` or `full` |
+| `github`       | Native       | `.github/hooks/promptscript.json` | All except terminal                              | JSON with Bash and PowerShell  | seconds       | Native `cwd`               | Use `multifile` or `full` |
 | `claude`       | Native       | `.claude/settings.json`           | All                                              | Nested command hooks           | seconds       | Environment                | Use `full`                |
-| `cursor`       | Native       | `.cursor/hooks.json`              | Pre/post tool, session/setup, subagent, stop     | Versioned JSON commands        | seconds       | Git root                   | Use `full`                |
+| `cursor`       | Native       | `.cursor/hooks.json`              | Terminal/tool, session/setup, subagent, stop     | Versioned JSON commands        | seconds       | Git root                   | Use `full`                |
 | `antigravity`  | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
-| `factory`      | Native       | `.factory/hooks.json`             | Pre/post tool, session/setup, notification, stop | Nested command hooks           | seconds       | Environment                | Use `multifile` or `full` |
+| `factory`      | Native       | `.factory/hooks.json`             | Terminal/tool, session/setup, notification, stop | Nested command hooks           | seconds       | Environment                | Use `multifile` or `full` |
 | `opencode`     | Plugin-only  | -                                 | -                                                | JavaScript/TypeScript plugin   | -             | -                          | Plugin or watch           |
-| `gemini`       | Native       | `.gemini/settings.json`           | Pre/post tool, session/setup, stop               | Nested command hooks           | milliseconds  | Environment                | Use `multifile` or `full` |
-| `windsurf`     | Native       | `.windsurf/hooks.json`            | Pre/post tool, stop                              | Unix and PowerShell entries    | -             | Native `working_directory` | Use `multifile` or `full` |
+| `gemini`       | Native       | `.gemini/settings.json`           | Terminal/tool, session/setup, stop               | Nested command hooks           | milliseconds  | Environment                | Use `multifile` or `full` |
+| `windsurf`     | Native       | `.windsurf/hooks.json`            | Terminal/tool, stop                              | Unix and PowerShell entries    | -             | Native `working_directory` | Use `multifile` or `full` |
 | `cline`        | Plugin-only  | -                                 | -                                                | SDK plugin                     | -             | -                          | Plugin or watch           |
 | `roo`          | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
-| `codex`        | Native       | `.codex/hooks.json`               | Pre/post tool, session/setup, subagent, stop     | JSON Unix and Windows commands | seconds       | Git root                   | Use `multifile` or `full` |
+| `codex`        | Native       | `.codex/hooks.json`               | Terminal/tool, session/setup, subagent, stop     | JSON Unix and Windows commands | seconds       | Git root                   | Use `multifile` or `full` |
 | `continue`     | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
 | `augment`      | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
 | `goose`        | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
@@ -297,7 +301,7 @@ means all seven portable events; `watch` means `prs compile --watch`.
 | `zed`          | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
 | `jules`        | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
 | `devin`        | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
-| `grok`         | Native       | `.grok/hooks/promptscript.json`   | All                                              | Nested command hooks           | seconds       | Environment                | Use `full`                |
+| `grok`         | Native       | `.grok/hooks/promptscript.json`   | All except terminal                              | Nested command hooks           | seconds       | Environment                | Use `full`                |
 | `kimi`         | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
 | `mimo`         | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
 | `deep-agents`  | Unsupported  | -                                 | -                                                | -                              | -             | -                          | watch                     |
@@ -311,22 +315,33 @@ the target-specific fallback. PromptScript never silently omits an enabled
 
 ### Terminal command semantics
 
-`pre-tool-use` is not a universal terminal interception guarantee. Use the
-target override syntax and native tool name when terminal coverage matters:
+Use `pre-terminal-command` when the hook intends to observe terminal commands.
+PromptScript selects a deterministic native matcher or event and reports
+`PS4002` whenever the host contract is best effort or unsupported:
 
-| Host                     | Terminal coverage                | Native tool or event                           |
-| ------------------------ | -------------------------------- | ---------------------------------------------- |
-| Claude Code              | Guaranteed                       | `Bash`                                         |
-| Factory Droid            | Guaranteed                       | `Execute`                                      |
-| Codex                    | Guaranteed                       | `Bash`                                         |
-| Windsurf                 | Guaranteed                       | `pre_run_command` / `post_run_command`         |
-| VS Code Agent            | Best effort                      | `run_in_terminal`, filtered inside the command |
-| GitHub Copilot CLI/cloud | Not guaranteed across both hosts | Tool coverage differs                          |
+| Host                     | Terminal coverage               | Native tool or event                           |
+| ------------------------ | ------------------------------- | ---------------------------------------------- |
+| Claude Code              | Guaranteed                      | `Bash`                                         |
+| Factory Droid            | Guaranteed                      | `Execute`                                      |
+| Codex                    | Guaranteed                      | `Bash`                                         |
+| Windsurf                 | Guaranteed                      | `pre_run_command`                              |
+| Cursor                   | Best effort (`PS4002`)          | `run_terminal_cmd`                             |
+| Gemini CLI               | Best effort (`PS4002`)          | `run_shell_command`                            |
+| VS Code Agent            | Best effort (`PS4002`)          | `run_in_terminal`, filtered inside the command |
+| GitHub Copilot CLI/cloud | Unsupported (`PS4002`, omitted) | Tool coverage differs                          |
+| Grok Build               | Unsupported (`PS4002`, omitted) | No audited terminal contract                   |
+
+Claude, Factory, Codex, Cursor, Gemini, and VS Code map the event to their
+pre-tool event with the matcher shown above. Windsurf emits only
+`pre_run_command`, not all pre-tool events. A target override can set `matcher`
+to a different native tool name. VS Code retains `run_in_terminal` for
+readability, but the host currently ignores matcher values, so the command
+must inspect `tool_name` and `tool_input`.
 
 If a host does not guarantee the desired terminal path, use `prs compile
---watch` for regeneration or filter the hook payload inside a script. A hook
-that matches file edits is not equivalent to a hook that observes every
-terminal command.
+--watch` for regeneration or filter the hook payload inside a script. A
+`pre-tool-use` hook with a broad matcher does not claim universal terminal
+coverage.
 
 Contract references:
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -24,6 +24,11 @@ Notes for compiled `@hooks` output:
 - **Matcher portability** - `matcher` filters by target-native tool names (Factory `Execute`,
   GitHub Copilot tool names, Claude `Edit|Write`). A matcher that works on one target may match
   nothing on another. See [@hooks](../reference/language.md#hooks).
+- **Terminal commands** - use `pre-terminal-command` instead of a broad
+  `pre-tool-use` matcher. PromptScript supplies audited native tool defaults,
+  allows `targets.<name>.matcher` overrides, and reports `PS4002` for
+  best-effort or unsupported host coverage. See
+  [Terminal command semantics](../features/automation.md#terminal-command-semantics).
 - **Cleanup** - removing `@hooks` deletes the obsolete generated hook file once every command in
   it carries the PromptScript ownership marker, and prunes managed directories left empty (such as
   `.github/hooks/`).

--- a/docs/reference/formatters/factory.md
+++ b/docs/reference/formatters/factory.md
@@ -82,6 +82,7 @@ description: PromptScript output format for Factory AI
 - Skills go to `.factory/skills/<name>/SKILL.md`
 - Agents are called "droids" - output to `.factory/droids/<name>.md`
 - `@hooks` uses `.factory/hooks.json` with PascalCase event names in `multifile` and `full` modes
+- `pre-terminal-command` maps to `PreToolUse` with the deterministic `Execute` matcher unless `targets.factory.matcher` overrides it
 - Hook `matcher` values match Factory tool names (for example `Execute`, `Read`, `Edit|Write`); other targets use different tool-name vocabularies, so a matcher that works here may match nothing elsewhere
 - `.factory/settings.json` remains a Factory fallback; `prs hooks install factory` migrates its unambiguous hooks
 - When `@hooks` is removed or no longer emits, the CLI removes a fully PromptScript-owned `.factory/hooks.json`; directories emptied by cleanup (`.factory/rules` and its subdirectories) are pruned as well

--- a/docs/reference/formatters/github.md
+++ b/docs/reference/formatters/github.md
@@ -87,9 +87,10 @@ description: PromptScript output format for GitHub Copilot
 - `@hooks` uses `.github/hooks/promptscript.json` for Copilot CLI and cloud agent in `multifile` and `full` modes
 - Hook commands use GitHub's shell-specific `bash` and `powershell` fields
 - Hook `matcher` values match GitHub Copilot tool names and are emitted only for `preToolUse`, `postToolUse`, `subagentStart`, and `notification`; other targets use different tool-name vocabularies, so a matcher that works here may match nothing elsewhere
+- `pre-terminal-command` is omitted from the shared Copilot CLI/cloud file with `PS4002` because those hosts do not provide one guaranteed repository-level terminal contract
 - `notification` hooks run in Copilot CLI but do not fire in Copilot cloud agent; PromptScript reports `PS4002`
 - `.github/hooks/promptscript-vscode.json` belongs to VS Code Agent integration installed by `prs hooks install copilot`
-- A `vscode` target override emits this file separately and uses PascalCase events; VS Code currently ignores matcher values
+- A `vscode` target override emits this file separately and uses PascalCase events; `pre-terminal-command` defaults to `run_in_terminal`, but VS Code currently ignores matcher values and reports best-effort `PS4002`
 - When `@hooks` is removed or no longer emits, the CLI removes a fully PromptScript-owned `.github/hooks/promptscript.json` and prunes the now-empty `.github/hooks/` directory
 
 ## Example Output

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -1301,15 +1301,16 @@ target's native event system and configuration format.
 
 Portable events:
 
-| Event            | Description                       |
-| ---------------- | --------------------------------- |
-| `pre-tool-use`   | Fires before a tool invocation    |
-| `post-tool-use`  | Fires after a tool invocation     |
-| `session-start`  | Fires when a session begins       |
-| `setup`          | Alias for `session-start`         |
-| `subagent-start` | Fires when a subagent is launched |
-| `notification`   | Fires on notification events      |
-| `stop`           | Fires when the agent stops        |
+| Event                  | Description                       |
+| ---------------------- | --------------------------------- |
+| `pre-terminal-command` | Fires before a terminal command   |
+| `pre-tool-use`         | Fires before a tool invocation    |
+| `post-tool-use`        | Fires after a tool invocation     |
+| `session-start`        | Fires when a session begins       |
+| `setup`                | Alias for `session-start`         |
+| `subagent-start`       | Fires when a subagent is launched |
+| `notification`         | Fires on notification events      |
+| `stop`                 | Fires when the agent stops        |
 
 Each hook entry is an object with:
 
@@ -1352,10 +1353,9 @@ must be portable relative paths and resolve from that root. Absolute paths, back
 segments, `.` segments, and `..` traversal are rejected. Hook configuration location does not set
 the command working directory.
 
-`matcher` filters by tool name using the target's own vocabulary: Factory matches names like
-`Execute` or `Read`, GitHub Copilot matches its own tool names (and only on `preToolUse`,
-`postToolUse`, `subagentStart`, and `notification`), and Claude Code matches names like
-`Edit|Write`. A matcher written for one target can match nothing on another, so review generated
+`matcher` uses each target's tool vocabulary, such as Factory `Execute` or `Read` and Claude
+`Edit|Write`. GitHub emits it only for `preToolUse`, `postToolUse`, `subagentStart`, and
+`notification`. A matcher written for one target can match nothing on another, so review generated
 hook files per target.
 
 Target overrides use the target name as the key:
@@ -2184,3 +2184,13 @@ interpreter, and argument validation as base executables. Enabled target
 scripts are included in Node and browser compiler resource validation.
 Disabled target overrides emit no hook and do not require their script
 resource.
+
+## Terminal Command Hook Portability
+
+`pre-terminal-command` supplies deterministic native defaults for terminal
+policy: Factory `Execute`, Claude and Codex `Bash`, Windsurf
+`pre_run_command`, Cursor `run_terminal_cmd`, Gemini `run_shell_command`, and
+VS Code `run_in_terminal`. Set `targets.<name>.matcher` to replace a native tool
+name. Cursor, Gemini, and VS Code emit `PS4002` because their coverage is best
+effort. GitHub Copilot CLI/cloud and Grok omit the event with `PS4002` because
+their repository hook contracts do not guarantee terminal interception.

--- a/packages/cli/skills/promptscript/SKILL.md
+++ b/packages/cli/skills/promptscript/SKILL.md
@@ -496,15 +496,16 @@ Portable lifecycle hooks. Requires syntax `1.4.0`. Each hook needs exactly one o
 
 Portable events:
 
-| Event            | Meaning                  |
-| ---------------- | ------------------------ |
-| `pre-tool-use`   | Before a tool invocation |
-| `post-tool-use`  | After a tool invocation  |
-| `session-start`  | Agent session start      |
-| `setup`          | Session setup            |
-| `subagent-start` | Subagent start           |
-| `notification`   | Agent notification       |
-| `stop`           | Agent stop               |
+| Event                  | Meaning                   |
+| ---------------------- | ------------------------- |
+| `pre-terminal-command` | Before a terminal command |
+| `pre-tool-use`         | Before a tool invocation  |
+| `post-tool-use`        | After a tool invocation   |
+| `session-start`        | Agent session start       |
+| `setup`                | Session setup             |
+| `subagent-start`       | Subagent start            |
+| `notification`         | Agent notification        |
+| `stop`                 | Agent stop                |
 
 `command` is a non-empty string array. Shell interpolation (`$()`, backticks,
 `${...}`) is forbidden. `script` requires:
@@ -520,6 +521,12 @@ Portable events:
 paths relative to project root. Hook config file location does not set command cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
+
+`pre-terminal-command` supplies native defaults: Factory `Execute`, Claude and
+Codex `Bash`, Windsurf `pre_run_command`, Cursor `run_terminal_cmd`, Gemini
+`run_shell_command`, and VS Code `run_in_terminal`. Override a native tool name
+with `targets.<name>.matcher`. Cursor, Gemini, and VS Code report best-effort
+`PS4002` warnings. GitHub and Grok omit the event with `PS4002`.
 
 Target overrides may change `event`, `matcher`, `timeoutMs`, `statusMessage`,
 `continueOnFailure`, `enabled`, or `cwd`. Native hook files are emitted only in

--- a/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
+++ b/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
@@ -104,6 +104,80 @@ describe('Hook target smoke tests', () => {
     expect(result.outputs.has('.windsurf/hooks.json')).toBe(true);
   });
 
+  it('compiles terminal command hooks with deterministic native coverage', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-terminal-hooks-'));
+    directories.push(directory);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "terminal-hook-smoke"
+  syntax: "1.4.0"
+}
+
+@hooks {
+  terminal-policy: {
+    event: "pre-terminal-command"
+    command: ["node", "check-terminal.mjs"]
+    targets: {
+      vscode: {}
+    }
+  }
+}
+`
+    );
+
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [
+        { name: 'claude', config: { version: 'full' } },
+        { name: 'codex', config: { version: 'full' } },
+        { name: 'factory', config: { version: 'full' } },
+        { name: 'github', config: { version: 'full' } },
+        { name: 'windsurf', config: { version: 'full' } },
+      ],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.success).toBe(true);
+
+    const factory = JSON.parse(result.outputs.get('.factory/hooks.json')!.content) as {
+      hooks: { PreToolUse: Array<{ matcher: string }> };
+    };
+    expect(factory.hooks.PreToolUse[0]!.matcher).toBe('Execute');
+
+    const claude = JSON.parse(result.outputs.get('.claude/settings.json')!.content) as {
+      hooks: { PreToolUse: Array<{ matcher: string }> };
+    };
+    expect(claude.hooks.PreToolUse[0]!.matcher).toBe('Bash');
+
+    const codex = JSON.parse(result.outputs.get('.codex/hooks.json')!.content) as {
+      hooks: { PreToolUse: Array<{ matcher: string }> };
+    };
+    expect(codex.hooks.PreToolUse[0]!.matcher).toBe('Bash');
+
+    const windsurf = JSON.parse(result.outputs.get('.windsurf/hooks.json')!.content) as {
+      hooks: Record<string, unknown>;
+    };
+    expect(Object.keys(windsurf.hooks)).toEqual(['pre_run_command']);
+
+    expect(result.outputs.has('.github/hooks/promptscript.json')).toBe(false);
+    const vscode = JSON.parse(
+      result.outputs.get('.github/hooks/promptscript-vscode.json')!.content
+    ) as {
+      hooks: { PreToolUse: Array<{ matcher: string }> };
+    };
+    expect(vscode.hooks.PreToolUse[0]!.matcher).toBe('run_in_terminal');
+
+    expect(result.warnings.map((warning) => warning.message)).toEqual(
+      expect.arrayContaining([
+        'Hook "terminal-policy" requests terminal command interception, which github cannot guarantee and will omit.',
+        'Hook "terminal-policy" maps terminal command interception to vscode with best-effort coverage.',
+      ])
+    );
+  });
+
   it('compiles target executable overrides to each native contract', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'promptscript-hook-overrides-'));
     directories.push(directory);

--- a/packages/core/src/__tests__/hook-capabilities.spec.ts
+++ b/packages/core/src/__tests__/hook-capabilities.spec.ts
@@ -50,7 +50,26 @@ describe('hook capabilities', () => {
       toolNames: ['Execute'],
       notes: expect.stringContaining('Factory Execute'),
     });
+    expect(HOOK_CAPABILITIES.claude.terminal).toEqual({
+      guarantee: 'guaranteed',
+      toolNames: ['Bash'],
+      notes: expect.stringContaining('Bash shell commands'),
+    });
+    expect(HOOK_CAPABILITIES.codex.terminal).toEqual({
+      guarantee: 'guaranteed',
+      toolNames: ['Bash'],
+      notes: expect.stringContaining('unified exec calls'),
+    });
+    expect(HOOK_CAPABILITIES.windsurf.terminal).toEqual({
+      guarantee: 'guaranteed',
+      toolNames: ['pre_run_command', 'post_run_command'],
+      notes: expect.stringContaining('dedicated pre-run'),
+    });
     expect(HOOK_CAPABILITIES.github.terminal?.guarantee).toBe('not-guaranteed');
-    expect(HOOK_RUNTIME_CAPABILITIES.vscode.terminal?.toolNames).toEqual(['run_in_terminal']);
+    expect(HOOK_RUNTIME_CAPABILITIES.vscode.terminal).toEqual({
+      guarantee: 'best-effort',
+      toolNames: ['run_in_terminal'],
+      notes: expect.stringContaining('ignores matcher values'),
+    });
   });
 });

--- a/packages/core/src/hook-capabilities.ts
+++ b/packages/core/src/hook-capabilities.ts
@@ -40,7 +40,7 @@ export interface HookCapability {
 
 export type HookRuntimeTarget = KnownTarget | 'vscode';
 
-const PORTABLE_EVENTS = [
+const PORTABLE_LIFECYCLE_EVENTS = [
   'pre-tool-use',
   'post-tool-use',
   'session-start',
@@ -49,6 +49,8 @@ const PORTABLE_EVENTS = [
   'notification',
   'stop',
 ] as const;
+
+const PORTABLE_EVENTS = ['pre-terminal-command', ...PORTABLE_LIFECYCLE_EVENTS] as const;
 
 const UNSUPPORTED_CAPABILITY = {
   status: 'unsupported',
@@ -73,7 +75,7 @@ export const HOOK_CAPABILITIES = {
   github: {
     status: 'native',
     configPath: '.github/hooks/promptscript.json',
-    events: PORTABLE_EVENTS,
+    events: PORTABLE_LIFECYCLE_EVENTS,
     commandFormat: 'versioned JSON with bash and powershell commands',
     timeoutUnit: 'seconds',
     projectRootStrategy: 'native-cwd',
@@ -108,7 +110,15 @@ export const HOOK_CAPABILITIES = {
   cursor: {
     status: 'native',
     configPath: '.cursor/hooks.json',
-    events: ['pre-tool-use', 'post-tool-use', 'session-start', 'setup', 'subagent-start', 'stop'],
+    events: [
+      'pre-terminal-command',
+      'pre-tool-use',
+      'post-tool-use',
+      'session-start',
+      'setup',
+      'subagent-start',
+      'stop',
+    ],
     commandFormat: 'versioned JSON command hooks',
     timeoutUnit: 'seconds',
     projectRootStrategy: 'git-root',
@@ -126,7 +136,15 @@ export const HOOK_CAPABILITIES = {
   factory: {
     status: 'native',
     configPath: '.factory/hooks.json',
-    events: ['pre-tool-use', 'post-tool-use', 'session-start', 'setup', 'notification', 'stop'],
+    events: [
+      'pre-terminal-command',
+      'pre-tool-use',
+      'post-tool-use',
+      'session-start',
+      'setup',
+      'notification',
+      'stop',
+    ],
     commandFormat: 'nested command hooks',
     timeoutUnit: 'seconds',
     projectRootStrategy: 'environment',
@@ -150,7 +168,14 @@ export const HOOK_CAPABILITIES = {
   gemini: {
     status: 'native',
     configPath: '.gemini/settings.json',
-    events: ['pre-tool-use', 'post-tool-use', 'session-start', 'setup', 'stop'],
+    events: [
+      'pre-terminal-command',
+      'pre-tool-use',
+      'post-tool-use',
+      'session-start',
+      'setup',
+      'stop',
+    ],
     commandFormat: 'nested command hooks',
     timeoutUnit: 'milliseconds',
     projectRootStrategy: 'environment',
@@ -167,7 +192,7 @@ export const HOOK_CAPABILITIES = {
   windsurf: {
     status: 'native',
     configPath: '.windsurf/hooks.json',
-    events: ['pre-tool-use', 'post-tool-use', 'stop'],
+    events: ['pre-terminal-command', 'pre-tool-use', 'post-tool-use', 'stop'],
     commandFormat: 'flat command and powershell entries',
     timeoutUnit: 'none',
     projectRootStrategy: 'native-cwd',
@@ -192,7 +217,15 @@ export const HOOK_CAPABILITIES = {
   codex: {
     status: 'native',
     configPath: '.codex/hooks.json',
-    events: ['pre-tool-use', 'post-tool-use', 'session-start', 'setup', 'subagent-start', 'stop'],
+    events: [
+      'pre-terminal-command',
+      'pre-tool-use',
+      'post-tool-use',
+      'session-start',
+      'setup',
+      'subagent-start',
+      'stop',
+    ],
     commandFormat: 'nested command and commandWindows hooks',
     timeoutUnit: 'seconds',
     projectRootStrategy: 'git-root',
@@ -260,7 +293,7 @@ export const HOOK_CAPABILITIES = {
   grok: {
     status: 'native',
     configPath: '.grok/hooks/promptscript.json',
-    events: PORTABLE_EVENTS,
+    events: PORTABLE_LIFECYCLE_EVENTS,
     commandFormat: 'nested command hooks',
     timeoutUnit: 'seconds',
     projectRootStrategy: 'environment',
@@ -278,7 +311,15 @@ export const HOOK_CAPABILITIES = {
 export const VSCODE_HOOK_CAPABILITY: HookCapability = {
   status: 'compatible',
   configPath: '.github/hooks/promptscript-vscode.json',
-  events: ['pre-tool-use', 'post-tool-use', 'session-start', 'setup', 'subagent-start', 'stop'],
+  events: [
+    'pre-terminal-command',
+    'pre-tool-use',
+    'post-tool-use',
+    'session-start',
+    'setup',
+    'subagent-start',
+    'stop',
+  ],
   commandFormat: 'Claude-compatible PascalCase JSON command hooks',
   timeoutUnit: 'seconds',
   projectRootStrategy: 'workspace-cwd',

--- a/packages/formatters/src/__tests__/hook-adapters.spec.ts
+++ b/packages/formatters/src/__tests__/hook-adapters.spec.ts
@@ -18,7 +18,12 @@ import {
   type HookDefinition,
   type HookTarget,
 } from '../hook-adapters.js';
-import { HOOK_CAPABILITIES, type Value } from '@promptscript/core';
+import {
+  HOOK_CAPABILITIES,
+  HOOK_RUNTIME_CAPABILITIES,
+  type HookCapability,
+  type Value,
+} from '@promptscript/core';
 
 function makeLoc() {
   return { file: 'test.prs', line: 1, column: 0 };
@@ -1294,6 +1299,13 @@ describe('hook-adapters', () => {
       expect(HOOK_CAPABILITIES[target].events).toEqual(
         events.filter((event) => mapEvent(event, target) !== null)
       );
+    }
+
+    for (const target of [...targets, 'vscode'] as const) {
+      if (mapEvent('pre-terminal-command', target)) {
+        const capability: HookCapability = HOOK_RUNTIME_CAPABILITIES[target];
+        expect(capability.terminal).toBeDefined();
+      }
     }
   });
 

--- a/packages/formatters/src/__tests__/hook-adapters.spec.ts
+++ b/packages/formatters/src/__tests__/hook-adapters.spec.ts
@@ -203,6 +203,23 @@ describe('hook-adapters', () => {
     it('should map pre-tool-use to VS Code PreToolUse', () => {
       expect(mapEvent('pre-tool-use', 'vscode')).toBe('PreToolUse');
     });
+
+    it.each([
+      ['claude', 'PreToolUse'],
+      ['cursor', 'preToolUse'],
+      ['codex', 'PreToolUse'],
+      ['factory', 'PreToolUse'],
+      ['gemini', 'BeforeTool'],
+      ['windsurf', 'pre_run_command'],
+      ['vscode', 'PreToolUse'],
+      ['github', null],
+      ['grok', null],
+    ] as const)(
+      'should map pre-terminal-command for %s without overstating coverage',
+      (target, event) => {
+        expect(mapEvent('pre-terminal-command', target)).toBe(event);
+      }
+    );
   });
 
   describe('convertTimeout', () => {
@@ -242,6 +259,27 @@ describe('hook-adapters', () => {
   });
 
   describe('generateClaudeHooks', () => {
+    it('should use the native terminal matcher by default and allow an override', () => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'default',
+          event: 'pre-terminal-command',
+          command: ['echo', 'default'],
+        },
+        {
+          id: 'override',
+          event: 'pre-terminal-command',
+          command: ['echo', 'override'],
+          targets: { claude: { matcher: 'CustomShell' } },
+        },
+      ];
+
+      expect(generateClaudeHooks(hooks)['PreToolUse']).toEqual([
+        expect.objectContaining({ matcher: 'Bash' }),
+        expect.objectContaining({ matcher: 'CustomShell' }),
+      ]);
+    });
+
     it('should generate PreToolUse hook entry', () => {
       const hooks = extractHooks(
         makeHooksBlock({
@@ -454,6 +492,27 @@ describe('hook-adapters', () => {
   });
 
   describe('generateFactoryHooks', () => {
+    it('should use Execute for terminal commands and allow a native matcher override', () => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'default',
+          event: 'pre-terminal-command',
+          command: ['echo', 'default'],
+        },
+        {
+          id: 'override',
+          event: 'pre-terminal-command',
+          command: ['echo', 'override'],
+          targets: { factory: { matcher: 'CustomExecute' } },
+        },
+      ];
+
+      expect(generateFactoryHooks(hooks)['PreToolUse']).toEqual([
+        expect.objectContaining({ matcher: 'Execute' }),
+        expect.objectContaining({ matcher: 'CustomExecute' }),
+      ]);
+    });
+
     it('should inherit the base executable when a target does not replace it', () => {
       const hooks = extractHooks(
         makeHooksBlock({
@@ -621,6 +680,21 @@ describe('hook-adapters', () => {
   });
 
   describe('generateVSCodeHooks', () => {
+    it('should emit the best-effort terminal matcher by default', () => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'terminal',
+          event: 'pre-terminal-command',
+          command: ['echo', 'terminal'],
+          targets: { vscode: {} },
+        },
+      ];
+
+      expect(generateVSCodeHooks(hooks)['PreToolUse']![0]).toEqual(
+        expect.objectContaining({ matcher: 'run_in_terminal' })
+      );
+    });
+
     it('should apply target overrides and emit the VS Code contract', () => {
       const hooks = extractHooks(
         makeHooksBlock({
@@ -1206,6 +1280,7 @@ describe('hook-adapters', () => {
       'grok',
     ] as const;
     const events = [
+      'pre-terminal-command',
       'pre-tool-use',
       'post-tool-use',
       'session-start',
@@ -1223,6 +1298,37 @@ describe('hook-adapters', () => {
   });
 
   describe('getHookCompatibilityWarnings', () => {
+    it('reports terminal coverage without warning for guaranteed targets', () => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'terminal',
+          event: 'pre-terminal-command',
+          command: ['echo', 'terminal'],
+          targets: { vscode: {} },
+        },
+      ];
+
+      for (const target of ['claude', 'codex', 'factory', 'windsurf'] as const) {
+        expect(getHookCompatibilityWarnings(hooks, target)).toEqual([]);
+      }
+      for (const target of ['cursor', 'gemini', 'vscode'] as const) {
+        expect(getHookCompatibilityWarnings(hooks, target)).toEqual([
+          expect.objectContaining({
+            code: 'PS4002',
+            message: expect.stringContaining('best-effort coverage'),
+          }),
+        ]);
+      }
+      for (const target of ['github', 'grok'] as const) {
+        expect(getHookCompatibilityWarnings(hooks, target)).toEqual([
+          expect.objectContaining({
+            code: 'PS4002',
+            message: expect.stringContaining('cannot guarantee and will omit'),
+          }),
+        ]);
+      }
+    });
+
     it('warns when Factory cannot represent an event or field', () => {
       const hooks = extractHooks(
         makeHooksBlock({

--- a/packages/formatters/src/hook-adapters.ts
+++ b/packages/formatters/src/hook-adapters.ts
@@ -1,5 +1,6 @@
 import {
   HOOK_RUNTIME_CAPABILITIES,
+  type HookCapability,
   type PortableHookInterpreter,
   type Value,
 } from '@promptscript/core';
@@ -10,6 +11,7 @@ import type { FormatterWarning } from './types.js';
  * These map to target-native event names per target contract.
  */
 export type PortableHookEvent =
+  | 'pre-terminal-command'
   | 'pre-tool-use'
   | 'post-tool-use'
   | 'session-start'
@@ -379,6 +381,7 @@ export function getEnabledHookScriptResources(hook: HookDefinition): HookScriptD
  * Maps portable events to target-specific event names.
  */
 const CLAUDE_EVENT_MAP: Record<PortableHookEvent, string> = {
+  'pre-terminal-command': 'PreToolUse',
   'pre-tool-use': 'PreToolUse',
   'post-tool-use': 'PostToolUse',
   'session-start': 'SessionStart',
@@ -389,6 +392,7 @@ const CLAUDE_EVENT_MAP: Record<PortableHookEvent, string> = {
 };
 
 const CURSOR_EVENT_MAP: Record<PortableHookEvent, string> = {
+  'pre-terminal-command': 'preToolUse',
   'pre-tool-use': 'preToolUse',
   'post-tool-use': 'postToolUse',
   'session-start': 'sessionStart',
@@ -399,6 +403,7 @@ const CURSOR_EVENT_MAP: Record<PortableHookEvent, string> = {
 };
 
 const CODEX_EVENT_MAP: Record<PortableHookEvent, string> = {
+  'pre-terminal-command': 'PreToolUse',
   'pre-tool-use': 'PreToolUse',
   'post-tool-use': 'PostToolUse',
   'session-start': 'SessionStart',
@@ -413,6 +418,7 @@ const CODEX_EVENT_MAP: Record<PortableHookEvent, string> = {
  * Factory uses PascalCase event names.
  */
 const FACTORY_EVENT_MAP: Partial<Record<PortableHookEvent, string>> = {
+  'pre-terminal-command': 'PreToolUse',
   'pre-tool-use': 'PreToolUse',
   'post-tool-use': 'PostToolUse',
   'session-start': 'SessionStart',
@@ -425,6 +431,7 @@ const FACTORY_EVENT_MAP: Partial<Record<PortableHookEvent, string>> = {
  * GitHub Copilot hook event names.
  */
 const GITHUB_EVENT_MAP: Record<PortableHookEvent, string> = {
+  'pre-terminal-command': '',
   'pre-tool-use': 'preToolUse',
   'post-tool-use': 'postToolUse',
   'session-start': 'sessionStart',
@@ -435,6 +442,7 @@ const GITHUB_EVENT_MAP: Record<PortableHookEvent, string> = {
 };
 
 const GEMINI_EVENT_MAP: Record<PortableHookEvent, string> = {
+  'pre-terminal-command': 'BeforeTool',
   'pre-tool-use': 'BeforeTool',
   'post-tool-use': 'AfterTool',
   'session-start': 'SessionStart',
@@ -445,6 +453,7 @@ const GEMINI_EVENT_MAP: Record<PortableHookEvent, string> = {
 };
 
 const GROK_EVENT_MAP: Record<PortableHookEvent, string> = {
+  'pre-terminal-command': '',
   'pre-tool-use': 'PreToolUse',
   'post-tool-use': 'PostToolUse',
   'session-start': 'SessionStart',
@@ -455,6 +464,7 @@ const GROK_EVENT_MAP: Record<PortableHookEvent, string> = {
 };
 
 const WINDSURF_EVENT_MAP: Record<PortableHookEvent, readonly string[]> = {
+  'pre-terminal-command': ['pre_run_command'],
   'pre-tool-use': ['pre_read_code', 'pre_write_code', 'pre_run_command', 'pre_mcp_tool_use'],
   'post-tool-use': ['post_read_code', 'post_write_code', 'post_run_command', 'post_mcp_tool_use'],
   'session-start': [],
@@ -465,6 +475,7 @@ const WINDSURF_EVENT_MAP: Record<PortableHookEvent, readonly string[]> = {
 };
 
 const VSCODE_EVENT_MAP: Record<PortableHookEvent, string> = {
+  'pre-terminal-command': 'PreToolUse',
   'pre-tool-use': 'PreToolUse',
   'post-tool-use': 'PostToolUse',
   'session-start': 'SessionStart',
@@ -502,6 +513,19 @@ function mapEvents(event: PortableHookEvent): readonly string[] {
   return WINDSURF_EVENT_MAP[event];
 }
 
+function getDefaultTerminalMatcher(
+  event: PortableHookEvent,
+  target: HookTarget
+): string | undefined {
+  if (event !== 'pre-terminal-command' || target === 'windsurf') return undefined;
+  const capability: HookCapability = HOOK_RUNTIME_CAPABILITIES[target];
+  return capability.terminal?.toolNames[0];
+}
+
+function getEffectiveMatcher(hook: HookDefinition, target: HookTarget): string | undefined {
+  return hook.matcher ?? getDefaultTerminalMatcher(hook.event, target);
+}
+
 /**
  * Convert timeout from milliseconds to target units.
  */
@@ -535,7 +559,7 @@ export function generateClaudeHooks(hooks: HookDefinition[]): Record<string, unk
     if (!result[nativeEvent]) result[nativeEvent] = [];
 
     const entry: Record<string, unknown> = {
-      matcher: hook.matcher ?? '.*',
+      matcher: getEffectiveMatcher(hook, 'claude') ?? '.*',
       hooks: [
         {
           type: 'command',
@@ -571,7 +595,7 @@ export function generateCursorHooks(hooks: HookDefinition[]): Record<string, unk
     if (!result[nativeEvent]) result[nativeEvent] = [];
 
     result[nativeEvent].push({
-      matcher: hook.matcher ?? '.*',
+      matcher: getEffectiveMatcher(hook, 'cursor') ?? '.*',
       command: serializeGitRootScriptCommand(hook),
       timeout: hook.timeoutMs ? convertTimeout(hook.timeoutMs, 'cursor') : 10,
     });
@@ -595,7 +619,7 @@ export function generateFactoryHooks(hooks: HookDefinition[]): Record<string, un
     if (!result[nativeEvent]) result[nativeEvent] = [];
 
     result[nativeEvent].push({
-      matcher: hook.matcher ?? '.*',
+      matcher: getEffectiveMatcher(hook, 'factory') ?? '.*',
       hooks: [
         {
           type: 'command',
@@ -625,13 +649,32 @@ export function getHookCompatibilityWarnings(
   for (const hook of applyHookTargetOverrides(hooks, target)) {
     if (hook.enabled === false) continue;
 
-    if (!mapEvent(hook.event, target)) {
+    const nativeEvent = mapEvent(hook.event, target);
+    const capability: HookCapability = HOOK_RUNTIME_CAPABILITIES[target];
+    if (!nativeEvent) {
       warnings.push({
         code: 'PS4002',
-        message: `Hook "${hook.id}" uses event "${hook.event}", which ${target} cannot represent and will omit.`,
-        suggestion: `Use an event supported by the ${target} hook contract.`,
+        message:
+          hook.event === 'pre-terminal-command'
+            ? `Hook "${hook.id}" requests terminal command interception, which ${target} cannot guarantee and will omit.`
+            : `Hook "${hook.id}" uses event "${hook.event}", which ${target} cannot represent and will omit.`,
+        suggestion:
+          hook.event === 'pre-terminal-command'
+            ? (capability.terminal?.notes ??
+              `Use an event supported by the ${target} hook contract.`)
+            : `Use an event supported by the ${target} hook contract.`,
       });
       continue;
+    }
+
+    if (hook.event === 'pre-terminal-command' && capability.terminal?.guarantee !== 'guaranteed') {
+      warnings.push({
+        code: 'PS4002',
+        message: `Hook "${hook.id}" maps terminal command interception to ${target} with ${capability.terminal?.guarantee ?? 'unknown'} coverage.`,
+        suggestion:
+          capability.terminal?.notes ??
+          'Inspect the target hook payload and filter terminal commands inside the hook.',
+      });
     }
 
     if (target === 'github' && hook.matcher && !GITHUB_MATCHER_EVENTS.has(hook.event)) {
@@ -650,7 +693,7 @@ export function getHookCompatibilityWarnings(
       });
     }
 
-    if (target === 'vscode' && hook.matcher) {
+    if (target === 'vscode' && hook.matcher && hook.event !== 'pre-terminal-command') {
       warnings.push({
         code: 'PS4002',
         message: `Hook "${hook.id}" uses matcher, which VS Code currently parses but ignores.`,
@@ -711,7 +754,6 @@ export function getHookCompatibilityWarnings(
       });
     }
 
-    const capability = HOOK_RUNTIME_CAPABILITIES[target];
     if (
       hook.script &&
       (capability.platforms as readonly string[]).includes('windows') &&
@@ -778,12 +820,13 @@ export function generateVSCodeHooks(hooks: HookDefinition[]): Record<string, unk
     if (!result[nativeEvent]) result[nativeEvent] = [];
     const command = serializeNativeCwdScriptCommand(hook, 'posix');
     const windows = serializeNativeCwdScriptCommand(hook, 'powershell');
+    const matcher = getEffectiveMatcher(hook, 'vscode');
 
     result[nativeEvent].push({
       type: 'command',
       command,
       ...(windows ? { windows } : {}),
-      ...(hook.matcher ? { matcher: hook.matcher } : {}),
+      ...(matcher ? { matcher } : {}),
       ...(hook.cwd ? { cwd: hook.cwd === 'project' ? '.' : hook.cwd } : {}),
       ...(hook.timeoutMs ? { timeout: convertTimeout(hook.timeoutMs, 'vscode') } : {}),
     });
@@ -804,8 +847,9 @@ export function generateGeminiHooks(hooks: HookDefinition[]): Record<string, unk
     if (!nativeEvent) continue;
 
     if (!result[nativeEvent]) result[nativeEvent] = [];
+    const matcher = getEffectiveMatcher(hook, 'gemini');
     result[nativeEvent].push({
-      ...(hook.matcher ? { matcher: hook.matcher } : {}),
+      ...(matcher ? { matcher } : {}),
       hooks: [
         {
           type: 'command',
@@ -888,7 +932,8 @@ export function generateCodexHooks(hooks: HookDefinition[]): string {
     if (!nativeEvent) continue;
 
     lines.push(`[[hooks.${nativeEvent}]]`);
-    if (hook.matcher) lines.push(`matcher = "${escapeTomlHookString(hook.matcher)}"`);
+    const matcher = getEffectiveMatcher(hook, 'codex');
+    if (matcher) lines.push(`matcher = "${escapeTomlHookString(matcher)}"`);
     lines.push(`[[hooks.${nativeEvent}.hooks]]`);
     lines.push('type = "command"');
     const command = hook.script ? serializeGitRootScriptCommand(hook) : serializeOwnedCommand(hook);
@@ -920,6 +965,7 @@ export function generateCodexHookConfig(hooks: HookDefinition[]): Record<string,
     const nativeEvent = mapEvent(hook.event, 'codex');
     if (!nativeEvent) continue;
 
+    const matcher = getEffectiveMatcher(hook, 'codex');
     const command = hook.script ? serializeGitRootScriptCommand(hook) : serializeOwnedCommand(hook);
     const commandWindows = hook.script
       ? serializePowerShellScriptCommand(hook)
@@ -934,7 +980,7 @@ export function generateCodexHookConfig(hooks: HookDefinition[]): Record<string,
 
     if (!result[nativeEvent]) result[nativeEvent] = [];
     result[nativeEvent].push({
-      ...(hook.matcher ? { matcher: hook.matcher } : {}),
+      ...(matcher ? { matcher } : {}),
       hooks: [handler],
     });
   }

--- a/packages/formatters/src/hook-adapters.ts
+++ b/packages/formatters/src/hook-adapters.ts
@@ -667,13 +667,16 @@ export function getHookCompatibilityWarnings(
       continue;
     }
 
-    if (hook.event === 'pre-terminal-command' && capability.terminal?.guarantee !== 'guaranteed') {
+    const terminalCapability = capability.terminal;
+    if (
+      hook.event === 'pre-terminal-command' &&
+      terminalCapability &&
+      terminalCapability.guarantee !== 'guaranteed'
+    ) {
       warnings.push({
         code: 'PS4002',
-        message: `Hook "${hook.id}" maps terminal command interception to ${target} with ${capability.terminal?.guarantee ?? 'unknown'} coverage.`,
-        suggestion:
-          capability.terminal?.notes ??
-          'Inspect the target hook payload and filter terminal commands inside the hook.',
+        message: `Hook "${hook.id}" maps terminal command interception to ${target} with ${terminalCapability.guarantee} coverage.`,
+        suggestion: terminalCapability.notes,
       });
     }
 

--- a/packages/validator/src/__tests__/rules/valid-hooks.spec.ts
+++ b/packages/validator/src/__tests__/rules/valid-hooks.spec.ts
@@ -444,6 +444,7 @@ describe('PS034: valid-hooks', () => {
 
   it('should accept all valid portable events', () => {
     const events = [
+      'pre-terminal-command',
       'pre-tool-use',
       'post-tool-use',
       'session-start',

--- a/packages/validator/src/rules/valid-hooks.ts
+++ b/packages/validator/src/rules/valid-hooks.ts
@@ -10,6 +10,7 @@ import {
 
 /** Portable hook events (PascalCase superset per architecture decision). */
 const VALID_HOOK_EVENTS = new Set([
+  'pre-terminal-command',
   'pre-tool-use',
   'post-tool-use',
   'session-start',

--- a/skills/promptscript/SKILL.md
+++ b/skills/promptscript/SKILL.md
@@ -496,15 +496,16 @@ Portable lifecycle hooks. Requires syntax `1.4.0`. Each hook needs exactly one o
 
 Portable events:
 
-| Event            | Meaning                  |
-| ---------------- | ------------------------ |
-| `pre-tool-use`   | Before a tool invocation |
-| `post-tool-use`  | After a tool invocation  |
-| `session-start`  | Agent session start      |
-| `setup`          | Session setup            |
-| `subagent-start` | Subagent start           |
-| `notification`   | Agent notification       |
-| `stop`           | Agent stop               |
+| Event                  | Meaning                   |
+| ---------------------- | ------------------------- |
+| `pre-terminal-command` | Before a terminal command |
+| `pre-tool-use`         | Before a tool invocation  |
+| `post-tool-use`        | After a tool invocation   |
+| `session-start`        | Agent session start       |
+| `setup`                | Session setup             |
+| `subagent-start`       | Subagent start            |
+| `notification`         | Agent notification        |
+| `stop`                 | Agent stop                |
 
 `command` is a non-empty string array. Shell interpolation (`$()`, backticks,
 `${...}`) is forbidden. `script` requires:
@@ -520,6 +521,12 @@ Portable events:
 paths relative to project root. Hook config file location does not set command cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
+
+`pre-terminal-command` supplies native defaults: Factory `Execute`, Claude and
+Codex `Bash`, Windsurf `pre_run_command`, Cursor `run_terminal_cmd`, Gemini
+`run_shell_command`, and VS Code `run_in_terminal`. Override a native tool name
+with `targets.<name>.matcher`. Cursor, Gemini, and VS Code report best-effort
+`PS4002` warnings. GitHub and Grok omit the event with `PS4002`.
 
 Target overrides may change `event`, `matcher`, `timeoutMs`, `statusMessage`,
 `continueOnFailure`, `enabled`, or `cwd`. Native hook files are emitted only in


### PR DESCRIPTION
## Summary
- add the portable `pre-terminal-command` lifecycle event to validation and public hook contracts
- map deterministic native defaults for Factory `Execute`, Claude/Codex `Bash`, Windsurf `pre_run_command`, Cursor, Gemini, and VS Code terminal tools
- preserve target-specific `matcher` overrides for alternate native tool names
- emit `PS4002` for best-effort Cursor, Gemini, and VS Code coverage
- omit GitHub Copilot CLI/cloud and Grok output with `PS4002` rather than claiming unsupported terminal guarantees
- add generated-output coverage for Factory, Claude, Codex, Windsurf, GitHub, and VS Code
- document guaranteed, best-effort, and unsupported terminal interception contracts

## Validation
- `pnpm nx affected -t test --coverage` (100% changed executable lines)
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:validate:check`
- `pnpm docs:formatters`
- `pnpm docs:build`

Closes #345
