### PR TITLE
fix(formatters): fail closed without project root

### DIFF
--- a/.claude/skills/promptscript/SKILL.md
+++ b/.claude/skills/promptscript/SKILL.md
@@ -519,6 +519,9 @@ Portable events:
 
 `cwd: "project"` runs from project root. Other values are portable forward-slash
 paths relative to project root. Hook config file location does not set command cwd.
+Environment-root and Git-root wrappers exit before script or command execution when
+the required root is unavailable. Native-cwd and workspace-cwd targets retain host
+cwd fields and report `PS4002` when PromptScript cannot verify that cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
 

--- a/.promptscript/skills/promptscript/SKILL.md
+++ b/.promptscript/skills/promptscript/SKILL.md
@@ -519,6 +519,9 @@ Portable events:
 
 `cwd: "project"` runs from project root. Other values are portable forward-slash
 paths relative to project root. Hook config file location does not set command cwd.
+Environment-root and Git-root wrappers exit before script or command execution when
+the required root is unavailable. Native-cwd and workspace-cwd targets retain host
+cwd fields and report `PS4002` when PromptScript cannot verify that cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
 

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -209,16 +209,16 @@ path independently from the agent session directory.
 
 ### Project-Root Strategy by Target
 
-| Target         | Root source                     | PromptScript `script` behavior                         |
-| -------------- | ------------------------------- | ------------------------------------------------------ |
-| Claude Code    | `CLAUDE_PROJECT_DIR`            | Quotes the root and script path                        |
-| Factory Droid  | `FACTORY_PROJECT_DIR`           | Quotes the root and script path                        |
-| GitHub Copilot | Native `cwd`                    | Emits `cwd` plus separate Bash and PowerShell commands |
-| Cursor         | `git rev-parse --show-toplevel` | Resolves a stable repository path on Unix              |
-| Codex          | `git rev-parse --show-toplevel` | Emits Unix and Windows root-resolving commands         |
-| Gemini CLI     | `GEMINI_PROJECT_DIR`            | Quotes the root and script path                        |
-| Windsurf       | Native `working_directory`      | Emits Unix and Windows commands relative to that cwd   |
-| Grok Build     | `GROK_WORKSPACE_ROOT`           | Quotes the root and script path                        |
+| Target         | Root source                     | PromptScript `script` behavior                           |
+| -------------- | ------------------------------- | -------------------------------------------------------- |
+| Claude Code    | `CLAUDE_PROJECT_DIR`            | Requires a non-empty root before invoking the script     |
+| Factory Droid  | `FACTORY_PROJECT_DIR`           | Requires a non-empty root before invoking the script     |
+| GitHub Copilot | Native `cwd`                    | Emits `cwd` plus separate Bash and PowerShell commands   |
+| Cursor         | `git rev-parse --show-toplevel` | Requires a non-empty Git worktree root on Unix           |
+| Codex          | `git rev-parse --show-toplevel` | Requires a non-empty Git root in Unix and Windows output |
+| Gemini CLI     | `GEMINI_PROJECT_DIR`            | Requires a non-empty root before invoking the script     |
+| Windsurf       | Native `working_directory`      | Emits Unix and Windows commands relative to that cwd     |
+| Grok Build     | `GROK_WORKSPACE_ROOT`           | Requires a non-empty root before invoking the script     |
 
 Cursor and Codex require the project to be a Git worktree because their native
 hook contracts do not expose a stable project-root variable.
@@ -234,17 +234,46 @@ shell. Claude Code and Factory Droid hook payloads assume a POSIX environment.
 For Windows coverage, prefer the GitHub Copilot target: its native `cwd` field
 and separate `bash` and `powershell` payloads are cross-shell.
 
-`CLAUDE_PROJECT_DIR` and `FACTORY_PROJECT_DIR` are set by the respective tool
-when it runs the hook. If the variable is unset, the wrapper normally fails
-with a non-zero exit and the hook reports an error. On some shells, such as
-macOS `/bin/sh`, `cd ""` is a no-op instead: the command then runs in the
-session working directory, where a same-named script could execute in the
-wrong location. Rely on the tool setting the variable, and treat a missing
-variable as a hook error rather than a fallback to another directory.
+Environment-root wrappers check their required variable before `cd`, the
+interpreter, or a project-relative command can run. An unset or empty variable
+writes a target-specific error to stderr and exits non-zero:
 
-For legacy `command` arrays, Cursor and Codex retain the agent session working
-directory and report `PS4002` when `cwd` was requested. Migrate repository-local
-commands to `script` to enable deterministic root handling.
+```sh
+if [ -z "${FACTORY_PROJECT_DIR:-}" ]; then
+  printf '%s\n' \
+    'PromptScript factory hook requires non-empty FACTORY_PROJECT_DIR.' >&2
+  exit 1
+fi
+```
+
+Cursor and Codex wrappers similarly reject a failed, empty, or whitespace-only
+`git rev-parse --show-toplevel` result. Codex Windows output checks
+`$LASTEXITCODE` and `[string]::IsNullOrWhiteSpace` before `Set-Location` or the
+interpreter:
+
+```powershell
+$promptscriptProjectRoot = git rev-parse --show-toplevel 2>$null
+if (
+  $LASTEXITCODE -ne 0 -or
+  [string]::IsNullOrWhiteSpace($promptscriptProjectRoot)
+) {
+  [Console]::Error.WriteLine(
+    'PromptScript codex hook requires a Git worktree project root.'
+  )
+  exit 1
+}
+```
+
+The same guards apply to a `command` array when it declares `cwd`. A command
+without `cwd` remains target-native and does not perform an unnecessary root
+lookup. No root strategy falls back to `$PWD`, `pwd`, or the process working
+directory.
+
+GitHub Copilot and Windsurf retain their native cwd fields. VS Code retains its
+workspace cwd field. PromptScript reports `PS4002` because it cannot
+independently verify that the host supplied the requested repository cwd. A
+host that cannot supply that cwd must reject or skip the hook, not execute it
+from another directory.
 
 On Windows, GitHub, Codex, and Windsurf emit PowerShell-safe commands. The
 `python3` interpreter maps to `py -3`. Unix-only shell interpreters (`bash`,
@@ -360,7 +389,7 @@ For example, the portable hook above generates this Factory command:
 ```json
 {
   "type": "command",
-  "command": "cd \"$FACTORY_PROJECT_DIR\" && python3 \"$FACTORY_PROJECT_DIR\"/.promptscript/scripts/validate.py --strict # promptscript-generated:validate-types"
+  "command": "if [ -z \"${FACTORY_PROJECT_DIR:-}\" ]; then printf '%s\\n' 'PromptScript factory hook requires non-empty FACTORY_PROJECT_DIR.' >&2; exit 1; fi; cd \"$FACTORY_PROJECT_DIR\" && python3 \"$FACTORY_PROJECT_DIR\"/.promptscript/scripts/validate.py --strict # promptscript-generated:validate-types"
 }
 ```
 
@@ -370,7 +399,7 @@ The GitHub repository hook uses its native working-directory field:
 {
   "type": "command",
   "bash": "python3 .promptscript/scripts/validate.py --strict # promptscript-generated:validate-types",
-  "powershell": "& 'python3' '.promptscript/scripts/validate.py' '--strict' # promptscript-generated:validate-types",
+  "powershell": "& 'py' '-3' '.promptscript/scripts/validate.py' '--strict' # promptscript-generated:validate-types",
   "cwd": "."
 }
 ```

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -34,7 +34,8 @@ Notes for compiled `@hooks` output:
   `.github/hooks/`).
 - **Working directory** - for repository-local lifecycle commands, set `cwd: "project"` in the
   language-level hook and keep shared scripts under `.promptscript/scripts/`. Generated hook file
-  location does not set command working directory. See
+  location does not set command working directory. Environment and Git-root wrappers exit before
+  resource execution when the required root is unavailable; they never fall back to process cwd. See
   [Hooks and Workflows](../features/automation.md#project-root-strategy-by-target) for target
   behavior, generated Factory and GitHub examples, and the complete capability matrix.
 

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -2194,3 +2194,11 @@ VS Code `run_in_terminal`. Set `targets.<name>.matcher` to replace a native tool
 name. Cursor, Gemini, and VS Code emit `PS4002` because their coverage is best
 effort. GitHub Copilot CLI/cloud and Grok omit the event with `PS4002` because
 their repository hook contracts do not guarantee terminal interception.
+
+## Hook Project Root Failure
+
+Environment-root and Git-root wrappers exit non-zero before an interpreter or
+command runs when they cannot resolve a non-empty project root. Native-cwd and
+workspace-cwd targets retain host-provided cwd fields and report `PS4002`
+because PromptScript cannot independently verify the host cwd. No target
+wrapper falls back to the process working directory.

--- a/packages/cli/skills/promptscript/SKILL.md
+++ b/packages/cli/skills/promptscript/SKILL.md
@@ -519,6 +519,9 @@ Portable events:
 
 `cwd: "project"` runs from project root. Other values are portable forward-slash
 paths relative to project root. Hook config file location does not set command cwd.
+Environment-root and Git-root wrappers exit before script or command execution when
+the required root is unavailable. Native-cwd and workspace-cwd targets retain host
+cwd fields and report `PS4002` when PromptScript cannot verify that cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
 

--- a/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
+++ b/packages/compiler/src/__tests__/hooks-targets.smoke.spec.ts
@@ -1,11 +1,29 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Compiler } from '../compiler.js';
 
 const directories: string[] = [];
+
+function environmentRootGuard(target: string, variable: string): string {
+  return `if [ -z "\${${variable}:-}" ]; then printf '%s\\n' 'PromptScript ${target} hook requires non-empty ${variable}.' >&2; exit 1; fi; `;
+}
+
+function gitRootGuard(target: string): string {
+  const failure = `printf '%s\\n' 'PromptScript ${target} hook requires a Git worktree project root.' >&2; exit 1`;
+  return `PROMPTSCRIPT_PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { ${failure}; }; case "$PROMPTSCRIPT_PROJECT_ROOT" in *[![:space:]]*) ;; *) ${failure} ;; esac; `;
+}
 
 afterEach(() => {
   for (const directory of directories.splice(0)) {
@@ -71,8 +89,7 @@ describe('Hook target smoke tests', () => {
             hooks: [
               {
                 type: 'command',
-                command:
-                  'cd "$FACTORY_PROJECT_DIR" && python3 "$FACTORY_PROJECT_DIR"/\'.promptscript/scripts/validate script.py\' --strict # promptscript-generated:validate',
+                command: `${environmentRootGuard('factory', 'FACTORY_PROJECT_DIR')}cd "$FACTORY_PROJECT_DIR" && python3 "$FACTORY_PROJECT_DIR"/'.promptscript/scripts/validate script.py' --strict # promptscript-generated:validate`,
                 timeout: 30,
               },
             ],
@@ -322,7 +339,208 @@ describe('Hook target smoke tests', () => {
     );
   });
 
-  it('reports targets that cannot guarantee project-root execution', async () => {
+  it('fails before script execution when an environment project root is unavailable', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript missing hook root '));
+    directories.push(directory);
+    const scriptDirectory = join(directory, '.promptscript', 'scripts');
+    const nestedDirectory = join(directory, 'packages', 'app');
+    const sentinelPath = join(directory, 'script-ran.txt');
+    mkdirSync(scriptDirectory, { recursive: true });
+    mkdirSync(nestedDirectory, { recursive: true });
+    const scriptPath = join(scriptDirectory, 'record-run.sh');
+    writeFileSync(scriptPath, `#!/bin/sh\ntouch ${JSON.stringify(sentinelPath)}\n`);
+    chmodSync(scriptPath, 0o755);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "hook-missing-root"
+  syntax: "1.4.0"
+}
+
+@hooks {
+  record-run: {
+    event: "session-start"
+    script: {
+      path: ".promptscript/scripts/record-run.sh"
+      interpreter: "sh"
+    }
+    cwd: "project"
+  }
+  record-command: {
+    event: "pre-tool-use"
+    command: ["touch", ${JSON.stringify(sentinelPath)}]
+    cwd: "project"
+  }
+}
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [{ name: 'factory', config: { version: 'full' } }],
+    });
+    const result = await compiler.compile(entryPath);
+    const hookFile = JSON.parse(result.outputs.get('.factory/hooks.json')!.content) as {
+      hooks: {
+        SessionStart: Array<{ hooks: Array<{ command: string }> }>;
+        PreToolUse: Array<{ hooks: Array<{ command: string }> }>;
+      };
+    };
+    const commands = [
+      hookFile.hooks.SessionStart[0]!.hooks[0]!.command,
+      hookFile.hooks.PreToolUse[0]!.hooks[0]!.command,
+    ];
+
+    for (const value of [undefined, '']) {
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      if (value === undefined) delete env['FACTORY_PROJECT_DIR'];
+      else env['FACTORY_PROJECT_DIR'] = value;
+
+      for (const command of commands) {
+        const execution = spawnSync('/bin/sh', ['-c', command], {
+          cwd: nestedDirectory,
+          env,
+          encoding: 'utf8',
+        });
+
+        expect(execution.status).toBe(1);
+        expect(execution.stderr).toContain(
+          'PromptScript factory hook requires non-empty FACTORY_PROJECT_DIR.'
+        );
+        expect(existsSync(sentinelPath)).toBe(false);
+      }
+    }
+  });
+
+  it('runs a Git-root script from a repository path containing spaces', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript git hook project '));
+    directories.push(directory);
+    execFileSync('git', ['init', '-q'], { cwd: directory });
+    const scriptDirectory = join(directory, '.promptscript', 'scripts');
+    const nestedDirectory = join(directory, 'packages', 'app');
+    mkdirSync(scriptDirectory, { recursive: true });
+    mkdirSync(nestedDirectory, { recursive: true });
+    const scriptPath = join(scriptDirectory, 'record-cwd.sh');
+    writeFileSync(scriptPath, '#!/bin/sh\npwd > .promptscript/hook-git-cwd.txt\n');
+    chmodSync(scriptPath, 0o755);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "hook-git-root-smoke"
+  syntax: "1.4.0"
+}
+
+@hooks {
+  record-cwd: {
+    event: "session-start"
+    script: {
+      path: ".promptscript/scripts/record-cwd.sh"
+      interpreter: "sh"
+    }
+    cwd: "project"
+  }
+}
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [{ name: 'cursor', config: { version: 'full' } }],
+    });
+    const result = await compiler.compile(entryPath);
+    const hookFile = JSON.parse(result.outputs.get('.cursor/hooks.json')!.content) as {
+      hooks: { sessionStart: Array<{ command: string }> };
+    };
+
+    execFileSync('/bin/sh', ['-c', hookFile.hooks.sessionStart[0]!.command], {
+      cwd: nestedDirectory,
+    });
+
+    expect(readFileSync(join(directory, '.promptscript', 'hook-git-cwd.txt'), 'utf8').trim()).toBe(
+      realpathSync(directory)
+    );
+  });
+
+  it('fails before script execution when a Git project root is unavailable', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript missing git root '));
+    directories.push(directory);
+    const scriptDirectory = join(directory, '.promptscript', 'scripts');
+    const fakeBin = join(directory, 'fake-bin');
+    const sentinelPath = join(directory, 'script-ran.txt');
+    mkdirSync(scriptDirectory, { recursive: true });
+    mkdirSync(fakeBin);
+    const scriptPath = join(scriptDirectory, 'record-run.sh');
+    writeFileSync(scriptPath, `#!/bin/sh\ntouch ${JSON.stringify(sentinelPath)}\n`);
+    chmodSync(scriptPath, 0o755);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "hook-missing-git-root"
+  syntax: "1.4.0"
+}
+
+@hooks {
+  record-run: {
+    event: "session-start"
+    script: {
+      path: ".promptscript/scripts/record-run.sh"
+      interpreter: "sh"
+    }
+    cwd: "project"
+  }
+  record-command: {
+    event: "pre-tool-use"
+    command: ["touch", ${JSON.stringify(sentinelPath)}]
+    cwd: "project"
+  }
+}
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [{ name: 'cursor', config: { version: 'full' } }],
+    });
+    const result = await compiler.compile(entryPath);
+    const hookFile = JSON.parse(result.outputs.get('.cursor/hooks.json')!.content) as {
+      hooks: {
+        sessionStart: Array<{ command: string }>;
+        preToolUse: Array<{ command: string }>;
+      };
+    };
+    const commands = [
+      hookFile.hooks.sessionStart[0]!.command,
+      hookFile.hooks.preToolUse[0]!.command,
+    ];
+
+    for (const command of commands) {
+      const missing = spawnSync('/bin/sh', ['-c', command], {
+        cwd: directory,
+        encoding: 'utf8',
+      });
+      expect(missing.status).toBe(1);
+      expect(missing.stderr).toContain(
+        'PromptScript cursor hook requires a Git worktree project root.'
+      );
+      expect(existsSync(sentinelPath)).toBe(false);
+    }
+
+    const fakeGit = join(fakeBin, 'git');
+    writeFileSync(fakeGit, "#!/bin/sh\nprintf '   \\n'\n");
+    chmodSync(fakeGit, 0o755);
+    const blank = spawnSync('/bin/sh', ['-c', commands[0]!], {
+      cwd: directory,
+      env: { ...process.env, PATH: `${fakeBin}:${process.env['PATH'] ?? ''}` },
+      encoding: 'utf8',
+    });
+    expect(blank.status).toBe(1);
+    expect(blank.stderr).toContain(
+      'PromptScript cursor hook requires a Git worktree project root.'
+    );
+    expect(existsSync(sentinelPath)).toBe(false);
+  });
+
+  it('guards project-relative commands without session cwd fallback warnings', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'promptscript-hooks-cwd-warnings-'));
     directories.push(directory);
     const entryPath = join(directory, 'project.prs');
@@ -354,23 +572,18 @@ describe('Hook target smoke tests', () => {
     const result = await compiler.compile(entryPath);
 
     expect(result.success).toBe(true);
-    expect(result.warnings.map((warning) => warning.message)).toEqual(
-      expect.arrayContaining([
-        'Hook "validate" requests cwd "project", which cursor cannot guarantee and will ignore.',
-        'Hook "validate" requests cwd "project", which codex cannot guarantee and will ignore.',
-      ])
-    );
+    expect(result.warnings).toEqual([]);
     const claude = JSON.parse(result.outputs.get('.claude/settings.json')!.content) as {
       hooks: { PostToolUse: Array<{ hooks: Array<{ command: string }> }> };
     };
     expect(claude.hooks.PostToolUse[0]!.hooks[0]!.command).toBe(
-      "cd \"${CLAUDE_PROJECT_DIR}\" && python3 '.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate"
+      `${environmentRootGuard('claude', 'CLAUDE_PROJECT_DIR')}cd "\${CLAUDE_PROJECT_DIR}" && python3 '.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate`
     );
     const cursor = JSON.parse(result.outputs.get('.cursor/hooks.json')!.content) as {
       hooks: { postToolUse: Array<{ command: string }> };
     };
     expect(cursor.hooks.postToolUse[0]!.command).toBe(
-      "python3 '.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate"
+      `${gitRootGuard('cursor')}cd "$PROMPTSCRIPT_PROJECT_ROOT" && python3 '.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate`
     );
     expect(result.outputs.get('.codex/hooks.json')!.content).toContain(
       "python3 '.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate"

--- a/packages/core/src/__tests__/hook-capabilities.spec.ts
+++ b/packages/core/src/__tests__/hook-capabilities.spec.ts
@@ -72,4 +72,26 @@ describe('hook capabilities', () => {
       notes: expect.stringContaining('ignores matcher values'),
     });
   });
+
+  it('classifies project-root resolution strategies for native hosts', () => {
+    expect(
+      Object.entries(HOOK_RUNTIME_CAPABILITIES)
+        .filter(([, capability]) => capability.projectRootStrategy === 'environment')
+        .map(([target]) => target)
+        .sort()
+    ).toEqual(['claude', 'factory', 'gemini', 'grok']);
+    expect(
+      Object.entries(HOOK_RUNTIME_CAPABILITIES)
+        .filter(([, capability]) => capability.projectRootStrategy === 'git-root')
+        .map(([target]) => target)
+        .sort()
+    ).toEqual(['codex', 'cursor']);
+    expect(
+      Object.entries(HOOK_RUNTIME_CAPABILITIES)
+        .filter(([, capability]) => capability.projectRootStrategy === 'native-cwd')
+        .map(([target]) => target)
+        .sort()
+    ).toEqual(['github', 'windsurf']);
+    expect(HOOK_RUNTIME_CAPABILITIES.vscode.projectRootStrategy).toBe('workspace-cwd');
+  });
 });

--- a/packages/formatters/src/__tests__/codex.spec.ts
+++ b/packages/formatters/src/__tests__/codex.spec.ts
@@ -735,23 +735,19 @@ describe('CodexFormatter', () => {
             {
               hooks: [
                 {
-                  command: 'echo hello # promptscript-generated:my-hook',
+                  command: expect.stringContaining(
+                    'PromptScript codex hook requires a Git worktree project root.'
+                  ),
+                  commandWindows: expect.stringContaining(
+                    '[string]::IsNullOrWhiteSpace($promptscriptProjectRoot)'
+                  ),
                 },
               ],
             },
           ],
         },
       });
-      expect(result.warnings).toEqual([
-        {
-          code: 'PS4002',
-          message:
-            'Hook "my-hook" requests cwd "project", which codex cannot guarantee and will ignore.',
-          suggestion:
-            'Review the generated codex hook because it will use the agent session working directory.',
-          location: createLoc(),
-        },
-      ]);
+      expect(result.warnings).toBeUndefined();
     });
 
     it('should skip agents with invalid names', () => {

--- a/packages/formatters/src/__tests__/cursor.spec.ts
+++ b/packages/formatters/src/__tests__/cursor.spec.ts
@@ -1414,16 +1414,11 @@ describe('CursorFormatter', () => {
       const parsed = JSON.parse(hooksFile!.content) as Record<string, unknown>;
       expect(parsed).toHaveProperty('version', 1);
       expect(parsed).toHaveProperty('hooks.preToolUse');
-      expect(result.warnings).toEqual([
-        {
-          code: 'PS4002',
-          message:
-            'Hook "my-hook" requests cwd "project", which cursor cannot guarantee and will ignore.',
-          suggestion:
-            'Review the generated cursor hook because it will use the agent session working directory.',
-          location: createLoc(),
-        },
-      ]);
+      expect(parsed).toHaveProperty(
+        'hooks.preToolUse.0.command',
+        expect.stringContaining('requires a Git worktree project root')
+      );
+      expect(result.warnings).toBeUndefined();
     });
 
     it.each([undefined, 'modern', 'multifile', 'legacy', 'agents-md'])(

--- a/packages/formatters/src/__tests__/hook-adapters.spec.ts
+++ b/packages/formatters/src/__tests__/hook-adapters.spec.ts
@@ -349,7 +349,7 @@ describe('hook-adapters', () => {
       const hook = (entry['hooks'] as Record<string, unknown>[])[0]!;
 
       expect(hook['command']).toBe(
-        'cd "${CLAUDE_PROJECT_DIR}"/\'tools/hook scripts\' && python3 .promptscript/scripts/check.py # promptscript-generated:test'
+        "if [ -z \"${CLAUDE_PROJECT_DIR:-}\" ]; then printf '%s\\n' 'PromptScript claude hook requires non-empty CLAUDE_PROJECT_DIR.' >&2; exit 1; fi; cd \"${CLAUDE_PROJECT_DIR}\"/'tools/hook scripts' && python3 .promptscript/scripts/check.py # promptscript-generated:test"
       );
     });
   });
@@ -653,7 +653,7 @@ describe('hook-adapters', () => {
               {
                 type: 'command',
                 command:
-                  'cd "$FACTORY_PROJECT_DIR"/\'tools/hook scripts\' && python3 .promptscript/scripts/check.py # promptscript-generated:rooted',
+                  "if [ -z \"${FACTORY_PROJECT_DIR:-}\" ]; then printf '%s\\n' 'PromptScript factory hook requires non-empty FACTORY_PROJECT_DIR.' >&2; exit 1; fi; cd \"$FACTORY_PROJECT_DIR\"/'tools/hook scripts' && python3 .promptscript/scripts/check.py # promptscript-generated:rooted",
               },
             ],
           },
@@ -731,6 +731,44 @@ describe('hook-adapters', () => {
             timeout: 15,
           },
         ],
+      });
+    });
+
+    it('pins repository scripts to the VS Code workspace cwd', () => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'script',
+          event: 'pre-tool-use',
+          script: {
+            path: '.promptscript/scripts/check.py',
+            interpreter: 'python3',
+            args: [],
+          },
+        },
+      ];
+
+      expect(generateVSCodeHooks(hooks)['PreToolUse']![0]).toMatchObject({
+        command: 'python3 .promptscript/scripts/check.py # promptscript-generated:script',
+        windows: "& 'py' '-3' '.promptscript/scripts/check.py' # promptscript-generated:script",
+        cwd: '.',
+      });
+    });
+
+    it.each([
+      ['project', '.'],
+      ['tools/hooks', 'tools/hooks'],
+    ])('maps VS Code cwd %s to %s', (cwd, expected) => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'command',
+          event: 'pre-tool-use',
+          command: ['node', 'check.mjs'],
+          cwd,
+        },
+      ];
+
+      expect(generateVSCodeHooks(hooks)['PreToolUse']![0]).toMatchObject({
+        cwd: expected,
       });
     });
 
@@ -980,6 +1018,12 @@ describe('hook-adapters', () => {
   });
 
   describe('portable repository-local scripts', () => {
+    const environmentGuard = (target: string, variable: string): string =>
+      `if [ -z "\${${variable}:-}" ]; then printf '%s\\n' 'PromptScript ${target} hook requires non-empty ${variable}.' >&2; exit 1; fi; `;
+    const gitRootGuard = (target: string): string => {
+      const failure = `printf '%s\\n' 'PromptScript ${target} hook requires a Git worktree project root.' >&2; exit 1`;
+      return `PROMPTSCRIPT_PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { ${failure}; }; case "$PROMPTSCRIPT_PROJECT_ROOT" in *[![:space:]]*) ;; *) ${failure} ;; esac; `;
+    };
     const hooks = extractHooks(
       makeHooksBlock({
         validate: {
@@ -1002,8 +1046,7 @@ describe('hook-adapters', () => {
 
       expect(handler).toEqual({
         type: 'command',
-        command:
-          "cd \"${CLAUDE_PROJECT_DIR}\"/'tools/hook scripts' && python3 \"${CLAUDE_PROJECT_DIR}\"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate",
+        command: `${environmentGuard('claude', 'CLAUDE_PROJECT_DIR')}cd "\${CLAUDE_PROJECT_DIR}"/'tools/hook scripts' && python3 "\${CLAUDE_PROJECT_DIR}"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate`,
         timeout: 2,
       });
     });
@@ -1015,8 +1058,7 @@ describe('hook-adapters', () => {
 
       expect(result.hooks['postToolUse']![0]).toEqual({
         matcher: 'Edit|Write',
-        command:
-          'PROMPTSCRIPT_PROJECT_ROOT="$(git rev-parse --show-toplevel)" && cd "$PROMPTSCRIPT_PROJECT_ROOT"/\'tools/hook scripts\' && python3 "$PROMPTSCRIPT_PROJECT_ROOT"/\'.promptscript/scripts/check file.py\' \'--label=hello world\' # promptscript-generated:validate',
+        command: `${gitRootGuard('cursor')}cd "$PROMPTSCRIPT_PROJECT_ROOT"/'tools/hook scripts' && python3 "$PROMPTSCRIPT_PROJECT_ROOT"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate`,
         timeout: 2,
       });
     });
@@ -1026,7 +1068,7 @@ describe('hook-adapters', () => {
       const handler = (entry['hooks'] as Record<string, unknown>[])[0]!;
 
       expect(handler['command']).toBe(
-        "cd \"$FACTORY_PROJECT_DIR\"/'tools/hook scripts' && python3 \"$FACTORY_PROJECT_DIR\"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate"
+        `${environmentGuard('factory', 'FACTORY_PROJECT_DIR')}cd "$FACTORY_PROJECT_DIR"/'tools/hook scripts' && python3 "$FACTORY_PROJECT_DIR"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate`
       );
       expect(handler['timeout']).toBe(2);
     });
@@ -1060,8 +1102,7 @@ describe('hook-adapters', () => {
 
       expect(handler).toEqual({
         type: 'command',
-        command:
-          "cd \"$GEMINI_PROJECT_DIR\"/'tools/hook scripts' && python3 \"$GEMINI_PROJECT_DIR\"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate",
+        command: `${environmentGuard('gemini', 'GEMINI_PROJECT_DIR')}cd "$GEMINI_PROJECT_DIR"/'tools/hook scripts' && python3 "$GEMINI_PROJECT_DIR"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate`,
         timeout: 1501,
       });
     });
@@ -1127,8 +1168,7 @@ describe('hook-adapters', () => {
 
       expect(handler).toEqual({
         type: 'command',
-        command:
-          "cd \"$GROK_WORKSPACE_ROOT\"/'tools/hook scripts' && python3 \"$GROK_WORKSPACE_ROOT\"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate",
+        command: `${environmentGuard('grok', 'GROK_WORKSPACE_ROOT')}cd "$GROK_WORKSPACE_ROOT"/'tools/hook scripts' && python3 "$GROK_WORKSPACE_ROOT"/'.promptscript/scripts/check file.py' '--label=hello world' # promptscript-generated:validate`,
         timeout: 2,
       });
     });
@@ -1201,7 +1241,9 @@ describe('hook-adapters', () => {
           {
             type: 'command',
             command: expect.stringContaining('scripts/project hook.js'),
-            commandWindows: expect.stringContaining('Set-Location $promptscriptProjectRoot'),
+            commandWindows: expect.stringContaining(
+              'Set-Location -LiteralPath $promptscriptProjectRoot -ErrorAction Stop'
+            ),
             timeout: 3,
             statusMessage: 'Checking project',
           },
@@ -1228,6 +1270,77 @@ describe('hook-adapters', () => {
         hooks: Record<string, unknown>[];
       };
       expect(sessionStart.hooks[0]).not.toHaveProperty('commandWindows');
+    });
+
+    it('guards project-relative command resources before command execution', () => {
+      const rooted: HookDefinition[] = [
+        {
+          id: 'rooted',
+          event: 'pre-tool-use',
+          command: ['node', 'check file.mjs'],
+          cwd: 'tools/hook scripts',
+        },
+      ];
+
+      const claudeEntry = generateClaudeHooks(rooted)['PreToolUse'] as Array<{
+        hooks: Array<{ command: string }>;
+      }>;
+      expect(claudeEntry[0]!.hooks[0]!.command).toBe(
+        `${environmentGuard('claude', 'CLAUDE_PROJECT_DIR')}cd "\${CLAUDE_PROJECT_DIR}"/'tools/hook scripts' && node 'check file.mjs' # promptscript-generated:rooted`
+      );
+
+      const cursor = generateCursorHooks(rooted) as {
+        hooks: { preToolUse: Array<{ command: string }> };
+      };
+      expect(cursor.hooks.preToolUse[0]!.command).toBe(
+        `${gitRootGuard('cursor')}cd "$PROMPTSCRIPT_PROJECT_ROOT"/'tools/hook scripts' && node 'check file.mjs' # promptscript-generated:rooted`
+      );
+
+      const codex = generateCodexHookConfig(rooted)['PreToolUse']![0] as {
+        hooks: Array<{ command: string; commandWindows: string }>;
+      };
+      expect(codex.hooks[0]!.command).toBe(
+        `${gitRootGuard('codex')}cd "$PROMPTSCRIPT_PROJECT_ROOT"/'tools/hook scripts' && node 'check file.mjs' # promptscript-generated:rooted`
+      );
+      expect(codex.hooks[0]!.commandWindows).toContain(
+        '$promptscriptProjectRoot = git rev-parse --show-toplevel 2>$null; if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($promptscriptProjectRoot))'
+      );
+      expect(codex.hooks[0]!.commandWindows).toContain(
+        "Set-Location -LiteralPath (Join-Path $promptscriptProjectRoot 'tools/hook scripts') -ErrorAction Stop; & 'node' 'check file.mjs'"
+      );
+      expect(codex.hooks[0]!.commandWindows).toMatch(
+        /exit 1.*Set-Location.*& 'node'.*# promptscript-generated:rooted$/
+      );
+    });
+
+    it('does not resolve a project root for commands without cwd', () => {
+      const unrooted: HookDefinition[] = [
+        {
+          id: 'unrooted',
+          event: 'pre-tool-use',
+          command: ['node', 'check.mjs'],
+        },
+      ];
+
+      const claudeEntry = generateClaudeHooks(unrooted)['PreToolUse'] as Array<{
+        hooks: Array<{ command: string }>;
+      }>;
+      expect(claudeEntry[0]!.hooks[0]!.command).toBe(
+        'node check.mjs # promptscript-generated:unrooted'
+      );
+      const cursor = generateCursorHooks(unrooted) as {
+        hooks: { preToolUse: Array<{ command: string }> };
+      };
+      expect(cursor.hooks.preToolUse[0]!.command).toBe(
+        'node check.mjs # promptscript-generated:unrooted'
+      );
+      const codex = generateCodexHookConfig(unrooted)['PreToolUse']![0] as {
+        hooks: Array<{ command: string; commandWindows: string }>;
+      };
+      expect(codex.hooks[0]).toMatchObject({
+        command: 'node check.mjs # promptscript-generated:unrooted',
+        commandWindows: "& 'node' 'check.mjs' # promptscript-generated:unrooted",
+      });
     });
 
     it('quotes script paths and metacharacter arguments for Unix and Windows', () => {
@@ -1397,7 +1510,7 @@ describe('hook-adapters', () => {
     });
 
     it.each(['cursor', 'codex'] as const)(
-      'warns when %s cannot guarantee a requested working directory',
+      'guards %s command cwd without a project-root warning',
       (target) => {
         const hooks = extractHooks(
           makeHooksBlock({
@@ -1416,17 +1529,51 @@ describe('hook-adapters', () => {
         ).toEqual(
           target === 'cursor'
             ? [
-                'Hook "rooted" requests cwd "project", which cursor cannot guarantee and will ignore.',
                 'Hook "rooted" uses statusMessage, which cursor cannot represent and will omit.',
                 'Hook "rooted" uses continueOnFailure, which cursor cannot represent and will omit.',
               ]
-            : [
-                'Hook "rooted" requests cwd "project", which codex cannot guarantee and will ignore.',
-                'Hook "rooted" uses continueOnFailure, which codex cannot represent and will omit.',
-              ]
+            : ['Hook "rooted" uses continueOnFailure, which codex cannot represent and will omit.']
         );
       }
     );
+
+    it.each(['github', 'windsurf'] as const)('reports the %s native cwd guarantee', (target) => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'rooted',
+          event: 'post-tool-use',
+          script: {
+            path: '.promptscript/scripts/check.py',
+            interpreter: 'python3',
+            args: [],
+          },
+        },
+      ];
+
+      expect(getHookCompatibilityWarnings(hooks, target)).toContainEqual({
+        code: 'PS4002',
+        message: `Hook "rooted" relies on ${target} native cwd, so PromptScript cannot independently guarantee project-root execution.`,
+        suggestion: `Ensure ${target} provides the configured repository cwd before running the hook.`,
+      });
+    });
+
+    it('reports the VS Code workspace cwd guarantee', () => {
+      const hooks: HookDefinition[] = [
+        {
+          id: 'rooted',
+          event: 'post-tool-use',
+          cwd: 'project',
+          command: ['node', 'check.mjs'],
+        },
+      ];
+
+      expect(getHookCompatibilityWarnings(hooks, 'vscode')).toContainEqual({
+        code: 'PS4002',
+        message:
+          'Hook "rooted" relies on vscode workspace cwd, so PromptScript cannot independently guarantee project-root execution.',
+        suggestion: 'Ensure vscode provides the configured repository cwd before running the hook.',
+      });
+    });
 
     it('warns when a Windows-capable target cannot invoke a shell interpreter', () => {
       const hooks = extractHooks(

--- a/packages/formatters/src/hook-adapters.ts
+++ b/packages/formatters/src/hook-adapters.ts
@@ -1,6 +1,7 @@
 import {
   HOOK_RUNTIME_CAPABILITIES,
   type HookCapability,
+  type HookProjectRootStrategy,
   type PortableHookInterpreter,
   type Value,
 } from '@promptscript/core';
@@ -86,6 +87,8 @@ export interface HookScriptDefinition {
 // (/# promptscript-generated:[A-Za-z0-9._-]+\s*$/); keep both sides in sync.
 const HOOK_OWNERSHIP_MARKER = '# promptscript-generated';
 const SHELL_SAFE_ARGUMENT = /^[A-Za-z0-9_@%+=:,./-]+$/;
+type EnvironmentRootTarget = 'claude' | 'factory' | 'gemini' | 'grok';
+type GitRootTarget = 'cursor' | 'codex';
 
 function quotePosixArgument(argument: string): string {
   return SHELL_SAFE_ARGUMENT.test(argument) ? argument : `'${argument.replace(/'/g, `'"'"'`)}'`;
@@ -113,17 +116,54 @@ function serializeOwnedCommand(
   return `${prefix}${getCommandArguments(hook).map(quoteArgument).join(' ')} ${HOOK_OWNERSHIP_MARKER}:${safeId}`;
 }
 
-function projectRootExpression(target: 'claude' | 'factory' | 'gemini' | 'grok'): string {
-  if (target === 'claude') return '"${CLAUDE_PROJECT_DIR}"';
-  if (target === 'factory') return '"$FACTORY_PROJECT_DIR"';
-  if (target === 'gemini') return '"$GEMINI_PROJECT_DIR"';
-  return '"$GROK_WORKSPACE_ROOT"';
+function projectRootVariable(target: EnvironmentRootTarget): string {
+  if (target === 'claude') return 'CLAUDE_PROJECT_DIR';
+  if (target === 'factory') return 'FACTORY_PROJECT_DIR';
+  if (target === 'gemini') return 'GEMINI_PROJECT_DIR';
+  return 'GROK_WORKSPACE_ROOT';
 }
 
-function projectCwdPrefix(
-  hook: HookDefinition,
-  target: 'claude' | 'factory' | 'gemini' | 'grok'
-): string {
+function projectRootExpression(target: EnvironmentRootTarget): string {
+  if (target === 'claude') return '"${CLAUDE_PROJECT_DIR}"';
+  return `"$${projectRootVariable(target)}"`;
+}
+
+function serializeRequiredEnvRootGuard(target: EnvironmentRootTarget): string {
+  const variable = projectRootVariable(target);
+  const message = quotePosixArgument(`PromptScript ${target} hook requires non-empty ${variable}.`);
+  return `if [ -z "\${${variable}:-}" ]; then printf '%s\\n' ${message} >&2; exit 1; fi; `;
+}
+
+function serializeGitRootGuard(target: GitRootTarget): string {
+  const message = quotePosixArgument(
+    `PromptScript ${target} hook requires a Git worktree project root.`
+  );
+  const failure = `printf '%s\\n' ${message} >&2; exit 1`;
+  return `PROMPTSCRIPT_PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { ${failure}; }; case "$PROMPTSCRIPT_PROJECT_ROOT" in *[![:space:]]*) ;; *) ${failure} ;; esac; `;
+}
+
+function serializePowerShellGitRootGuard(target: 'codex'): string {
+  const message = quotePowerShellArgument(
+    `PromptScript ${target} hook requires a Git worktree project root.`
+  );
+  return `$promptscriptProjectRoot = git rev-parse --show-toplevel 2>$null; if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($promptscriptProjectRoot)) { [Console]::Error.WriteLine(${message}); exit 1 }; `;
+}
+
+const HOST_CWD_STRATEGIES = {
+  environment: false,
+  'git-root': false,
+  'native-cwd': true,
+  'workspace-cwd': true,
+  none: false,
+} as const satisfies Record<HookProjectRootStrategy, boolean>;
+
+function isHostCwdStrategy(
+  strategy: HookProjectRootStrategy
+): strategy is 'native-cwd' | 'workspace-cwd' {
+  return HOST_CWD_STRATEGIES[strategy];
+}
+
+function projectCwdPrefix(hook: HookDefinition, target: EnvironmentRootTarget): string {
   if (!hook.cwd) return '';
 
   const root = projectRootExpression(target);
@@ -133,10 +173,14 @@ function projectCwdPrefix(
 
 function serializeProjectScriptCommand(
   hook: HookDefinition,
-  target: 'claude' | 'factory' | 'gemini' | 'grok'
+  target: EnvironmentRootTarget
 ): string {
+  const prefix =
+    hook.script || hook.cwd
+      ? `${serializeRequiredEnvRootGuard(target)}${projectCwdPrefix(hook, target)}`
+      : '';
   if (!hook.script) {
-    return serializeOwnedCommand(hook, quotePosixArgument, projectCwdPrefix(hook, target));
+    return serializeOwnedCommand(hook, quotePosixArgument, prefix);
   }
 
   const root = projectRootExpression(target);
@@ -146,26 +190,31 @@ function serializeProjectScriptCommand(
     ...hook.script.args.map(quotePosixArgument),
   ].join(' ');
   const marker = ` ${HOOK_OWNERSHIP_MARKER}:${hook.id.replace(/[^A-Za-z0-9._-]/g, '-')}`;
-  return `${projectCwdPrefix(hook, target)}${invocation}${marker}`;
+  return `${prefix}${invocation}${marker}`;
 }
 
-function serializeGitRootScriptCommand(hook: HookDefinition): string {
-  if (!hook.script) {
+function serializeGitRootScriptCommand(hook: HookDefinition, target: GitRootTarget): string {
+  if (!hook.script && !hook.cwd) {
     return serializeOwnedCommand(hook);
   }
 
   const root = '"$PROMPTSCRIPT_PROJECT_ROOT"';
+  const guard = serializeGitRootGuard(target);
   const cwd =
     hook.cwd === undefined
       ? ''
       : `cd ${hook.cwd === 'project' ? root : `${root}/${quotePosixArgument(hook.cwd)}`} && `;
+  if (!hook.script) {
+    return serializeOwnedCommand(hook, quotePosixArgument, `${guard}${cwd}`);
+  }
+
   const invocation = [
     ...getPosixInterpreter(hook.script.interpreter).map(quotePosixArgument),
     `${root}/${quotePosixArgument(hook.script.path)}`,
     ...hook.script.args.map(quotePosixArgument),
   ].join(' ');
   const marker = ` ${HOOK_OWNERSHIP_MARKER}:${hook.id.replace(/[^A-Za-z0-9._-]/g, '-')}`;
-  return `PROMPTSCRIPT_PROJECT_ROOT="$(git rev-parse --show-toplevel)" && ${cwd}${invocation}${marker}`;
+  return `${guard}${cwd}${invocation}${marker}`;
 }
 
 function getWindowsInterpreter(interpreter: PortableHookInterpreter): string[] | null {
@@ -175,9 +224,22 @@ function getWindowsInterpreter(interpreter: PortableHookInterpreter): string[] |
   return [interpreter];
 }
 
-function serializePowerShellScriptCommand(hook: HookDefinition): string | null {
-  if (!hook.script) {
+function serializePowerShellScriptCommand(hook: HookDefinition, target: 'codex'): string | null {
+  if (!hook.script && !hook.cwd) {
     return serializeOwnedCommand(hook, quotePowerShellArgument, '& ');
+  }
+
+  const guard = serializePowerShellGitRootGuard(target);
+  const cwd =
+    hook.cwd === undefined
+      ? ''
+      : `Set-Location -LiteralPath ${
+          hook.cwd === 'project'
+            ? '$promptscriptProjectRoot'
+            : `(Join-Path $promptscriptProjectRoot ${quotePowerShellArgument(hook.cwd)})`
+        } -ErrorAction Stop; `;
+  if (!hook.script) {
+    return serializeOwnedCommand(hook, quotePowerShellArgument, `${guard}${cwd}& `);
   }
 
   const interpreter = getWindowsInterpreter(hook.script.interpreter);
@@ -191,16 +253,7 @@ function serializePowerShellScriptCommand(hook: HookDefinition): string | null {
     ...hook.script.args.map(quotePowerShellArgument),
   ].join(' ');
   const marker = ` ${HOOK_OWNERSHIP_MARKER}:${hook.id.replace(/[^A-Za-z0-9._-]/g, '-')}`;
-
-  const cwd =
-    hook.cwd === undefined
-      ? ''
-      : `Set-Location ${
-          hook.cwd === 'project'
-            ? '$promptscriptProjectRoot'
-            : `(Join-Path $promptscriptProjectRoot ${quotePowerShellArgument(hook.cwd)})`
-        }; `;
-  return `$promptscriptProjectRoot = git rev-parse --show-toplevel; ${cwd}${invocation}${marker}`;
+  return `${guard}${cwd}${invocation}${marker}`;
 }
 
 function getScriptPathFromNativeCwd(hook: HookDefinition): string {
@@ -596,7 +649,7 @@ export function generateCursorHooks(hooks: HookDefinition[]): Record<string, unk
 
     result[nativeEvent].push({
       matcher: getEffectiveMatcher(hook, 'cursor') ?? '.*',
-      command: serializeGitRootScriptCommand(hook),
+      command: serializeGitRootScriptCommand(hook, 'cursor'),
       timeout: hook.timeoutMs ? convertTimeout(hook.timeoutMs, 'cursor') : 10,
     });
   }
@@ -704,11 +757,13 @@ export function getHookCompatibilityWarnings(
       });
     }
 
-    if (hook.cwd && !hook.script && (target === 'cursor' || target === 'codex')) {
+    if ((hook.script || hook.cwd) && isHostCwdStrategy(capability.projectRootStrategy)) {
+      const strategy =
+        capability.projectRootStrategy === 'native-cwd' ? 'native cwd' : 'workspace cwd';
       warnings.push({
         code: 'PS4002',
-        message: `Hook "${hook.id}" requests cwd "${hook.cwd}", which ${target} cannot guarantee and will ignore.`,
-        suggestion: `Review the generated ${target} hook because it will use the agent session working directory.`,
+        message: `Hook "${hook.id}" relies on ${target} ${strategy}, so PromptScript cannot independently guarantee project-root execution.`,
+        suggestion: `Ensure ${target} provides the configured repository cwd before running the hook.`,
       });
     }
 
@@ -830,7 +885,9 @@ export function generateVSCodeHooks(hooks: HookDefinition[]): Record<string, unk
       command,
       ...(windows ? { windows } : {}),
       ...(matcher ? { matcher } : {}),
-      ...(hook.cwd ? { cwd: hook.cwd === 'project' ? '.' : hook.cwd } : {}),
+      ...(hook.cwd || hook.script
+        ? { cwd: !hook.cwd || hook.cwd === 'project' ? '.' : hook.cwd }
+        : {}),
       ...(hook.timeoutMs ? { timeout: convertTimeout(hook.timeoutMs, 'vscode') } : {}),
     });
   }
@@ -856,9 +913,7 @@ export function generateGeminiHooks(hooks: HookDefinition[]): Record<string, unk
       hooks: [
         {
           type: 'command',
-          command: hook.script
-            ? serializeProjectScriptCommand(hook, 'gemini')
-            : serializeOwnedCommand(hook, quotePosixArgument, projectCwdPrefix(hook, 'gemini')),
+          command: serializeProjectScriptCommand(hook, 'gemini'),
           ...(hook.timeoutMs ? { timeout: convertTimeout(hook.timeoutMs, 'gemini') } : {}),
         },
       ],
@@ -911,9 +966,7 @@ export function generateGrokHooks(hooks: HookDefinition[]): Record<string, unkno
       hooks: [
         {
           type: 'command',
-          command: hook.script
-            ? serializeProjectScriptCommand(hook, 'grok')
-            : serializeOwnedCommand(hook, quotePosixArgument, projectCwdPrefix(hook, 'grok')),
+          command: serializeProjectScriptCommand(hook, 'grok'),
           ...(hook.timeoutMs ? { timeout: convertTimeout(hook.timeoutMs, 'grok') } : {}),
         },
       ],
@@ -939,11 +992,9 @@ export function generateCodexHooks(hooks: HookDefinition[]): string {
     if (matcher) lines.push(`matcher = "${escapeTomlHookString(matcher)}"`);
     lines.push(`[[hooks.${nativeEvent}.hooks]]`);
     lines.push('type = "command"');
-    const command = hook.script ? serializeGitRootScriptCommand(hook) : serializeOwnedCommand(hook);
+    const command = serializeGitRootScriptCommand(hook, 'codex');
     lines.push(`command = "${escapeTomlHookString(command)}"`);
-    const commandWindows = hook.script
-      ? serializePowerShellScriptCommand(hook)
-      : serializeOwnedCommand(hook, quotePowerShellArgument, '& ');
+    const commandWindows = serializePowerShellScriptCommand(hook, 'codex');
     if (commandWindows) {
       lines.push(`command_windows = "${escapeTomlHookString(commandWindows)}"`);
     }
@@ -969,10 +1020,8 @@ export function generateCodexHookConfig(hooks: HookDefinition[]): Record<string,
     if (!nativeEvent) continue;
 
     const matcher = getEffectiveMatcher(hook, 'codex');
-    const command = hook.script ? serializeGitRootScriptCommand(hook) : serializeOwnedCommand(hook);
-    const commandWindows = hook.script
-      ? serializePowerShellScriptCommand(hook)
-      : serializeOwnedCommand(hook, quotePowerShellArgument, '& ');
+    const command = serializeGitRootScriptCommand(hook, 'codex');
+    const commandWindows = serializePowerShellScriptCommand(hook, 'codex');
     const handler = {
       type: 'command',
       command,

--- a/skills/promptscript/SKILL.md
+++ b/skills/promptscript/SKILL.md
@@ -519,6 +519,9 @@ Portable events:
 
 `cwd: "project"` runs from project root. Other values are portable forward-slash
 paths relative to project root. Hook config file location does not set command cwd.
+Environment-root and Git-root wrappers exit before script or command execution when
+the required root is unavailable. Native-cwd and workspace-cwd targets retain host
+cwd fields and report `PS4002` when PromptScript cannot verify that cwd.
 `timeoutMs` range is 100-600000. `matcher` uses target-native tool names, so a
 matcher valid for one target may match nothing on another.
 


### PR DESCRIPTION
## Summary
- require non-empty Claude, Factory, Gemini, and Grok project-root variables before project-relative hook resources execute
- reject failed, empty, and whitespace-only Git roots for Cursor and Codex POSIX wrappers
- check Codex PowerShell Git resolution with `$LASTEXITCODE` and `IsNullOrWhiteSpace` before cwd changes or execution
- apply root guards to both portable scripts and command arrays with `cwd`, while leaving commands without `cwd` unchanged
- preserve GitHub and Windsurf native cwd plus VS Code workspace cwd, with explicit `PS4002` guarantee warnings
- pin script-only VS Code hooks to workspace cwd
- document fail-closed behavior without any session cwd fallback

## Validation
- `pnpm nx affected -t test --coverage --base=origin/main`
- `pnpm nx test formatters --coverage` (all changed statements, branches, and functions covered)
- `pnpm nx test compiler -- --run src/__tests__/hooks-targets.smoke.spec.ts`
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:formatters`
- `pnpm docs:validate:check`
- `pnpm docs:build`

Closes #346
