### PR TITLE
feat(core): add explicit override operations

### DIFF
--- a/.claude/skills/promptscript/SKILL.md
+++ b/.claude/skills/promptscript/SKILL.md
@@ -747,16 +747,38 @@ Replacement works after `@inherit` and `@use`, including aliases and nested targ
 A missing field is set. The modifier is rejected for `@skills`, which retain their dedicated
 merge and sealing semantics.
 
+#### Replacing complete targets with @override
+
+Syntax `1.6.0` adds atomic replacement for an existing block or nested value:
+
+```
+@meta { id: "project" syntax: "1.6.0" }
+
+@standards {
+  testing: ["Use Jest", "Use Mocha"]
+}
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+```
+
+`@override` requires the complete target path to exist, applies in declaration
+order, and cannot bypass sealed skill properties. Later `@extend` declarations
+merge into the replacement. Use `@extend` for additive changes, `field!` for
+compatibility replacement of one direct regular field, and `@override` for
+intentional complete replacement.
+
 #### Skill-aware @extend semantics
 
 When extending a skill definition via `@extend`, individual skill properties follow specific merge
 strategies rather than the generic block merge rules:
 
-| Strategy          | Properties                                                                                         |
-| ----------------- | -------------------------------------------------------------------------------------------------- |
-| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent |
-| **Append**        | references, examples, requires                                                                     |
-| **Shallow merge** | params, inputs, outputs                                                                            |
+| Strategy          | Properties                                                                                                  |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent, license |
+| **Append**        | references, examples, requires                                                                              |
+| **Shallow merge** | params, inputs, outputs                                                                                     |
 
 Example — extending a base skill to add references and override content:
 
@@ -1007,6 +1029,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
 | `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
+| `1.6.0` | Adds atomic block and nested value replacement with contextual `@override`                                              |
 
 ### Block Version Requirements
 
@@ -1022,6 +1045,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
 Generated section title overrides with `@header` require syntax `1.5.0`.
+Atomic replacement with `@override` requires syntax `1.6.0`.
 
 ### Generated Section Headers
 

--- a/.promptscript/skills/promptscript/SKILL.md
+++ b/.promptscript/skills/promptscript/SKILL.md
@@ -747,16 +747,38 @@ Replacement works after `@inherit` and `@use`, including aliases and nested targ
 A missing field is set. The modifier is rejected for `@skills`, which retain their dedicated
 merge and sealing semantics.
 
+#### Replacing complete targets with @override
+
+Syntax `1.6.0` adds atomic replacement for an existing block or nested value:
+
+```
+@meta { id: "project" syntax: "1.6.0" }
+
+@standards {
+  testing: ["Use Jest", "Use Mocha"]
+}
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+```
+
+`@override` requires the complete target path to exist, applies in declaration
+order, and cannot bypass sealed skill properties. Later `@extend` declarations
+merge into the replacement. Use `@extend` for additive changes, `field!` for
+compatibility replacement of one direct regular field, and `@override` for
+intentional complete replacement.
+
 #### Skill-aware @extend semantics
 
 When extending a skill definition via `@extend`, individual skill properties follow specific merge
 strategies rather than the generic block merge rules:
 
-| Strategy          | Properties                                                                                         |
-| ----------------- | -------------------------------------------------------------------------------------------------- |
-| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent |
-| **Append**        | references, examples, requires                                                                     |
-| **Shallow merge** | params, inputs, outputs                                                                            |
+| Strategy          | Properties                                                                                                  |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent, license |
+| **Append**        | references, examples, requires                                                                              |
+| **Shallow merge** | params, inputs, outputs                                                                                     |
 
 Example — extending a base skill to add references and override content:
 
@@ -1007,6 +1029,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
 | `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
+| `1.6.0` | Adds atomic block and nested value replacement with contextual `@override`                                              |
 
 ### Block Version Requirements
 
@@ -1022,6 +1045,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
 Generated section title overrides with `@header` require syntax `1.5.0`.
+Atomic replacement with `@override` requires syntax `1.6.0`.
 
 ### Generated Section Headers
 

--- a/apps/vscode/syntaxes/promptscript.tmLanguage.json
+++ b/apps/vscode/syntaxes/promptscript.tmLanguage.json
@@ -5,6 +5,7 @@
   "patterns": [
     { "include": "#comment" },
     { "include": "#registry-import" },
+    { "include": "#override-directive" },
     { "include": "#control-directive" },
     { "include": "#block-directive" },
     { "include": "#url-import" },
@@ -37,6 +38,10 @@
     },
     "control-directive": {
       "match": "@(?:meta|inherit|use|extend|header)\\b",
+      "name": "keyword.control.directive.prs"
+    },
+    "override-directive": {
+      "match": "@override(?=\\s+[a-zA-Z_][\\w-]*(?:\\.[a-zA-Z_][\\w-]*)*\\s*\\{)",
       "name": "keyword.control.directive.prs"
     },
     "block-directive": {

--- a/docs/__snapshots__/docs/guides/migration.md/migrated-project_L871/claude.md
+++ b/docs/__snapshots__/docs/guides/migration.md/migrated-project_L871/claude.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## Code Style
+
+- Use Vitest

--- a/docs/__snapshots__/docs/guides/migration.md/migrated-project_L871/cursor.mdc
+++ b/docs/__snapshots__/docs/guides/migration.md/migrated-project_L871/cursor.mdc
@@ -1,0 +1,9 @@
+---
+description: "Project-specific rules"
+alwaysApply: true
+---
+
+You are working on the project.
+
+Code style:
+- Use Vitest

--- a/docs/__snapshots__/docs/guides/migration.md/migrated-project_L871/github.md
+++ b/docs/__snapshots__/docs/guides/migration.md/migrated-project_L871/github.md
@@ -1,0 +1,7 @@
+# GitHub Copilot Instructions
+
+## code-standards
+
+### testing
+
+- Use Vitest

--- a/docs/__snapshots__/docs/reference/language.md/override-shapes_L2267/claude.md
+++ b/docs/__snapshots__/docs/reference/language.md/override-shapes_L2267/claude.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+## Project
+
+New identity
+
+## Code Style
+
+- Use Vitest
+- Document failures
+
+## Config Files
+
+- Retries: 3
+
+## Don'ts
+
+- No unsafe casts

--- a/docs/__snapshots__/docs/reference/language.md/override-shapes_L2267/cursor.mdc
+++ b/docs/__snapshots__/docs/reference/language.md/override-shapes_L2267/cursor.mdc
@@ -1,0 +1,16 @@
+---
+description: "Project-specific rules"
+alwaysApply: true
+---
+
+You are working on New identity.
+
+Code style:
+- Use Vitest
+- Document failures
+
+Config:
+- retries: 3
+
+Never:
+- No unsafe casts

--- a/docs/__snapshots__/docs/reference/language.md/override-shapes_L2267/github.md
+++ b/docs/__snapshots__/docs/reference/language.md/override-shapes_L2267/github.md
@@ -1,0 +1,19 @@
+# GitHub Copilot Instructions
+
+## project
+
+New identity
+
+## code-standards
+
+### testing
+
+- Use Vitest
+
+### items
+
+- Document failures
+
+## donts
+
+- No unsafe casts

--- a/docs/guides/inheritance.md
+++ b/docs/guides/inheritance.md
@@ -368,11 +368,11 @@ The `@extend` block modifies specific paths:
 When `@extend` targets a skill definition, individual skill properties follow dedicated merge
 strategies rather than the generic block merge rules:
 
-| Strategy          | Properties                                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **Replace**       | `content`, `description`, `trigger`, `userInvocable`, `allowedTools`, `disableModelInvocation`, `context`, `agent` |
-| **Append**        | `references`, `examples`, `requires`                                                                               |
-| **Shallow merge** | `params`, `inputs`, `outputs`                                                                                      |
+| Strategy          | Properties                                                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Replace**       | `content`, `description`, `trigger`, `userInvocable`, `allowedTools`, `disableModelInvocation`, `context`, `agent`, `license` |
+| **Append**        | `references`, `examples`, `requires`                                                                                          |
+| **Shallow merge** | `params`, `inputs`, `outputs`                                                                                                 |
 
 Example — overlay content and add a reference file without replacing the base skill's references:
 
@@ -1019,3 +1019,27 @@ Warning: Requested @company/base@2.0.0, found 1.5.0
 ```
 
 Update version constraints or registry.
+
+## Replacing Complete Values
+
+Use `@extend` when inherited content should be merged. Use `@override` with
+syntax `1.6.0` when the complete existing value should be replaced:
+
+```text
+@meta { id: "project" syntax: "1.6.0" }
+@inherit @company/base
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+
+@extend standards {
+  testing: ["Require coverage"]
+}
+```
+
+The target must exist after preceding declarations are applied. Replacement is
+atomic, and later declarations operate on the replacement. `field!` remains
+supported for replacing one direct regular field inside `@extend`, but new code
+should use `@override` when complete replacement is the intended operation.
+Sealed skill properties cannot be replaced or removed.

--- a/docs/guides/migration.md
+++ b/docs/guides/migration.md
@@ -860,6 +860,29 @@ Modify inherited blocks at specific paths:
 }
 ```
 
+Choose modification syntax by migration intent:
+
+- Keep `@extend` when old and new values should merge or append.
+- Keep `field!` as a compatibility form for replacing one direct regular
+  field inside `@extend`.
+- Use `@override` with syntax `1.6.0` when one complete existing block or
+  nested value must replace the previous value.
+
+```promptscript
+@meta { id: "migrated-project" syntax: "1.6.0" }
+
+@standards {
+  testing: ["Use Jest", "Use Mocha"]
+}
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+```
+
+Unlike `field!`, `@override` requires the complete target path to exist. It
+cannot bypass sealed skill properties.
+
 <!-- playground-link-start -->
 <a href="https://getpromptscript.dev/playground/?s=N4IgZglgNgpgziAXAbVABwIYBcAWSQwAeGAtmrAHRoBOCANCAMYD2AdljO-gMQAEAAhFY4Y1CFgEsyGVgE8A9ACMMcGL158AFNRgBzCHCzVZvALS8AJgYyLYF3mGbVe5DLN3VmAV1YWAlAA6rHwAghb2WMy8RAZYQrq8EBaccViyQfxEHL6JyeziJsBB6gEgpeWs6mFWcWwYUNGEaKJxqomVAEowGIwSyQBuMFDMaCQpFMW85WVlrAC+QUF8ALLMVmAmrPAc9oYyFhjUFnAZWZy7WPuHxxQsyRQchvG8RZUO1KQwAO5OANaIUxA-XE2wq6hYgw+uhgAIAnAAGIILVhLXjVXiRXg6QxiXoQNhwXiHD7pViZQjZezYowQPEEl6TcylACqbTAPjprHqvCkaDYKUJbCg6Vm6iZIAAclFGFAVHBTMpVPZefz2CdZnMQHMALoMFLGfBEUjkGBUWggBiQuD41j4ACMWqAA" target="_blank" rel="noopener noreferrer">
   <img src="https://img.shields.io/badge/Try_in-Playground-blue?style=flat-square" alt="Try in Playground" />

--- a/docs/guides/skill-overlays.md
+++ b/docs/guides/skill-overlays.md
@@ -63,11 +63,11 @@ Result: `description` = `"Travel review"` (last replace wins), `references` incl
 
 When `@extend` targets a skill, each property follows a specific merge strategy:
 
-| Strategy          | Properties                                                                                                         | Behavior                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
-| **Replace**       | `content`, `description`, `trigger`, `userInvocable`, `allowedTools`, `disableModelInvocation`, `context`, `agent` | Extension value wins outright    |
-| **Append**        | `references`, `requires`                                                                                           | Extension entries added to base  |
-| **Shallow merge** | `params`, `inputs`, `outputs`                                                                                      | Extension keys added/overwritten |
+| Strategy          | Properties                                                                                                                    | Behavior                         |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| **Replace**       | `content`, `description`, `trigger`, `userInvocable`, `allowedTools`, `disableModelInvocation`, `context`, `agent`, `license` | Extension value wins outright    |
+| **Append**        | `references`, `requires`                                                                                                      | Extension entries added to base  |
+| **Shallow merge** | `params`, `inputs`, `outputs`                                                                                                 | Extension keys added/overwritten |
 
 ### Replace Example
 

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -125,7 +125,8 @@ The `syntax` field in `@meta` declares which version of the PromptScript languag
 | `1.2.0` | Stable  | All 1.1.0 blocks + `@examples`                                                                                                             |
 | `1.3.0` | Stable  | All 1.2.0 features + regular block field replacement in `@extend`                                                                          |
 | `1.4.0` | Stable  | All 1.3.0 features + `@hooks`, `@mcpServers`, `@plugins`                                                                                   |
-| `1.5.0` | Current | All 1.4.0 features + generated section title overrides with contextual `@header`                                                           |
+| `1.5.0` | Stable  | All 1.4.0 features + generated section title overrides with contextual `@header`                                                           |
+| `1.6.0` | Current | All 1.5.0 features + atomic replacement with contextual `@override`                                                                        |
 
 !!! note "Block Availability"
 `@workflows` emits workflow files such as `.claude/workflows/<name>.md`.
@@ -144,8 +145,7 @@ The `syntax` field in `@meta` declares which version of the PromptScript languag
 | `@plugins`    | `1.4.0`                |
 
 All other built-in blocks are available from `1.0.0`.
-
-Regular block field replacement with `field!: value` requires syntax `1.3.0`. Generated section title overrides with `@header` require syntax `1.5.0`.
+Regular block field replacement with `field!: value` requires syntax `1.3.0`. Generated section title overrides with `@header` require syntax `1.5.0`. Atomic target replacement with `@override` requires syntax `1.6.0`.
 
 ### Validation (PS018, PS019)
 
@@ -1548,11 +1548,11 @@ because a replacement and a fallback default are mutually exclusive.
 
 When `@extend` targets a skill definition inside `@skills`, properties follow dedicated merge strategies:
 
-| Strategy          | Properties                                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **Replace**       | `content`, `description`, `trigger`, `userInvocable`, `allowedTools`, `disableModelInvocation`, `context`, `agent` |
-| **Append**        | `references`, `requires`                                                                                           |
-| **Shallow merge** | `params`, `inputs`, `outputs`                                                                                      |
+| Strategy          | Properties                                                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Replace**       | `content`, `description`, `trigger`, `userInvocable`, `allowedTools`, `disableModelInvocation`, `context`, `agent`, `license` |
+| **Append**        | `references`, `requires`                                                                                                      |
+| **Shallow merge** | `params`, `inputs`, `outputs`                                                                                                 |
 
 ### Reference Negation
 
@@ -2208,3 +2208,80 @@ wrapper falls back to the process working directory.
 See [Block Shapes](block-shapes.md) for the canonical shape, compatibility
 forms, merge rules, diagnostics, and formatter behavior of every built-in
 block.
+
+## Atomic Replacement with @override
+
+Syntax `1.6.0` adds `@override` for replacing a complete existing target:
+
+```text
+@standards {
+  testing: ["Use Jest", "Use Mocha"]
+  tooling: { runner: "jest" coverage: 80 }
+}
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+
+@override standards.tooling.runner {
+  "vitest"
+}
+
+@extend standards {
+  testing: ["Require coverage"]
+}
+```
+
+`@override standards.testing` replaces the complete array. The later `@extend`
+then adds to that replacement. A root override replaces the complete block body:
+
+```text
+@override standards {
+  testing: ["Use Vitest"]
+}
+```
+
+Root replacements accept regular text, object, array, or mixed block bodies.
+Nested replacements also accept standalone object, string, number, boolean, and
+`null` values. The complete target path must already exist when the operation
+runs. Missing targets and traversal through scalar values are errors.
+
+Operations use declaration order in syntax `1.6.0`. This includes `@inherit`,
+top-level `@use`, local blocks, `@extend`, and `@override`. An `@override` used
+with an older declared syntax also uses declaration order so replacement remains
+deterministic, while PS018 requests a syntax upgrade.
+
+Use the forms according to intent:
+
+| Form        | Behavior                                                       |
+| ----------- | -------------------------------------------------------------- |
+| `@extend`   | Add or merge content using the target shape's merge policy.    |
+| `field!`    | Compatibility replacement for one direct regular extend field. |
+| `@override` | Replace one complete existing block or nested target value.    |
+
+`@override` cannot change or remove sealed skill properties. `@override { ... }`
+without a target remains a legal custom block named `override`.
+
+This complete example exercises root and nested replacement shapes:
+
+```promptscript
+@meta { id: "override-shapes" syntax: "1.6.0" }
+
+@identity { """Old identity""" }
+@restrictions { - "Old restriction" }
+@standards {
+  testing: ["Use Jest"]
+  config: { enabled: true retries: 1 }
+}
+
+@override identity { "New identity" }
+@override restrictions { ["No unsafe casts"] }
+@override standards {
+  """Required engineering rules."""
+  testing: ["Use Vitest"]
+  config: { enabled: true retries: 1 }
+  - "Document failures"
+}
+@override standards.config.enabled { false }
+@override standards.config.retries { 3 }
+```

--- a/docs_extensions/promptscript_lexer.py
+++ b/docs_extensions/promptscript_lexer.py
@@ -40,6 +40,7 @@ BLOCK_DIRECTIVES = (
 )
 
 CONTEXTUAL_DIRECTIVES = ("header",)
+CONTEXTUAL_OPERATION_DIRECTIVES = ("override",)
 
 ENV_VAR_PATTERN = r"\$\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\}"
 TEMPLATE_VAR_PATTERN = r"(\{\{)([A-Za-z_][A-Za-z0-9_]*)(\}\})"
@@ -83,6 +84,11 @@ class PromptScriptLexer(RegexLexer):
             # Extend statement with a dotted target
             (
                 r"(@extend)(\s+)([A-Za-z_][\w-]*(?:\.[A-Za-z_][\w-]*)*)",
+                bygroups(Keyword.Namespace, Whitespace, String),
+            ),
+            # Override statement with a dotted target
+            (
+                r"(@override)(\s+)([A-Za-z_][\w-]*(?:\.[A-Za-z_][\w-]*)*)",
                 bygroups(Keyword.Namespace, Whitespace, String),
             ),
             # Meta directive

--- a/packages/browser-compiler/src/__tests__/compiler.spec.ts
+++ b/packages/browser-compiler/src/__tests__/compiler.spec.ts
@@ -183,6 +183,85 @@ describe('compile', () => {
     );
   });
 
+  it('should report explicit overrides declared below syntax 1.6.0', async () => {
+    const files = {
+      'project.prs': `@meta { id: "test" syntax: "1.5.0" }
+@standards { testing: ["Use Jest"] }
+@override standards.testing { ["Use Vitest"] }
+`,
+    };
+
+    const result = await compile(files, 'project.prs');
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        ruleId: 'PS018',
+        message: expect.stringContaining('explicit-override'),
+        location: expect.objectContaining({ file: 'project.prs', line: 3, column: 1 }),
+      }),
+    ]);
+  });
+
+  it('should retain syntax warnings when explicit override resolution fails', async () => {
+    const files = {
+      'project.prs': `@meta { id: "test" syntax: "1.5.0" }
+@standards { testing: ["Use Jest"] }
+@override standards.missing { true }
+`,
+    };
+
+    const result = await compile(files, 'project.prs');
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('does not exist at segment "missing"'),
+      }),
+    ]);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        ruleId: 'PS018',
+        message: expect.stringContaining('explicit-override'),
+      }),
+    ]);
+  });
+
+  it('should honor configured syntax compatibility severity on override errors', async () => {
+    const files = {
+      'project.prs': `@meta { id: "test" syntax: "1.5.0" }
+@standards { testing: ["Use Jest"] }
+@override standards.missing { true }
+`,
+    };
+
+    const errorResult = await compile(files, 'project.prs', {
+      validator: { rules: { 'syntax-version-compat': 'error' } },
+    });
+    const offResult = await compile(files, 'project.prs', {
+      validator: { rules: { 'syntax-version-compat': 'off' } },
+    });
+
+    expect(errorResult.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining('does not exist at segment "missing"'),
+        }),
+        expect.objectContaining({
+          code: 'PS018',
+          message: expect.stringContaining('explicit-override'),
+        }),
+      ])
+    );
+    expect(errorResult.warnings).toEqual([]);
+    expect(offResult.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('does not exist at segment "missing"'),
+      }),
+    ]);
+    expect(offResult.warnings).toEqual([]);
+  });
+
   it('should report and format section header overrides in browser builds', async () => {
     const files = {
       'project.prs': `@meta { id: "test" syntax: "1.4.0" }

--- a/packages/browser-compiler/src/__tests__/override-parity.spec.ts
+++ b/packages/browser-compiler/src/__tests__/override-parity.spec.ts
@@ -189,4 +189,29 @@ describe('explicit override browser parity regressions', () => {
     expect(result.errors.map((error) => error.message).join(' ')).toContain('missing');
     expect((skills?.content as { inlineUses?: unknown }).inlineUses).toBeUndefined();
   });
+
+  it('normalizes unexpected ordered extension failures', async () => {
+    const resolver = new BrowserResolver({
+      fs: new VirtualFileSystem({
+        'project.prs': `@meta { id: "extension-error" syntax: "1.6.0" }
+@extend missing { enabled: true }
+`,
+      }),
+    });
+    (
+      resolver as unknown as {
+        applyExtend: () => never;
+      }
+    ).applyExtend = () => {
+      throw new Error('unexpected failure');
+    };
+
+    const result = await resolver.resolve('project.prs');
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: 'Extension resolution failed: unexpected failure',
+      }),
+    ]);
+  });
 });

--- a/packages/browser-compiler/src/__tests__/override-parity.spec.ts
+++ b/packages/browser-compiler/src/__tests__/override-parity.spec.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from '../index.js';
+import { BrowserResolver } from '../resolver.js';
+import { VirtualFileSystem } from '../virtual-fs.js';
+
+describe('explicit override browser parity regressions', () => {
+  it('compiles ordered replacements into formatter output', async () => {
+    const files = {
+      'project.prs': `@meta { id: "parity" syntax: "1.6.0" }
+@inherit ./parent
+@use ./shared as shared
+@override context.runtime { "bun" }
+@override shared.standards.testing { ["Use Vitest"] }
+@extend standards { testing: ["Require coverage"] }
+`,
+      'parent.prs': `@meta { id: "parent" syntax: "1.6.0" }
+@context { runtime: "node" }
+`,
+      'shared.prs': `@meta { id: "shared" syntax: "1.6.0" }
+@standards { testing: ["Use Jest"] }
+`,
+    };
+
+    const result = await compile(files, 'project.prs', {
+      projectRoot: '.',
+      formatters: [{ name: 'claude', config: { version: 'full' } }],
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.outputs.get('CLAUDE.md')?.content).toContain('bun');
+    expect(result.outputs.get('CLAUDE.md')?.content).toContain('Use Vitest');
+    expect(result.outputs.get('CLAUDE.md')?.content).toContain('Require coverage');
+    expect(result.outputs.get('CLAUDE.md')?.content).not.toContain('Use Jest');
+  });
+
+  it('lets later inherit operations replace earlier block values', async () => {
+    const resolver = new BrowserResolver({
+      fs: new VirtualFileSystem({
+        'project.prs': `@meta { id: "sequential-inherit" syntax: "1.6.0" }
+@context { runtime: "local" localOnly: true }
+@inherit ./parent
+`,
+        'parent.prs': `@meta { id: "parent" syntax: "1.6.0" }
+@context { runtime: "parent" parentOnly: true }
+`,
+      }),
+    });
+
+    const result = await resolver.resolve('project.prs');
+    const context = result.ast?.blocks.find((block) => block.name === 'context');
+
+    expect(result.errors).toEqual([]);
+    expect(context?.content).toMatchObject({
+      properties: { runtime: 'parent', localOnly: true, parentOnly: true },
+    });
+  });
+
+  it('reports semantic errors at the override directive', async () => {
+    const resolver = new BrowserResolver({
+      fs: new VirtualFileSystem({
+        'project.prs': `@meta { id: "invalid-parity" syntax: "1.6.0" }
+@standards { testing: { runner: "jest" } }
+@override standards.testing.runner.name { "vitest" }
+`,
+      }),
+    });
+
+    const result = await resolver.resolve('project.prs');
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('non-object segment "name"'),
+        location: expect.objectContaining({ file: 'project.prs', line: 3, column: 1 }),
+      }),
+    ]);
+  });
+
+  it('preserves duplicate skill errors before later overrides', async () => {
+    const resolver = new BrowserResolver({
+      fs: new VirtualFileSystem({
+        'project.prs': `@meta { id: "duplicate-skill" syntax: "1.6.0" }
+@skills { review: { description: "Local" content: "Local review" } }
+@use ./shared
+@override skills.review.description { "Updated local review" }
+`,
+        'shared.prs': `@meta { id: "shared" syntax: "1.6.0" }
+@skills { review: { description: "Imported" content: "Imported review" } }
+`,
+      }),
+    });
+
+    const result = await resolver.resolve('project.prs');
+    const skills = result.ast?.blocks.find((block) => block.name === 'skills');
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('Duplicate skill name(s) detected'),
+      }),
+    ]);
+    expect(skills?.content).toMatchObject({
+      properties: { review: { description: 'Updated local review', content: 'Local review' } },
+    });
+  });
+
+  it('preserves imported skill output directories through overrides', async () => {
+    const resolver = new BrowserResolver({
+      fs: new VirtualFileSystem({
+        'project.prs': `@meta { id: "output-dir" syntax: "1.6.0" }
+@use ./shared as shared into "skills/team"
+@override shared.skills.review.description { "Updated review" }
+`,
+        'shared.prs': `@meta { id: "shared" syntax: "1.6.0" }
+@skills { review: { description: "Imported" content: "Imported review" } }
+`,
+      }),
+    });
+
+    const result = await resolver.resolve('project.prs');
+    const skills = result.ast?.blocks.find((block) => block.name === 'skills');
+
+    expect(result.errors).toEqual([]);
+    expect(skills?.content).toMatchObject({
+      properties: {
+        review: {
+          description: 'Updated review',
+          content: 'Imported review',
+          __outputDir: 'skills/team',
+        },
+      },
+    });
+  });
+
+  it('applies later overrides after inline composition', async () => {
+    const resolver = new BrowserResolver({
+      fs: new VirtualFileSystem({
+        'project.prs': `@meta { id: "composition" syntax: "1.6.0" }
+@skills {
+  workflow: { description: "Workflow" content: "Parent workflow" }
+  @use ./phase
+}
+@override skills.workflow.content { "Final workflow" }
+`,
+        'phase.prs': `@meta { id: "phase" syntax: "1.6.0" }
+@skills { phase: { description: "Phase" content: "Run phase" } }
+`,
+      }),
+    });
+
+    const result = await resolver.resolve('project.prs');
+    const skills = result.ast?.blocks.find((block) => block.name === 'skills');
+
+    expect(result.errors).toEqual([]);
+    expect(skills?.content).toMatchObject({
+      properties: {
+        workflow: {
+          content: 'Final workflow',
+          __composedFrom: [expect.objectContaining({ name: 'phase' })],
+        },
+      },
+    });
+  });
+
+  it('does not retry failed inline composition after later operations', async () => {
+    const resolver = new BrowserResolver({
+      fs: new VirtualFileSystem({
+        'project.prs': `@meta { id: "failed-composition" syntax: "1.6.0" }
+@skills {
+  workflow: { description: "Workflow" content: "Parent workflow" }
+  @use ./missing
+}
+@standards { testing: ["Use Vitest"] }
+@override standards.testing { ["Use browser tests"] }
+`,
+      }),
+    });
+
+    const result = await resolver.resolve('project.prs');
+    const skills = result.ast?.blocks.find((block) => block.name === 'skills');
+
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors.map((error) => error.message).join(' ')).toContain('missing');
+    expect((skills?.content as { inlineUses?: unknown }).inlineUses).toBeUndefined();
+  });
+});

--- a/packages/browser-compiler/src/__tests__/override-parity.spec.ts
+++ b/packages/browser-compiler/src/__tests__/override-parity.spec.ts
@@ -11,13 +11,19 @@ describe('explicit override browser parity regressions', () => {
 @use ./shared as shared
 @override context.runtime { "bun" }
 @override shared.standards.testing { ["Use Vitest"] }
-@extend standards { testing: ["Require coverage"] }
+@extend standards {
+  testing: ["Require coverage"]
+  linting!: ["Use ESLint"]
+}
 `,
       'parent.prs': `@meta { id: "parent" syntax: "1.6.0" }
 @context { runtime: "node" }
 `,
       'shared.prs': `@meta { id: "shared" syntax: "1.6.0" }
-@standards { testing: ["Use Jest"] }
+@standards {
+  testing: ["Use Jest"]
+  linting: ["Use Biome"]
+}
 `,
     };
 
@@ -30,7 +36,9 @@ describe('explicit override browser parity regressions', () => {
     expect(result.outputs.get('CLAUDE.md')?.content).toContain('bun');
     expect(result.outputs.get('CLAUDE.md')?.content).toContain('Use Vitest');
     expect(result.outputs.get('CLAUDE.md')?.content).toContain('Require coverage');
+    expect(result.outputs.get('CLAUDE.md')?.content).toContain('Use ESLint');
     expect(result.outputs.get('CLAUDE.md')?.content).not.toContain('Use Jest');
+    expect(result.outputs.get('CLAUDE.md')?.content).not.toContain('Use Biome');
   });
 
   it('lets later inherit operations replace earlier block values', async () => {

--- a/packages/browser-compiler/src/__tests__/resolver.spec.ts
+++ b/packages/browser-compiler/src/__tests__/resolver.spec.ts
@@ -3370,6 +3370,93 @@ describe('BrowserResolver', () => {
     });
   });
 
+  describe('explicit override resolution', () => {
+    it('applies ordered replacements and later extensions', async () => {
+      const fs = new VirtualFileSystem({
+        'project.prs': `@meta { id: "override" syntax: "1.6.0" }
+@standards { testing: ["Use Jest"] config: { runner: "jest" coverage: 80 } }
+@override standards.testing { ["Use Vitest"] }
+@extend standards { testing: ["Require coverage"] }
+@override standards.config.runner { "vitest" }`,
+      });
+      const resolver = new BrowserResolver({ fs });
+
+      const result = await resolver.resolve('project.prs');
+      const standards = result.ast?.blocks.find((block) => block.name === 'standards');
+
+      expect(result.errors).toEqual([]);
+      expect(standards?.content).toMatchObject({
+        type: 'ObjectContent',
+        properties: {
+          testing: ['Use Vitest', 'Require coverage'],
+          config: { runner: 'vitest', coverage: 80 },
+        },
+      });
+    });
+
+    it('replaces inherited and aliased imported values', async () => {
+      const fs = new VirtualFileSystem({
+        'project.prs': `@meta { id: "child" syntax: "1.6.0" }
+@inherit ./parent
+@use ./shared as shared
+@override context.runtime { "bun" }
+@override shared.standards.testing { ["Use Vitest"] }`,
+        'parent.prs': `@meta { id: "parent" syntax: "1.6.0" }
+@context { runtime: "node" }`,
+        'shared.prs': `@meta { id: "shared" syntax: "1.6.0" }
+@standards { testing: ["Use Jest"] }`,
+      });
+      const resolver = new BrowserResolver({ fs });
+
+      const result = await resolver.resolve('project.prs');
+      const context = result.ast?.blocks.find((block) => block.name === 'context');
+      const standards = result.ast?.blocks.find((block) => block.name === 'standards');
+
+      expect(result.errors).toEqual([]);
+      expect(context?.content).toMatchObject({ properties: { runtime: 'bun' } });
+      expect(standards?.content).toMatchObject({
+        properties: { testing: ['Use Vitest'] },
+      });
+      expect(result.ast?.blocks.some((block) => block.name.startsWith('__import__'))).toBe(false);
+    });
+
+    it('reports missing and sealed targets without partial mutation', async () => {
+      const fs = new VirtualFileSystem({
+        'project.prs': `@meta { id: "invalid" syntax: "1.5.0" }
+@skills {
+  review: {
+    description: "Review code"
+    content: "Critical"
+    sealed: ["content"]
+  }
+}
+@override skills.review.missing { true }
+@override skills.review.content { "Changed" }`,
+      });
+      const resolver = new BrowserResolver({ fs });
+
+      const result = await resolver.resolve('project.prs');
+      const skills = result.ast?.blocks.find((block) => block.name === 'skills');
+
+      expect(result.errors.map((error) => error.message)).toEqual([
+        expect.stringContaining('does not exist at segment "missing"'),
+        expect.stringContaining("Cannot override sealed property 'content'"),
+      ]);
+      expect(skills?.content).toMatchObject({
+        properties: {
+          review: {
+            content: 'Critical',
+          },
+        },
+      });
+      expect(result.ast?.syntaxFeatures).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ feature: SYNTAX_FEATURES.EXPLICIT_OVERRIDE }),
+        ])
+      );
+    });
+  });
+
   describe('deepCloneValue array cloning', () => {
     it('should deep clone array values in skill properties during extend', async () => {
       // Covers resolver.ts line 1443: Array.isArray(value) in deepCloneValue

--- a/packages/browser-compiler/src/compiler.ts
+++ b/packages/browser-compiler/src/compiler.ts
@@ -229,13 +229,21 @@ export class BrowserCompiler {
     // Check for resolve errors
     if (resolved.errors.length > 0 || !resolved.ast) {
       stats.totalTime = Date.now() - startTotal;
+      const compatibility = resolved.ast ? this.validator.validate(resolved.ast) : undefined;
+      const compatibilityErrors =
+        compatibility?.errors.filter((message) => message.ruleId === 'PS018') ?? [];
+      const compatibilityWarnings =
+        compatibility?.warnings.filter((message) => message.ruleId === 'PS018') ?? [];
 
       return {
         success: false,
         outputs: new Map(),
         outputOwners: new Map(),
-        errors: resolved.errors.map((e) => this.toCompileError(e)),
-        warnings: [],
+        errors: [
+          ...resolved.errors.map((error) => this.toCompileError(error)),
+          ...compatibilityErrors.map((message) => this.validationToCompileError(message)),
+        ],
+        warnings: compatibilityWarnings,
         stats,
       };
     }

--- a/packages/browser-compiler/src/resolver.ts
+++ b/packages/browser-compiler/src/resolver.ts
@@ -16,8 +16,10 @@ import {
   CircularDependencyError,
   deepMerge,
   deepClone,
+  applyOverride,
+  blockBodyToContent,
+  consumeInlineUses,
   isTextContent,
-  IMPORT_MERGE_POLICY,
   INHERITANCE_MERGE_POLICY,
   mergeBlockCollections,
   bindParams,
@@ -26,9 +28,13 @@ import {
   getSyntaxFeatureUsages,
   normalizeBlockAliases,
   normalizeProgram,
+  toLegacyBlock,
+  usesSequentialOperations,
   composeBlockBodies,
   prepareBlockContentForMerge,
   reconcileBlockBodyAtPath,
+  resolveUseImport,
+  SKILL_REPLACE_PROPERTY_NAMES,
   type TemplateContext,
 } from '@promptscript/core';
 import { VirtualFileSystem } from './virtual-fs.js';
@@ -42,8 +48,8 @@ import type {
   ArrayContent,
   MixedContent,
   Value,
-  UseDeclaration,
   ExtendBlock,
+  OverrideBlock,
   ParamArgument,
 } from '@promptscript/core';
 
@@ -208,17 +214,7 @@ const IMPORT_MARKER_PREFIX = '__import__';
 // `content` instead of letting the overlay replace them.
 
 /** Properties where the extension value replaces the base value. */
-const SKILL_REPLACE_PROPERTIES = new Set([
-  'content',
-  'description',
-  'trigger',
-  'userInvocable',
-  'allowedTools',
-  'disableModelInvocation',
-  'context',
-  'agent',
-  'license',
-]);
+const SKILL_REPLACE_PROPERTIES = new Set<string>(SKILL_REPLACE_PROPERTY_NAMES);
 
 /** Properties where array elements are appended (deduplicated). */
 const SKILL_APPEND_PROPERTIES = new Set(['references', 'examples', 'requires', 'scripts']);
@@ -432,32 +428,41 @@ export class BrowserResolver {
       return { ast: null, sources, errors };
     }
 
-    let ast = normalizeBlockAliases(parseData.ast);
+    let ast = parseData.ast;
+    const sequentialOperations = usesSequentialOperations(ast);
+    ast = normalizeBlockAliases(ast, {
+      preserveDeclarationOrder: sequentialOperations,
+    });
 
-    // Resolve inheritance
-    ast = await this.resolveInherit(ast, absPath, sources, errors);
+    if (sequentialOperations) {
+      ast = await this.resolveSequentialOperations(ast, absPath, sources, errors);
+    } else {
+      ast = await this.resolveInherit(ast, absPath, sources, errors);
+      ast = await this.resolveImports(ast, absPath, sources, errors);
+    }
 
-    // Resolve imports
-    ast = await this.resolveImports(ast, absPath, sources, errors);
-
-    // Resolve skill composition (inline @use within @skills blocks)
-    ast = await this.resolveComposition(ast, absPath, sources, errors);
+    // Legacy phase order resolves inline composition after top-level imports.
+    if (!sequentialOperations) {
+      ast = await this.resolveComposition(ast, absPath, sources, errors);
+    }
 
     // Apply extensions
-    if (ast.extends.length > 0) {
+    if (!sequentialOperations && ast.extends.length > 0) {
       this.logger.debug(`Applying ${ast.extends.length} extension(s)`);
     }
-    try {
-      ast = this.applyExtends(ast);
-    } catch (err) {
-      if (err instanceof ResolveError) {
-        errors.push(err);
-      } else {
-        errors.push(
-          new ResolveError(
-            `Extension resolution failed: ${err instanceof Error ? err.message : String(err)}`
-          )
-        );
+    if (!sequentialOperations) {
+      try {
+        ast = this.applyExtends(ast);
+      } catch (err) {
+        if (err instanceof ResolveError) {
+          errors.push(err);
+        } else {
+          errors.push(
+            new ResolveError(
+              `Extension resolution failed: ${err instanceof Error ? err.message : String(err)}`
+            )
+          );
+        }
       }
     }
 
@@ -470,6 +475,147 @@ export class BrowserResolver {
       canonicalAst: normalizeProgram(ast),
       sources: [...new Set(sources)],
       errors,
+    };
+  }
+
+  private async resolveSequentialOperations(
+    ast: Program,
+    absPath: string,
+    sources: string[],
+    errors: ResolveError[]
+  ): Promise<Program> {
+    const operations = normalizeProgram(ast).operations;
+    const localBlockNames = new Set<string>();
+    let result: Program = {
+      ...ast,
+      inherit: undefined,
+      uses: [],
+      blocks: [],
+      extends: [],
+      overrides: [],
+      syntaxFeatures: getSyntaxFeatureUsages(ast),
+    };
+
+    for (const operation of operations) {
+      switch (operation.type) {
+        case 'InheritOperation':
+          result = await this.resolveInherit(
+            {
+              ...result,
+              inherit: deepClone(operation.declaration) as unknown as NonNullable<
+                Program['inherit']
+              >,
+            },
+            absPath,
+            sources,
+            errors,
+            true
+          );
+          break;
+        case 'UseOperation':
+          result = await this.resolveImports(
+            {
+              ...result,
+              uses: [deepClone(operation.declaration) as unknown as Program['uses'][number]],
+            },
+            absPath,
+            sources,
+            errors
+          );
+          result = { ...result, uses: [] };
+          break;
+        case 'BlockOperation': {
+          const block = toLegacyBlock(operation.block, { preserveCanonicalBody: true });
+          result = {
+            ...result,
+            blocks: localBlockNames.has(block.name)
+              ? [...result.blocks, block]
+              : mergeBlockCollections(result.blocks, [block], {
+                  content: INHERITANCE_MERGE_POLICY,
+                  outputOrder: 'base',
+                }),
+          };
+          localBlockNames.add(block.name);
+          result = await this.resolveComposition(result, absPath, sources, errors);
+          break;
+        }
+        case 'ExtendOperation': {
+          const extension: ExtendBlock = {
+            type: 'ExtendBlock',
+            targetPath: operation.extension.targetPath,
+            content: blockBodyToContent(operation.extension.body),
+            canonicalBody: deepClone(operation.extension.body),
+            ...(operation.extension.replacements
+              ? {
+                  replacements: operation.extension.replacements.map(
+                    (replacement) =>
+                      deepClone(replacement) as unknown as NonNullable<
+                        ExtendBlock['replacements']
+                      >[number]
+                  ),
+                }
+              : {}),
+            loc: deepClone(operation.extension.loc),
+          };
+          try {
+            result = {
+              ...result,
+              blocks: this.applyExtend(result.blocks, extension),
+            };
+            result = await this.resolveComposition(result, absPath, sources, errors);
+          } catch (error) {
+            errors.push(
+              error instanceof ResolveError
+                ? error
+                : new ResolveError(
+                    `Extension resolution failed: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                    extension.loc
+                  )
+            );
+          }
+          break;
+        }
+        case 'OverrideOperation': {
+          const override: OverrideBlock = {
+            type: 'OverrideBlock',
+            targetPath: operation.override.targetPath,
+            replacement: deepClone(
+              operation.override.replacement
+            ) as unknown as OverrideBlock['replacement'],
+            loc: deepClone(operation.override.loc),
+          };
+          try {
+            result = applyOverride(result, override, {
+              importMarkerPrefix: IMPORT_MARKER_PREFIX,
+            });
+            result = await this.resolveComposition(result, absPath, sources, errors);
+          } catch (error) {
+            errors.push(
+              error instanceof ResolveError
+                ? error
+                : new ResolveError(
+                    `Override resolution failed: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                    override.loc
+                  )
+            );
+          }
+          break;
+        }
+      }
+    }
+
+    return {
+      ...result,
+      blocks: result.blocks.filter((block) => !block.name.startsWith(IMPORT_MARKER_PREFIX)),
+      inherit: undefined,
+      uses: [],
+      extends: [],
+      overrides: [],
+      syntaxFeatures: getSyntaxFeatureUsages(result),
     };
   }
 
@@ -521,7 +667,8 @@ export class BrowserResolver {
     ast: Program,
     absPath: string,
     sources: string[],
-    errors: ResolveError[]
+    errors: ResolveError[],
+    parentWins = false
   ): Promise<Program> {
     if (!ast.inherit) {
       return ast;
@@ -563,7 +710,16 @@ export class BrowserResolver {
         }
 
         this.logger.debug(`Merging with parent AST`);
-        return this.resolveInheritance(resolvedParent, ast);
+        const inherited = this.resolveInheritance(resolvedParent, ast);
+        return parentWins
+          ? {
+              ...inherited,
+              blocks: mergeBlockCollections(ast.blocks, resolvedParent.blocks, {
+                content: INHERITANCE_MERGE_POLICY,
+                outputOrder: 'base',
+              }),
+            }
+          : inherited;
       }
     } catch (err) {
       if (err instanceof CircularDependencyError) {
@@ -652,7 +808,7 @@ export class BrowserResolver {
           }
 
           this.logger.debug(`Merging import${use.alias ? ` as "${use.alias}"` : ''}`);
-          result = this.resolveUses(result, use, resolvedImport);
+          result = resolveUseImport(result, use, resolvedImport);
         }
       } catch (err) {
         if (err instanceof CircularDependencyError) {
@@ -725,6 +881,7 @@ export class BrowserResolver {
           )
         );
       }
+      ast = consumeInlineUses(ast);
     }
 
     return ast;
@@ -768,51 +925,6 @@ export class BrowserResolver {
   // ============================================================
   // Import Resolution (ported from @promptscript/resolver)
   // ============================================================
-
-  /**
-   * Resolve @use imports by merging blocks into target.
-   */
-  private resolveUses(target: Program, use: UseDeclaration, source: Program): Program {
-    const mergedBlocks = mergeBlockCollections(source.blocks, target.blocks, {
-      content: IMPORT_MERGE_POLICY,
-      outputOrder: 'incoming',
-    });
-
-    const aliasedBlocks: Block[] = [];
-    if (use.alias) {
-      const alias = use.alias;
-      const markerName = `${IMPORT_MARKER_PREFIX}${alias}`;
-
-      const marker: Block = {
-        type: 'Block',
-        name: markerName,
-        content: {
-          type: 'ObjectContent',
-          properties: {
-            __source: use.path.raw,
-            __blocks: source.blocks.map((b) => b.name),
-          },
-          loc: use.loc,
-        } as ObjectContent,
-        loc: use.loc,
-      };
-
-      aliasedBlocks.push(marker);
-
-      for (const block of source.blocks) {
-        aliasedBlocks.push({
-          ...block,
-          name: `${IMPORT_MARKER_PREFIX}${alias}.${block.name}`,
-        });
-      }
-    }
-
-    return {
-      ...target,
-      blocks: [...mergedBlocks, ...aliasedBlocks],
-      syntaxFeatures: [...getSyntaxFeatureUsages(target), ...getSyntaxFeatureUsages(source)],
-    };
-  }
 
   // ============================================================
   // Extension Resolution (ported from @promptscript/resolver)

--- a/packages/cli/skills/promptscript/SKILL.md
+++ b/packages/cli/skills/promptscript/SKILL.md
@@ -747,16 +747,38 @@ Replacement works after `@inherit` and `@use`, including aliases and nested targ
 A missing field is set. The modifier is rejected for `@skills`, which retain their dedicated
 merge and sealing semantics.
 
+#### Replacing complete targets with @override
+
+Syntax `1.6.0` adds atomic replacement for an existing block or nested value:
+
+```
+@meta { id: "project" syntax: "1.6.0" }
+
+@standards {
+  testing: ["Use Jest", "Use Mocha"]
+}
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+```
+
+`@override` requires the complete target path to exist, applies in declaration
+order, and cannot bypass sealed skill properties. Later `@extend` declarations
+merge into the replacement. Use `@extend` for additive changes, `field!` for
+compatibility replacement of one direct regular field, and `@override` for
+intentional complete replacement.
+
 #### Skill-aware @extend semantics
 
 When extending a skill definition via `@extend`, individual skill properties follow specific merge
 strategies rather than the generic block merge rules:
 
-| Strategy          | Properties                                                                                         |
-| ----------------- | -------------------------------------------------------------------------------------------------- |
-| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent |
-| **Append**        | references, examples, requires                                                                     |
-| **Shallow merge** | params, inputs, outputs                                                                            |
+| Strategy          | Properties                                                                                                  |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent, license |
+| **Append**        | references, examples, requires                                                                              |
+| **Shallow merge** | params, inputs, outputs                                                                                     |
 
 Example — extending a base skill to add references and override content:
 
@@ -1007,6 +1029,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
 | `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
+| `1.6.0` | Adds atomic block and nested value replacement with contextual `@override`                                              |
 
 ### Block Version Requirements
 
@@ -1022,6 +1045,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
 Generated section title overrides with `@header` require syntax `1.5.0`.
+Atomic replacement with `@override` requires syntax `1.6.0`.
 
 ### Generated Section Headers
 

--- a/packages/cli/src/__tests__/cli-guard-run.spec.ts
+++ b/packages/cli/src/__tests__/cli-guard-run.spec.ts
@@ -24,7 +24,8 @@ vi.mock('../utils/version-check', () => ({
 }));
 
 // Mock core getPackageVersion
-vi.mock('@promptscript/core', () => ({
+vi.mock('@promptscript/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@promptscript/core')>()),
   getPackageVersion: vi.fn().mockReturnValue('1.0.0'),
 }));
 

--- a/packages/cli/src/commands/__tests__/validate-fix.spec.ts
+++ b/packages/cli/src/commands/__tests__/validate-fix.spec.ts
@@ -400,6 +400,23 @@ describe('validateCommand --fix', () => {
     );
   });
 
+  it('should fix syntax version for explicit overrides', async () => {
+    mkdirSync(join(tmpDir, '.promptscript'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.promptscript', 'project.prs'),
+      `@meta { id: "project" syntax: "1.5.0" }
+@standards { testing: ["Use Jest"] }
+@override standards.testing { ["Use Vitest"] }
+`
+    );
+
+    await validateCommand({ fix: true });
+
+    expect(readFileSync(join(tmpDir, '.promptscript', 'project.prs'), 'utf-8')).toContain(
+      'syntax: "1.6.0"'
+    );
+  });
+
   it('should report no fixes needed when syntax is correct', async () => {
     mkdirSync(join(tmpDir, '.promptscript'), { recursive: true });
     writeFileSync(

--- a/packages/compiler/src/__tests__/syntax-feature-validation.spec.ts
+++ b/packages/compiler/src/__tests__/syntax-feature-validation.spec.ts
@@ -13,6 +13,112 @@ afterEach(() => {
 });
 
 describe('syntax feature validation after resolution', () => {
+  it('should report explicit overrides declared below syntax 1.6.0', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-syntax-feature-'));
+    directories.push(directory);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta { id: "test" syntax: "1.5.0" }
+@standards { testing: ["Use Jest"] }
+@override standards.testing { ["Use Vitest"] }
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        ruleId: 'PS018',
+        message: expect.stringContaining('explicit-override'),
+        location: expect.objectContaining({ file: entryPath, line: 3, column: 1 }),
+      }),
+    ]);
+  });
+
+  it('should retain syntax diagnostics when override resolution fails', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-syntax-feature-'));
+    directories.push(directory);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta { id: "test" syntax: "1.5.0" }
+@standards { testing: ["Use Jest"] }
+@override standards.missing { true }
+`
+    );
+    const compiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory },
+      formatters: [],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('does not exist at segment "missing"'),
+      }),
+    ]);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        ruleId: 'PS018',
+        message: expect.stringContaining('explicit-override'),
+      }),
+    ]);
+  });
+
+  it('should honor configured PS018 severity during override failures', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'promptscript-syntax-feature-'));
+    directories.push(directory);
+    const entryPath = join(directory, 'project.prs');
+    writeFileSync(
+      entryPath,
+      `@meta { id: "test" syntax: "1.5.0" }
+@standards { testing: ["Use Jest"] }
+@override standards.missing { true }
+`
+    );
+    const errorCompiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory, cache: false },
+      validator: { rules: { 'syntax-version-compat': 'error' } },
+      formatters: [],
+    });
+    const offCompiler = new Compiler({
+      resolver: { registryPath: directory, projectRoot: directory, cache: false },
+      validator: { rules: { 'syntax-version-compat': 'off' } },
+      formatters: [],
+    });
+
+    const errorResult = await errorCompiler.compile(entryPath);
+    const offResult = await offCompiler.compile(entryPath);
+
+    expect(errorResult.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining('does not exist at segment "missing"'),
+        }),
+        expect.objectContaining({
+          code: 'PS018',
+          message: expect.stringContaining('explicit-override'),
+        }),
+      ])
+    );
+    expect(errorResult.warnings).toEqual([]);
+    expect(offResult.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('does not exist at segment "missing"'),
+      }),
+    ]);
+    expect(offResult.warnings).toEqual([]);
+  });
+
   it('should report replace modifiers declared with syntax 1.2.0', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'promptscript-syntax-feature-'));
     directories.push(directory);

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -224,12 +224,20 @@ export class Compiler {
     // Check for resolve errors
     if (resolved.errors.length > 0 || !resolved.ast) {
       stats.totalTime = Date.now() - startTotal;
+      const compatibility = resolved.ast ? this.validator.validate(resolved.ast) : undefined;
+      const compatibilityErrors =
+        compatibility?.errors.filter((message) => message.ruleId === 'PS018') ?? [];
+      const compatibilityWarnings =
+        compatibility?.warnings.filter((message) => message.ruleId === 'PS018') ?? [];
 
       return {
         success: false,
         outputs: new Map(),
-        errors: resolved.errors.map((e) => this.toCompileError(e)),
-        warnings: [],
+        errors: [
+          ...resolved.errors.map((error) => this.toCompileError(error)),
+          ...compatibilityErrors.map((message) => this.validationToCompileError(message)),
+        ],
+        warnings: compatibilityWarnings,
         stats,
       };
     }

--- a/packages/core/src/__tests__/block-aliases.spec.ts
+++ b/packages/core/src/__tests__/block-aliases.spec.ts
@@ -120,6 +120,59 @@ describe('block aliases', () => {
     });
   });
 
+  it('orders alias declarations by line when offsets are unavailable', () => {
+    const first = block('commands', { '/test': 'Run tests' }, 10);
+    const second = block('shortcuts', { '/review': 'Review code' }, 20);
+    first.loc = { file: LOC.file, line: 2, column: 1 };
+    second.loc = { file: LOC.file, line: 3, column: 1 };
+
+    const result = normalizeBlockAliases(program([first, second]), {
+      preserveDeclarationOrder: true,
+    });
+
+    expect(result.blocks.map((candidate) => candidate.name)).toEqual(['shortcuts', 'shortcuts']);
+    expect(result.blocks[0]?.content).toMatchObject({
+      properties: { '/test': 'Run tests' },
+    });
+    expect(result.blocks[1]?.content).toMatchObject({
+      properties: { '/review': 'Review code' },
+    });
+  });
+
+  it('uses line order for import alias visibility without offsets', () => {
+    const ast = program([]);
+    ast.uses = [
+      {
+        type: 'UseDeclaration',
+        path: {
+          type: 'PathReference',
+          raw: './commands',
+          segments: ['commands'],
+          isRelative: true,
+          loc: { file: LOC.file, line: 1, column: 1 },
+        },
+        alias: 'commands',
+        loc: { file: LOC.file, line: 1, column: 1 },
+      },
+    ];
+    ast.overrides = [
+      {
+        type: 'OverrideBlock',
+        targetPath: 'commands.skills',
+        replacement: {
+          type: 'ValueReplacement',
+          value: createValueNode(true, { file: LOC.file, line: 2, column: 1 }),
+          loc: { file: LOC.file, line: 2, column: 1 },
+        },
+        loc: { file: LOC.file, line: 2, column: 1 },
+      },
+    ];
+
+    const result = normalizeBlockAliases(ast, { preserveDeclarationOrder: true });
+
+    expect(result.overrides?.[0]?.targetPath).toBe('commands.skills');
+  });
+
   it('normalizes commands extension targets', () => {
     const ast = program([block('commands', { '/test': 'Run tests' }, 1)]);
     ast.extends = [

--- a/packages/core/src/__tests__/block-aliases.spec.ts
+++ b/packages/core/src/__tests__/block-aliases.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Block, Program } from '../index.js';
-import { getCanonicalBlockName, normalizeBlockAliases } from '../index.js';
+import { createValueNode, getCanonicalBlockName, normalizeBlockAliases } from '../index.js';
 
 const LOC = { file: 'aliases.prs', line: 1, column: 1, offset: 0 };
 
@@ -103,6 +103,23 @@ describe('block aliases', () => {
     });
   });
 
+  it('preserves alias declarations as separate ordered blocks when requested', () => {
+    const ast = program([
+      block('shortcuts', { '/review': 'Review code' }, 10),
+      block('commands', { '/test': 'Run tests' }, 30),
+    ]);
+
+    const result = normalizeBlockAliases(ast, { preserveDeclarationOrder: true });
+
+    expect(result.blocks.map((candidate) => candidate.name)).toEqual(['shortcuts', 'shortcuts']);
+    expect(result.blocks[0]?.content).toMatchObject({
+      properties: { '/review': 'Review code' },
+    });
+    expect(result.blocks[1]?.content).toMatchObject({
+      properties: { '/test': 'Run tests' },
+    });
+  });
+
   it('normalizes commands extension targets', () => {
     const ast = program([block('commands', { '/test': 'Run tests' }, 1)]);
     ast.extends = [
@@ -121,6 +138,26 @@ describe('block aliases', () => {
     const result = normalizeBlockAliases(ast);
 
     expect(result.extends[0]?.targetPath).toBe('shortcuts.test');
+  });
+
+  it('normalizes commands override targets', () => {
+    const ast = program([block('commands', { '/test': 'Run tests' }, 1)]);
+    ast.overrides = [
+      {
+        type: 'OverrideBlock',
+        targetPath: 'commands.test',
+        replacement: {
+          type: 'ValueReplacement',
+          value: createValueNode('Run complete tests', LOC),
+          loc: LOC,
+        },
+        loc: LOC,
+      },
+    ];
+
+    const result = normalizeBlockAliases(ast);
+
+    expect(result.overrides?.[0]?.targetPath).toBe('shortcuts.test');
   });
 
   it('preserves extension roots that match import aliases', () => {
@@ -156,5 +193,87 @@ describe('block aliases', () => {
 
     expect(result).toBe(ast);
     expect(result.extends[0]?.targetPath).toBe('commands.skills');
+  });
+
+  it('preserves override roots that match import aliases', () => {
+    const ast = program([block('identity', { role: 'Maintainer' }, 1)]);
+    ast.uses = [
+      {
+        type: 'UseDeclaration',
+        path: {
+          type: 'PathReference',
+          raw: './commands.prs',
+          segments: ['commands.prs'],
+          isRelative: true,
+          loc: LOC,
+        },
+        alias: 'commands',
+        loc: LOC,
+      },
+    ];
+    ast.overrides = [
+      {
+        type: 'OverrideBlock',
+        targetPath: 'commands.skills',
+        replacement: {
+          type: 'ValueReplacement',
+          value: createValueNode({ review: true }, LOC),
+          loc: LOC,
+        },
+        loc: LOC,
+      },
+    ];
+
+    const result = normalizeBlockAliases(ast);
+
+    expect(result).toBe(ast);
+    expect(result.overrides?.[0]?.targetPath).toBe('commands.skills');
+  });
+
+  it('resolves import aliases only after their declaration in ordered mode', () => {
+    const ast = program([block('identity', { role: 'Maintainer' }, 20)]);
+    ast.uses = [
+      {
+        type: 'UseDeclaration',
+        path: {
+          type: 'PathReference',
+          raw: './commands.prs',
+          segments: ['commands.prs'],
+          isRelative: true,
+          loc: { ...LOC, offset: 30 },
+        },
+        alias: 'commands',
+        loc: { ...LOC, offset: 30 },
+      },
+    ];
+    ast.overrides = [
+      {
+        type: 'OverrideBlock',
+        targetPath: 'commands.test',
+        replacement: {
+          type: 'ValueReplacement',
+          value: createValueNode('Run complete tests', { ...LOC, offset: 10 }),
+          loc: { ...LOC, offset: 10 },
+        },
+        loc: { ...LOC, offset: 10 },
+      },
+      {
+        type: 'OverrideBlock',
+        targetPath: 'commands.skills',
+        replacement: {
+          type: 'ValueReplacement',
+          value: createValueNode({ review: true }, { ...LOC, offset: 40 }),
+          loc: { ...LOC, offset: 40 },
+        },
+        loc: { ...LOC, offset: 40 },
+      },
+    ];
+
+    const result = normalizeBlockAliases(ast, { preserveDeclarationOrder: true });
+
+    expect(result.overrides?.map((override) => override.targetPath)).toEqual([
+      'shortcuts.test',
+      'commands.skills',
+    ]);
   });
 });

--- a/packages/core/src/__tests__/block-import.spec.ts
+++ b/packages/core/src/__tests__/block-import.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveUseImport,
+  type Block,
+  type Program,
+  type UseDeclaration,
+  type Value,
+} from '../index.js';
+
+const LOC = { file: 'import.prs', line: 1, column: 1, offset: 0 };
+
+function block(name: string, properties: Record<string, Value>): Block {
+  return {
+    type: 'Block',
+    name,
+    content: { type: 'ObjectContent', properties, loc: LOC },
+    loc: LOC,
+  };
+}
+
+function program(blocks: Block[], syntaxFeatures: Program['syntaxFeatures'] = []): Program {
+  return {
+    type: 'Program',
+    uses: [],
+    blocks,
+    extends: [],
+    overrides: [],
+    syntaxFeatures,
+    loc: LOC,
+  };
+}
+
+function use(overrides: Partial<UseDeclaration> = {}): UseDeclaration {
+  return {
+    type: 'UseDeclaration',
+    path: {
+      type: 'PathReference',
+      raw: './shared',
+      segments: ['shared'],
+      isRelative: true,
+      loc: LOC,
+    },
+    loc: LOC,
+    ...overrides,
+  };
+}
+
+describe('block import', () => {
+  it('merges blocks and syntax features without an alias', () => {
+    const target = program(
+      [block('context', { local: true })],
+      [{ feature: 'section-header-override', location: LOC }]
+    );
+    const source = program(
+      [block('standards', { testing: ['Use Vitest'] })],
+      [{ feature: 'explicit-override', location: LOC }]
+    );
+
+    const result = resolveUseImport(target, use(), source);
+
+    expect(result.blocks.map((entry) => entry.name)).toEqual(['context', 'standards']);
+    expect(result.syntaxFeatures).toEqual([
+      { feature: 'section-header-override', location: LOC },
+      { feature: 'explicit-override', location: LOC },
+    ]);
+  });
+
+  it('creates alias markers and preserves skill output directories', () => {
+    const source = program([
+      block('skills', {
+        review: { description: 'Review', content: 'Review code' },
+        primitive: 'Imported',
+      }),
+    ]);
+
+    const result = resolveUseImport(
+      program([]),
+      use({ alias: 'shared', outputDir: 'skills/team' }),
+      source
+    );
+
+    expect(result.blocks.map((entry) => entry.name)).toEqual([
+      'skills',
+      '__import__shared',
+      '__import__shared.skills',
+    ]);
+    expect(result.blocks[0]?.content).toMatchObject({
+      properties: {
+        review: { __outputDir: 'skills/team' },
+        primitive: { __outputDir: 'skills/team' },
+      },
+    });
+    expect(result.blocks[1]?.content).toMatchObject({
+      properties: {
+        __source: './shared',
+        __blocks: ['skills'],
+      },
+    });
+    expect(source.blocks[0]?.content).not.toMatchObject({
+      properties: { review: { __outputDir: 'skills/team' } },
+    });
+  });
+
+  it('rejects conflicting duplicate skills but permits identical definitions', () => {
+    const target = program([block('skills', { review: { content: 'Local' } })]);
+
+    expect(() =>
+      resolveUseImport(
+        target,
+        use(),
+        program([block('skills', { review: { content: 'Imported' } })])
+      )
+    ).toThrow(/Duplicate skill name/);
+    expect(() =>
+      resolveUseImport(target, use(), program([block('skills', { review: { content: 'Local' } })]))
+    ).not.toThrow();
+  });
+
+  it('does not treat object prototype names as existing skills', () => {
+    const result = resolveUseImport(
+      program([block('skills', { review: { content: 'Review' } })]),
+      use(),
+      program([block('skills', { toString: { content: 'Stringify' } })])
+    );
+    const skills = result.blocks.find((entry) => entry.name === 'skills');
+
+    expect(skills?.content).toMatchObject({
+      properties: { toString: { content: 'Stringify' } },
+    });
+  });
+
+  it('ignores output directory metadata when no skills block exists', () => {
+    const result = resolveUseImport(
+      program([]),
+      use({ outputDir: 'skills/team' }),
+      program([block('standards', { testing: true })])
+    );
+
+    expect(result.blocks).toEqual([block('standards', { testing: true })]);
+  });
+});

--- a/packages/core/src/__tests__/block-override.spec.ts
+++ b/packages/core/src/__tests__/block-override.spec.ts
@@ -146,6 +146,70 @@ describe('block override', () => {
     });
   });
 
+  it('converts standalone block bodies for nested replacements', () => {
+    const nested = (
+      entries: Parameters<typeof createBlockBody>[0],
+      projection?: 'ArrayContent'
+    ): OverrideBlock => ({
+      type: 'OverrideBlock',
+      targetPath: 'standards.testing',
+      replacement: {
+        type: 'BlockReplacement',
+        body: createBlockBody(entries, LOC, projection ? { projection } : undefined),
+        loc: LOC,
+      },
+      loc: LOC,
+    });
+    const ast = program([block('standards', { testing: 'Old' })]);
+
+    const textResult = applyOverride(
+      ast,
+      nested([{ type: 'TextEntry', text: 'Use Vitest', loc: LOC }])
+    );
+    const arrayResult = applyOverride(
+      ast,
+      nested(
+        [{ type: 'ListEntry', value: createValueNode('Use Vitest', LOC), loc: LOC }],
+        'ArrayContent'
+      )
+    );
+    const objectResult = applyOverride(
+      ast,
+      nested([
+        {
+          type: 'FieldEntry',
+          name: 'runner',
+          value: createValueNode('vitest', LOC),
+          loc: LOC,
+        },
+      ])
+    );
+
+    expect(textResult.blocks[0]?.content).toMatchObject({
+      properties: { testing: { type: 'TextContent', value: 'Use Vitest' } },
+    });
+    expect(arrayResult.blocks[0]?.content).toMatchObject({
+      properties: { testing: ['Use Vitest'] },
+    });
+    expect(objectResult.blocks[0]?.content).toMatchObject({
+      properties: { testing: { runner: 'vitest' } },
+    });
+    expect(() =>
+      applyOverride(
+        ast,
+        nested([
+          { type: 'TextEntry', text: 'Required', loc: LOC },
+          {
+            type: 'FieldEntry',
+            name: 'runner',
+            value: createValueNode('vitest', LOC),
+            loc: LOC,
+          },
+        ])
+      )
+    ).toThrow(/mixed block content/);
+  });
+
   it('replaces root text, array, and mixed block bodies', () => {
     const textResult = applyOverride(
       program([block('identity', { old: true })]),
@@ -181,6 +245,16 @@ describe('block override', () => {
       },
       loc: LOC,
     });
+    const textNodeResult = applyOverride(program([block('identity', { old: true })]), {
+      type: 'OverrideBlock',
+      targetPath: 'identity',
+      replacement: {
+        type: 'ValueReplacement',
+        value: { type: 'TextValueNode', value: 'Text node identity', loc: LOC },
+        loc: LOC,
+      },
+      loc: LOC,
+    });
 
     expect(textResult.blocks[0]?.content).toMatchObject({
       type: 'TextContent',
@@ -197,6 +271,10 @@ describe('block override', () => {
         testing: ['Use Vitest'],
         items: ['Document failures'],
       },
+    });
+    expect(textNodeResult.blocks[0]?.content).toMatchObject({
+      type: 'TextContent',
+      value: 'Text node identity',
     });
   });
 
@@ -327,6 +405,23 @@ describe('block override', () => {
     expect(() => applyOverride(ast, valueOverride('standards.toString', 'invalid'))).toThrow(
       /does not exist at segment "toString"/
     );
+    const objectAst = program([block('standards', { testing: { runner: 'jest' } })]);
+    expect(() =>
+      applyOverride(objectAst, valueOverride('standards.testing.missing', 'invalid'))
+    ).toThrow(/does not exist at segment "missing"/);
+    expect(() => applyOverride(ast, valueOverride('context.runtime', 'node'))).toThrow(
+      /target "context.runtime" does not exist/
+    );
+
+    const textBlock: Block = {
+      type: 'Block',
+      name: 'identity',
+      content: { type: 'TextContent', value: 'Identity', loc: LOC },
+      loc: LOC,
+    };
+    expect(() =>
+      applyOverride(program([textBlock]), valueOverride('identity.name', 'invalid'))
+    ).toThrow(/root block is not object-shaped/);
   });
 
   it('rejects primitive root block replacements', () => {
@@ -355,6 +450,9 @@ describe('block override', () => {
     expect(() => applyOverride(ast, valueOverride('skills.review.license', 'Apache-2.0'))).toThrow(
       /Cannot override sealed property 'license'/
     );
+    expect(() => applyOverride(ast, valueOverride('skills.review.sealed', false))).toThrow(
+      /Cannot override protected property 'sealed'/
+    );
     expect(() =>
       applyOverride(
         ast,
@@ -365,6 +463,70 @@ describe('block override', () => {
         })
       )
     ).toThrow(/Cannot change sealed property 'content'/);
+
+    const fullySealed = program([
+      block('skills', {
+        review: {
+          description: 'Review code',
+          content: 'Critical instructions',
+          sealed: true,
+        },
+      }),
+    ]);
+    expect(() =>
+      applyOverride(fullySealed, valueOverride('skills.review.description', 'Changed'))
+    ).toThrow(/Cannot override sealed property 'description'/);
+
+    const unsealed = program([
+      block('skills', {
+        review: {
+          description: 'Review code',
+          content: 'Instructions',
+          sealed: false,
+        },
+      }),
+    ]);
+    expect(
+      applyOverride(unsealed, valueOverride('skills.review.description', 'Changed')).blocks[0]
+        ?.content
+    ).toMatchObject({
+      properties: { review: { description: 'Changed' } },
+    });
+  });
+
+  it('rejects replacements that weaken sealed skill contracts', () => {
+    const ast = program([
+      block('skills', {
+        review: {
+          description: 'Review code',
+          content: 'Critical instructions',
+          sealed: ['content'],
+        },
+      }),
+    ]);
+
+    expect(() => applyOverride(ast, valueOverride('skills', 'Invalid'))).toThrow(
+      /Cannot replace @skills with non-object content/
+    );
+    expect(() =>
+      applyOverride(ast, valueOverride('skills', { deploy: { content: 'Deploy' } }))
+    ).toThrow(/Cannot remove skill "review"/);
+    expect(() => applyOverride(ast, valueOverride('skills.missing.content', 'Invalid'))).toThrow(
+      /does not exist at segment "missing"/
+    );
+    expect(() => applyOverride(ast, valueOverride('skills.review', 'Invalid'))).toThrow(
+      /Cannot replace skill "review" with non-object content/
+    );
+    expect(() =>
+      applyOverride(
+        ast,
+        valueOverride('skills.review', {
+          description: 'Review code',
+          content: 'Critical instructions',
+          sealed: ['description'],
+        })
+      )
+    ).toThrow(/Cannot change protected property 'sealed'/);
   });
 
   it('protects sealed declarations during complete skills replacement', () => {

--- a/packages/core/src/__tests__/block-override.spec.ts
+++ b/packages/core/src/__tests__/block-override.spec.ts
@@ -1,0 +1,493 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyOverride,
+  createBlockBody,
+  createValueNode,
+  type Block,
+  type OverrideBlock,
+  type Program,
+  type Value,
+} from '../index.js';
+
+const LOC = { file: 'override.prs', line: 1, column: 1, offset: 0 };
+
+function block(name: string, properties: Record<string, Value>): Block {
+  return {
+    type: 'Block',
+    name,
+    content: { type: 'ObjectContent', properties, loc: LOC },
+    loc: LOC,
+  };
+}
+
+function program(blocks: Block[]): Program {
+  return {
+    type: 'Program',
+    uses: [],
+    blocks,
+    extends: [],
+    overrides: [],
+    loc: LOC,
+  };
+}
+
+function valueOverride(targetPath: string, value: Value): OverrideBlock {
+  return {
+    type: 'OverrideBlock',
+    targetPath,
+    replacement: {
+      type: 'ValueReplacement',
+      value: createValueNode(value, LOC),
+      loc: LOC,
+    },
+    loc: LOC,
+  };
+}
+
+describe('block override', () => {
+  it('replaces existing nested values without mutating input', () => {
+    const replacementLoc = { ...LOC, line: 7, offset: 120 };
+    const ast = program([
+      {
+        ...block('standards', {
+          testing: { runner: 'jest', coverage: 80 },
+        }),
+        canonicalBody: createBlockBody(
+          [
+            {
+              type: 'PresentationEntry',
+              title: 'Engineering Rules',
+              source: 'explicit',
+              titleLoc: LOC,
+              loc: LOC,
+            },
+            {
+              type: 'FieldEntry',
+              name: 'testing',
+              value: createValueNode({ runner: 'jest', coverage: 80 }, LOC),
+              loc: LOC,
+            },
+          ],
+          LOC
+        ),
+      },
+    ]);
+
+    const result = applyOverride(ast, {
+      type: 'OverrideBlock',
+      targetPath: 'standards.testing.runner',
+      replacement: {
+        type: 'ValueReplacement',
+        value: createValueNode('vitest', replacementLoc),
+        loc: replacementLoc,
+      },
+      loc: replacementLoc,
+    });
+
+    expect(result.blocks[0]?.content).toMatchObject({
+      properties: {
+        testing: { runner: 'vitest', coverage: 80 },
+      },
+    });
+    expect(result.blocks[0]?.canonicalBody?.entries[0]).toMatchObject({
+      type: 'PresentationEntry',
+      title: 'Engineering Rules',
+    });
+    expect(result.blocks[0]?.canonicalBody?.entries[1]).toMatchObject({
+      type: 'FieldEntry',
+      value: {
+        type: 'ObjectValueNode',
+        fields: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'runner',
+            value: expect.objectContaining({ loc: replacementLoc }),
+          }),
+        ]),
+      },
+    });
+    expect(ast.blocks[0]?.content).toMatchObject({
+      properties: {
+        testing: { runner: 'jest', coverage: 80 },
+      },
+    });
+  });
+
+  it('replaces a complete block body atomically', () => {
+    const ast = program([block('standards', { old: true })]);
+    const override: OverrideBlock = {
+      type: 'OverrideBlock',
+      targetPath: 'standards',
+      replacement: {
+        type: 'BlockReplacement',
+        body: createBlockBody(
+          [
+            {
+              type: 'FieldEntry',
+              name: 'testing',
+              value: createValueNode(['Use Vitest'], LOC),
+              loc: LOC,
+            },
+          ],
+          LOC
+        ),
+        loc: LOC,
+      },
+      loc: LOC,
+    };
+
+    const result = applyOverride(ast, override);
+
+    expect(result.blocks[0]?.content).toMatchObject({
+      type: 'ObjectContent',
+      properties: { testing: ['Use Vitest'] },
+    });
+    expect(result.blocks[0]?.content).not.toMatchObject({
+      properties: { old: true },
+    });
+  });
+
+  it('replaces root text, array, and mixed block bodies', () => {
+    const textResult = applyOverride(
+      program([block('identity', { old: true })]),
+      valueOverride('identity', 'New identity')
+    );
+    const arrayResult = applyOverride(
+      program([block('restrictions', { old: true })]),
+      valueOverride('restrictions', ['No unsafe casts'])
+    );
+    const mixedResult = applyOverride(program([block('standards', { old: true })]), {
+      type: 'OverrideBlock',
+      targetPath: 'standards',
+      replacement: {
+        type: 'BlockReplacement',
+        body: createBlockBody(
+          [
+            { type: 'TextEntry', text: 'Required rules', loc: LOC },
+            {
+              type: 'FieldEntry',
+              name: 'testing',
+              value: createValueNode(['Use Vitest'], LOC),
+              loc: LOC,
+            },
+            {
+              type: 'ListEntry',
+              value: createValueNode('Document failures', LOC),
+              loc: LOC,
+            },
+          ],
+          LOC
+        ),
+        loc: LOC,
+      },
+      loc: LOC,
+    });
+
+    expect(textResult.blocks[0]?.content).toMatchObject({
+      type: 'TextContent',
+      value: 'New identity',
+    });
+    expect(arrayResult.blocks[0]?.content).toMatchObject({
+      type: 'ArrayContent',
+      elements: ['No unsafe casts'],
+    });
+    expect(mixedResult.blocks[0]?.content).toMatchObject({
+      type: 'MixedContent',
+      text: { value: 'Required rules' },
+      properties: {
+        testing: ['Use Vitest'],
+        items: ['Document failures'],
+      },
+    });
+  });
+
+  it('treats domain type fields as ordinary object data', () => {
+    const typeExpressionResult = applyOverride(
+      program([block('standards', { old: true })]),
+      valueOverride('standards', { type: 'TypeExpression', data: true })
+    );
+    const textContentResult = applyOverride(
+      program([block('standards', { old: true })]),
+      valueOverride('standards', {
+        type: 'TextContent',
+        value: 'domain value',
+        extra: true,
+      })
+    );
+    const nestedObjectContentResult = applyOverride(
+      program([
+        block('standards', {
+          config: {
+            type: 'ObjectContent',
+            properties: { runner: 'jest' },
+          },
+        }),
+      ]),
+      valueOverride('standards.config.properties.runner', 'vitest')
+    );
+
+    expect(typeExpressionResult.blocks[0]?.content).toMatchObject({
+      type: 'ObjectContent',
+      properties: { type: 'TypeExpression', data: true },
+    });
+    expect(textContentResult.blocks[0]?.content).toMatchObject({
+      type: 'ObjectContent',
+      properties: {
+        type: 'TextContent',
+        value: 'domain value',
+        extra: true,
+      },
+    });
+    expect(nestedObjectContentResult.blocks[0]?.content).toMatchObject({
+      properties: {
+        config: {
+          type: 'ObjectContent',
+          properties: { runner: 'vitest' },
+        },
+      },
+    });
+  });
+
+  it('replaces presentation and inline uses with the root body', () => {
+    const ast = program([
+      {
+        ...block('skills', { old: { content: 'Old' } }),
+        canonicalBody: createBlockBody(
+          [
+            {
+              type: 'PresentationEntry',
+              title: 'Old Skills',
+              source: 'explicit',
+              titleLoc: LOC,
+              loc: LOC,
+            },
+            {
+              type: 'InlineUseEntry',
+              declaration: {
+                type: 'InlineUseDeclaration',
+                path: {
+                  type: 'PathReference',
+                  raw: './old',
+                  segments: ['old'],
+                  isRelative: true,
+                  loc: LOC,
+                },
+                loc: LOC,
+              },
+              loc: LOC,
+            },
+          ],
+          LOC
+        ),
+      },
+    ]);
+
+    const result = applyOverride(ast, valueOverride('skills', { new: { content: 'New' } }));
+
+    expect(result.blocks[0]?.canonicalBody?.entries).toEqual([
+      expect.objectContaining({ type: 'FieldEntry', name: 'new' }),
+    ]);
+  });
+
+  it('resolves imported aliases to surviving blocks', () => {
+    const ast = program([
+      block('__import__base', { __source: './base.prs' }),
+      block('standards', { testing: ['Old'] }),
+    ]);
+
+    const result = applyOverride(ast, valueOverride('base.standards.testing', ['New']));
+
+    expect(result.blocks[1]?.content).toMatchObject({
+      properties: { testing: ['New'] },
+    });
+  });
+
+  it('rejects blocks that were not exported by an imported alias', () => {
+    const ast = program([
+      block('__import__base', {
+        __source: './base.prs',
+        __blocks: ['context'],
+      }),
+      block('standards', { testing: ['Local'] }),
+    ]);
+
+    expect(() => applyOverride(ast, valueOverride('base.standards.testing', ['Invalid']))).toThrow(
+      /is not exported by alias "base"/
+    );
+  });
+
+  it('rejects missing paths and scalar traversal', () => {
+    const ast = program([block('standards', { testing: 'strict' })]);
+
+    expect(() => applyOverride(ast, valueOverride('standards.missing', true))).toThrow(
+      /does not exist at segment "missing"/
+    );
+    expect(() => applyOverride(ast, valueOverride('standards.testing.runner', 'vitest'))).toThrow(
+      /non-object segment "runner"/
+    );
+    expect(() => applyOverride(ast, valueOverride('standards.toString', 'invalid'))).toThrow(
+      /does not exist at segment "toString"/
+    );
+  });
+
+  it('rejects primitive root block replacements', () => {
+    const ast = program([block('standards', { testing: ['Old'] })]);
+
+    expect(() => applyOverride(ast, valueOverride('standards', true))).toThrow(
+      /Cannot replace block "@standards" with boolean content/
+    );
+  });
+
+  it('cannot remove or change sealed skill properties', () => {
+    const ast = program([
+      block('skills', {
+        review: {
+          description: 'Review code',
+          content: 'Critical instructions',
+          license: 'MIT',
+          sealed: ['content', 'license'],
+        },
+      }),
+    ]);
+
+    expect(() => applyOverride(ast, valueOverride('skills.review.content', 'Changed'))).toThrow(
+      /Cannot override sealed property 'content'/
+    );
+    expect(() => applyOverride(ast, valueOverride('skills.review.license', 'Apache-2.0'))).toThrow(
+      /Cannot override sealed property 'license'/
+    );
+    expect(() =>
+      applyOverride(
+        ast,
+        valueOverride('skills.review', {
+          description: 'Review code',
+          license: 'MIT',
+          sealed: ['content', 'license'],
+        })
+      )
+    ).toThrow(/Cannot change sealed property 'content'/);
+  });
+
+  it('protects sealed declarations during complete skills replacement', () => {
+    const ast = program([
+      block('skills', {
+        review: {
+          description: 'Review code',
+          content: 'Critical instructions',
+          sealed: ['content'],
+        },
+      }),
+    ]);
+
+    expect(() =>
+      applyOverride(
+        ast,
+        valueOverride('skills', {
+          review: {
+            description: 'Updated description',
+            content: 'Critical instructions',
+            sealed: ['content'],
+          },
+          deploy: {
+            content: 'Deploy',
+            sealed: ['content'],
+          },
+        })
+      )
+    ).toThrow(/Cannot add protected property 'sealed'/);
+    expect(() =>
+      applyOverride(
+        ast,
+        valueOverride('skills', {
+          review: {
+            description: 'Updated description',
+            content: 'Critical instructions',
+            sealed: ['content'],
+          },
+          toString: {
+            content: 'Prototype collision',
+            sealed: ['content'],
+          },
+        })
+      )
+    ).toThrow(/Cannot add protected property 'sealed'/);
+  });
+
+  it('allows complete skills replacement to update unsealed fields', () => {
+    const ast = program([
+      block('skills', {
+        review: {
+          description: 'Review code',
+          content: 'Critical instructions',
+          sealed: ['content'],
+        },
+        removable: {
+          content: 'Unsealed instructions',
+        },
+      }),
+    ]);
+
+    const result = applyOverride(
+      ast,
+      valueOverride('skills', {
+        review: {
+          description: 'Updated description',
+          content: 'Critical instructions',
+          sealed: ['content'],
+        },
+      })
+    );
+
+    expect(result.blocks[0]?.content).toMatchObject({
+      properties: {
+        review: {
+          description: 'Updated description',
+          content: 'Critical instructions',
+          sealed: ['content'],
+        },
+      },
+    });
+  });
+
+  it('compares sealed text semantically instead of by source location', () => {
+    const originalTextLoc = { ...LOC, line: 3, offset: 25 };
+    const replacementTextLoc = { ...LOC, line: 12, offset: 180 };
+    const ast = program([
+      block('skills', {
+        review: {
+          description: 'Review code',
+          content: {
+            type: 'TextContent',
+            value: 'Critical instructions',
+            loc: originalTextLoc,
+          },
+          sealed: ['content'],
+        },
+      }),
+    ]);
+
+    const result = applyOverride(
+      ast,
+      valueOverride('skills.review', {
+        description: 'Updated description',
+        content: {
+          type: 'TextContent',
+          value: 'Critical instructions',
+          loc: replacementTextLoc,
+        },
+        sealed: ['content'],
+      })
+    );
+
+    expect(result.blocks[0]?.content).toMatchObject({
+      properties: {
+        review: {
+          description: 'Updated description',
+          content: {
+            value: 'Critical instructions',
+            loc: replacementTextLoc,
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/core/src/__tests__/canonical-ast.spec.ts
+++ b/packages/core/src/__tests__/canonical-ast.spec.ts
@@ -117,6 +117,35 @@ describe('canonical AST compatibility', () => {
     ]);
   });
 
+  it('normalizes legacy overrides into ordered canonical operations', () => {
+    const canonical = normalizeProgram({
+      type: 'Program',
+      uses: [],
+      blocks: [],
+      extends: [],
+      overrides: [
+        {
+          type: 'OverrideBlock',
+          targetPath: 'standards.testing',
+          replacement: {
+            type: 'ValueReplacement',
+            value: createValueNode(['Use Vitest'], LOC),
+            loc: LOC,
+          },
+          loc: LOC,
+        },
+      ],
+      loc: LOC,
+    });
+
+    expect(canonical.operations).toEqual([
+      expect.objectContaining({
+        type: 'OverrideOperation',
+        override: expect.objectContaining({ targetPath: 'standards.testing' }),
+      }),
+    ]);
+  });
+
   it('creates immutable updates without modifying the original graph', () => {
     const canonical = normalizeProgram({
       type: 'Program',

--- a/packages/core/src/__tests__/canonical-ast.spec.ts
+++ b/packages/core/src/__tests__/canonical-ast.spec.ts
@@ -6,6 +6,7 @@ import {
   createBlockBody,
   createCanonicalBlock,
   createCanonicalExtendBlock,
+  createCanonicalOverrideBlock,
   createCanonicalProgram,
   createValueNode,
   blockBodyToContent,
@@ -82,6 +83,38 @@ describe('canonical AST compatibility', () => {
 
     expect(getBlockText(canonical.blocks[0]!)).toBe('Original');
     expect(getBlockText(projection.blocks[0]!)).toBe('Changed');
+  });
+
+  it('projects canonical overrides with the legacy discriminant', () => {
+    const override = createCanonicalOverrideBlock(
+      'standards.testing',
+      {
+        type: 'ValueReplacement',
+        value: createValueNode(['Use Vitest'], LOC),
+        loc: LOC,
+      },
+      LOC
+    );
+    const canonical = createCanonicalProgram({
+      operations: [
+        {
+          type: 'OverrideOperation',
+          override,
+          sourceLayerId: LOC.file,
+          loc: LOC,
+        },
+      ],
+      loc: LOC,
+    });
+
+    const legacy = toLegacyProgram(canonical);
+
+    expect(legacy.overrides).toEqual([
+      expect.objectContaining({
+        type: 'OverrideBlock',
+        targetPath: 'standards.testing',
+      }),
+    ]);
   });
 
   it('creates immutable updates without modifying the original graph', () => {

--- a/packages/core/src/__tests__/inline-uses.spec.ts
+++ b/packages/core/src/__tests__/inline-uses.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  consumeInlineUses,
+  type Block,
+  type InlineUseDeclaration,
+  type Program,
+} from '../index.js';
+
+const LOC = { file: 'inline.prs', line: 1, column: 1, offset: 0 };
+
+function program(blocks: Block[]): Program {
+  return {
+    type: 'Program',
+    uses: [],
+    blocks,
+    extends: [],
+    overrides: [],
+    loc: LOC,
+  };
+}
+
+const INLINE_USE: InlineUseDeclaration = {
+  type: 'InlineUseDeclaration',
+  path: {
+    type: 'PathReference',
+    raw: './phase',
+    segments: ['phase'],
+    isRelative: true,
+    loc: LOC,
+  },
+  loc: LOC,
+};
+
+describe('consumeInlineUses', () => {
+  it('returns the original program when no inline uses are pending', () => {
+    const ast = program([
+      {
+        type: 'Block',
+        name: 'standards',
+        content: { type: 'ObjectContent', properties: {}, loc: LOC },
+        loc: LOC,
+      },
+    ]);
+
+    expect(consumeInlineUses(ast)).toBe(ast);
+  });
+
+  it('clears pending skill uses without changing unrelated blocks', () => {
+    const standards: Block = {
+      type: 'Block',
+      name: 'standards',
+      content: { type: 'ObjectContent', properties: { testing: true }, loc: LOC },
+      loc: LOC,
+    };
+    const ast = program([
+      {
+        type: 'Block',
+        name: 'skills',
+        content: {
+          type: 'ObjectContent',
+          properties: { review: { content: 'Review' } },
+          inlineUses: [INLINE_USE],
+          loc: LOC,
+        },
+        loc: LOC,
+      },
+      standards,
+    ]);
+
+    const result = consumeInlineUses(ast);
+
+    expect(result).not.toBe(ast);
+    expect(result.blocks[0]?.content).toMatchObject({
+      properties: { review: { content: 'Review' } },
+      inlineUses: undefined,
+    });
+    expect(result.blocks[1]).toBe(standards);
+    expect((ast.blocks[0]?.content as { inlineUses?: InlineUseDeclaration[] }).inlineUses).toEqual([
+      INLINE_USE,
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/syntax-versions.spec.ts
+++ b/packages/core/src/__tests__/syntax-versions.spec.ts
@@ -9,6 +9,7 @@ import {
   getMinimumVersionForFeature,
   getSyntaxFeatureUsages,
   SYNTAX_FEATURES,
+  usesSequentialOperations,
   type SyntaxFeature,
 } from '../syntax-versions.js';
 import type { Program } from '../types/ast.js';
@@ -43,6 +44,52 @@ describe('SYNTAX_VERSIONS', () => {
   });
 });
 
+describe('usesSequentialOperations', () => {
+  const loc = { file: 'ordered.prs', line: 1, column: 1, offset: 0 };
+  const program = (syntax: string): Program => ({
+    type: 'Program',
+    meta: {
+      type: 'MetaBlock',
+      fields: { id: 'ordered', syntax },
+      loc,
+    },
+    uses: [],
+    blocks: [],
+    extends: [],
+    overrides: [],
+    loc,
+  });
+
+  it('enables ordered execution for syntax 1.6.0 and explicit overrides', () => {
+    const legacyWithOverride = program('1.5.0');
+    legacyWithOverride.overrides = [
+      {
+        type: 'OverrideBlock',
+        targetPath: 'standards.testing',
+        replacement: {
+          type: 'ValueReplacement',
+          value: {
+            type: 'ScalarValueNode',
+            value: true,
+            loc,
+          },
+          loc,
+        },
+        loc,
+      },
+    ];
+
+    expect(usesSequentialOperations(program('1.5.0'))).toBe(false);
+    expect(usesSequentialOperations(program('1.6.0'))).toBe(true);
+    expect(usesSequentialOperations(legacyWithOverride)).toBe(true);
+  });
+
+  it('does not treat partial or invalid versions as sequential', () => {
+    expect(usesSequentialOperations(program('1.6'))).toBe(false);
+    expect(usesSequentialOperations(program('invalid'))).toBe(false);
+  });
+});
+
 describe('registry consistency', () => {
   it('latest version should contain ALL block types from BLOCK_TYPES', () => {
     const latest = getLatestSyntaxVersion();
@@ -69,7 +116,7 @@ describe('registry consistency', () => {
 
 describe('getLatestSyntaxVersion', () => {
   it('should return the highest known version', () => {
-    expect(getLatestSyntaxVersion()).toBe('1.5.0');
+    expect(getLatestSyntaxVersion()).toBe('1.6.0');
   });
 });
 
@@ -125,12 +172,14 @@ describe('syntax feature capabilities', () => {
       SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE,
       SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE,
     ]);
+    expect(getFeaturesForVersion('1.6.0')).toContain(SYNTAX_FEATURES.EXPLICIT_OVERRIDE);
     expect(getFeaturesForVersion('9.9.9')).toBeUndefined();
   });
 
   it('should return the minimum version for registered features', () => {
     expect(getMinimumVersionForFeature(SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE)).toBe('1.3.0');
     expect(getMinimumVersionForFeature(SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE)).toBe('1.5.0');
+    expect(getMinimumVersionForFeature(SYNTAX_FEATURES.EXPLICIT_OVERRIDE)).toBe('1.6.0');
     expect(getMinimumVersionForFeature('unknown-feature' as SyntaxFeature)).toBeUndefined();
   });
 

--- a/packages/core/src/__tests__/syntax-versions.spec.ts
+++ b/packages/core/src/__tests__/syntax-versions.spec.ts
@@ -199,10 +199,23 @@ describe('syntax feature capabilities', () => {
           loc,
         },
       ],
+      overrides: [
+        {
+          type: 'OverrideBlock',
+          targetPath: 'standards.testing',
+          replacement: {
+            type: 'ValueReplacement',
+            value: { type: 'ScalarValueNode', value: true, loc },
+            loc,
+          },
+          loc,
+        },
+      ],
     };
 
     expect(getSyntaxFeatureUsages(ast)).toEqual([
       { feature: SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE, location: loc },
+      { feature: SYNTAX_FEATURES.EXPLICIT_OVERRIDE, location: loc },
     ]);
   });
 

--- a/packages/core/src/block-aliases.ts
+++ b/packages/core/src/block-aliases.ts
@@ -28,13 +28,29 @@ function mergeAliasCollision(base: Block, incoming: Block): Block {
   return mergeBlockCollections([base], [incoming], ALIAS_MERGE_POLICY)[0]!;
 }
 
+export interface NormalizeBlockAliasOptions {
+  readonly preserveDeclarationOrder?: boolean;
+}
+
+function precedes(
+  left: { file: string; line: number; column: number; offset?: number },
+  right: { file: string; line: number; column: number; offset?: number }
+): boolean {
+  if (left.file !== right.file) return false;
+  if (left.offset !== undefined && right.offset !== undefined) return left.offset < right.offset;
+  return left.line < right.line || (left.line === right.line && left.column < right.column);
+}
+
 /**
  * Normalize aliases and merge alias/canonical collisions in source order.
  *
  * Repeated canonical blocks remain distinct for compatibility. A collision is
  * merged only when at least one declaration used an alias.
  */
-export function normalizeBlockAliases(ast: Program): Program {
+export function normalizeBlockAliases(
+  ast: Program,
+  options: NormalizeBlockAliasOptions = {}
+): Program {
   let changed = false;
   const blocks: Block[] = [];
   const aliasNames = new Set<string>();
@@ -43,6 +59,11 @@ export function normalizeBlockAliases(ast: Program): Program {
     const canonicalName = BLOCK_ALIASES[block.name];
     const normalized = canonicalName ? { ...block, name: canonicalName } : block;
     if (canonicalName) changed = true;
+
+    if (options.preserveDeclarationOrder) {
+      blocks.push(normalized);
+      continue;
+    }
 
     const existingIndexes = blocks.flatMap((candidate, index) =>
       candidate.name === normalized.name ? [index] : []
@@ -75,9 +96,16 @@ export function normalizeBlockAliases(ast: Program): Program {
       .map((declaration) => declaration.alias)
       .filter((alias): alias is string => alias !== undefined)
   );
+  const isVisibleUseAlias = (name: string, location: Block['loc']): boolean =>
+    options.preserveDeclarationOrder
+      ? ast.uses.some(
+          (declaration) => declaration.alias === name && precedes(declaration.loc, location)
+        )
+      : useAliases.has(name);
   const extensions = ast.extends.map((extension) => {
     const [root, ...rest] = extension.targetPath.split('.');
-    const canonicalName = root && !useAliases.has(root) ? BLOCK_ALIASES[root] : undefined;
+    const canonicalName =
+      root && !isVisibleUseAlias(root, extension.loc) ? BLOCK_ALIASES[root] : undefined;
     if (!canonicalName) return extension;
     changed = true;
     return {
@@ -85,6 +113,17 @@ export function normalizeBlockAliases(ast: Program): Program {
       targetPath: [canonicalName, ...rest].join('.'),
     };
   });
+  const overrides = (ast.overrides ?? []).map((override) => {
+    const [root, ...rest] = override.targetPath.split('.');
+    const canonicalName =
+      root && !isVisibleUseAlias(root, override.loc) ? BLOCK_ALIASES[root] : undefined;
+    if (!canonicalName) return override;
+    changed = true;
+    return {
+      ...override,
+      targetPath: [canonicalName, ...rest].join('.'),
+    };
+  });
 
-  return changed ? { ...ast, blocks, extends: extensions } : ast;
+  return changed ? { ...ast, blocks, extends: extensions, overrides } : ast;
 }

--- a/packages/core/src/block-import.ts
+++ b/packages/core/src/block-import.ts
@@ -1,0 +1,103 @@
+import type { Block, ObjectContent, Program, UseDeclaration, Value } from './types/index.js';
+import { ResolveError } from './errors/index.js';
+import { IMPORT_MERGE_POLICY, mergeBlockCollections } from './block-merge.js';
+import { getSyntaxFeatureUsages } from './syntax-versions.js';
+import { deepClone } from './utils/index.js';
+
+export const IMPORT_MARKER_PREFIX = '__import__';
+
+function withSkillOutputDirectory(source: Program, outputDir: string): Program {
+  const result = deepClone(source);
+  const skillsBlock = result.blocks.find((block) => block.name === 'skills');
+  if (skillsBlock?.content.type !== 'ObjectContent') return result;
+
+  for (const [name, value] of Object.entries(skillsBlock.content.properties)) {
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      (value as Record<string, Value>)['__outputDir'] = outputDir;
+    } else {
+      skillsBlock.content.properties[name] = {
+        __outputDir: outputDir,
+      } as unknown as Value;
+    }
+  }
+  return result;
+}
+
+function assertNoDuplicateSkills(
+  target: Program,
+  source: Program,
+  declaration: UseDeclaration
+): void {
+  const targetSkills = target.blocks.find((block) => block.name === 'skills');
+  const sourceSkills = source.blocks.find((block) => block.name === 'skills');
+  if (
+    targetSkills?.content.type !== 'ObjectContent' ||
+    sourceSkills?.content.type !== 'ObjectContent'
+  ) {
+    return;
+  }
+
+  const targetProperties = targetSkills.content.properties;
+  const sourceProperties = sourceSkills.content.properties;
+  const duplicates = Object.keys(sourceProperties).filter(
+    (name) =>
+      Object.hasOwn(targetProperties, name) &&
+      JSON.stringify(sourceProperties[name]) !== JSON.stringify(targetProperties[name])
+  );
+  if (duplicates.length > 0) {
+    throw new ResolveError(
+      `Duplicate skill name(s) detected when importing '${declaration.path.raw}': ${duplicates.join(', ')}`,
+      declaration.loc
+    );
+  }
+}
+
+function createAliasBlocks(declaration: UseDeclaration, source: Program): Block[] {
+  if (!declaration.alias) return [];
+
+  const alias = declaration.alias;
+  const marker: Block = {
+    type: 'Block',
+    name: `${IMPORT_MARKER_PREFIX}${alias}`,
+    content: {
+      type: 'ObjectContent',
+      properties: {
+        __source: declaration.path.raw,
+        __blocks: source.blocks.map((block) => block.name),
+      },
+      loc: declaration.loc,
+    } satisfies ObjectContent,
+    loc: declaration.loc,
+  };
+  return [
+    marker,
+    ...source.blocks.map((block) => ({
+      ...block,
+      name: `${IMPORT_MARKER_PREFIX}${alias}.${block.name}`,
+    })),
+  ];
+}
+
+/**
+ * Merge one resolved top-level import into a program.
+ */
+export function resolveUseImport(
+  target: Program,
+  declaration: UseDeclaration,
+  imported: Program
+): Program {
+  const source = declaration.outputDir
+    ? withSkillOutputDirectory(imported, declaration.outputDir)
+    : imported;
+  assertNoDuplicateSkills(target, source, declaration);
+
+  const blocks = mergeBlockCollections(source.blocks, target.blocks, {
+    content: IMPORT_MERGE_POLICY,
+    outputOrder: 'incoming',
+  });
+  return {
+    ...target,
+    blocks: [...blocks, ...createAliasBlocks(declaration, source)],
+    syntaxFeatures: [...getSyntaxFeatureUsages(target), ...getSyntaxFeatureUsages(source)],
+  };
+}

--- a/packages/core/src/block-override.ts
+++ b/packages/core/src/block-override.ts
@@ -122,9 +122,6 @@ function replacementToBlockContent(
         properties: deepClone(value as Record<string, Value>),
         loc: deepClone(location),
       };
-    case 'TemplateValueNode':
-    case 'TypeExpressionValueNode':
-      break;
   }
 
   const observed = value === null ? 'null' : typeof value;
@@ -202,9 +199,6 @@ function valueReplacementToBlockBody(
           { projection: 'TextContent' }
         );
       }
-      break;
-    case 'TemplateValueNode':
-    case 'TypeExpressionValueNode':
       break;
   }
   return blockContentToBody(content);

--- a/packages/core/src/block-override.ts
+++ b/packages/core/src/block-override.ts
@@ -168,39 +168,40 @@ function valueReplacementToBlockBody(
   }
 
   const node = replacement.value;
-  switch (node.type) {
-    case 'ArrayValueNode':
-      return createBlockBody(
-        node.elements.map((element) => ({
-          type: 'ListEntry',
-          value: deepClone(element.value),
-          loc: deepClone(element.loc),
-        })),
-        node.loc,
-        { projection: 'ArrayContent' }
-      );
-    case 'ObjectValueNode':
-      return createBlockBody(
-        node.fields.map((field) => ({
-          type: 'FieldEntry',
-          name: field.name,
-          value: deepClone(field.value),
-          loc: deepClone(field.loc),
-        })),
-        node.loc,
-        { projection: 'ObjectContent' }
-      );
-    case 'ScalarValueNode':
-    case 'TextValueNode':
-      if (typeof node.value === 'string') {
-        return createBlockBody(
-          [{ type: 'TextEntry', text: node.value, loc: deepClone(node.loc) }],
-          node.loc,
-          { projection: 'TextContent' }
-        );
-      }
-      break;
+  if (node.type === 'ArrayValueNode') {
+    return createBlockBody(
+      node.elements.map((element) => ({
+        type: 'ListEntry',
+        value: deepClone(element.value),
+        loc: deepClone(element.loc),
+      })),
+      node.loc,
+      { projection: 'ArrayContent' }
+    );
   }
+  if (node.type === 'ObjectValueNode') {
+    return createBlockBody(
+      node.fields.map((field) => ({
+        type: 'FieldEntry',
+        name: field.name,
+        value: deepClone(field.value),
+        loc: deepClone(field.loc),
+      })),
+      node.loc,
+      { projection: 'ObjectContent' }
+    );
+  }
+  if (
+    (node.type === 'ScalarValueNode' || node.type === 'TextValueNode') &&
+    typeof node.value === 'string'
+  ) {
+    return createBlockBody(
+      [{ type: 'TextEntry', text: node.value, loc: deepClone(node.loc) }],
+      node.loc,
+      { projection: 'TextContent' }
+    );
+  }
+  /* v8 ignore next -- root replacement validation rejects this fallback */
   return blockContentToBody(content);
 }
 
@@ -317,6 +318,7 @@ function createValueNodeFromBlockReplacement(replacement: BlockReplacement): Val
       }),
     };
   }
+  /* v8 ignore next -- block replacements project to text, arrays, or objects */
   return fallback;
 }
 

--- a/packages/core/src/block-override.ts
+++ b/packages/core/src/block-override.ts
@@ -1,0 +1,596 @@
+import type {
+  Block,
+  BlockBody,
+  BlockContent,
+  BlockReplacement,
+  FieldEntry,
+  ObjectContent,
+  OverrideBlock,
+  OverrideReplacement,
+  Program,
+  SourceLocation,
+  Value,
+  ValueNode,
+} from './types/index.js';
+import {
+  blockBodyToContent,
+  blockContentToBody,
+  createBlockBody,
+  createValueNode,
+  reconcileBlockBody,
+  valueNodeToValue,
+} from './canonical-ast.js';
+import { ResolveError } from './errors/index.js';
+import { deepClone } from './utils/index.js';
+
+export const SKILL_REPLACE_PROPERTY_NAMES = [
+  'content',
+  'description',
+  'trigger',
+  'userInvocable',
+  'allowedTools',
+  'disableModelInvocation',
+  'context',
+  'agent',
+  'license',
+] as const;
+
+const SKILL_REPLACE_PROPERTIES = new Set<string>(SKILL_REPLACE_PROPERTY_NAMES);
+
+const DEFAULT_IMPORT_MARKER_PREFIX = '__import__';
+
+function isRecord(value: unknown): value is Record<string, Value> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSourceLocation(value: unknown): value is SourceLocation {
+  return (
+    isRecord(value) &&
+    typeof value['file'] === 'string' &&
+    typeof value['line'] === 'number' &&
+    typeof value['column'] === 'number'
+  );
+}
+
+function isObjectContent(value: unknown): value is ObjectContent {
+  return (
+    isRecord(value) &&
+    value['type'] === 'ObjectContent' &&
+    isRecord(value['properties']) &&
+    isSourceLocation(value['loc'])
+  );
+}
+
+function getRecord(value: Value | undefined): Record<string, Value> | undefined {
+  if (!isRecord(value)) return undefined;
+  return isObjectContent(value) ? value.properties : value;
+}
+
+function getProperties(content: BlockContent): Record<string, Value> | undefined {
+  if (content.type === 'ObjectContent' || content.type === 'MixedContent') {
+    return content.properties;
+  }
+  return undefined;
+}
+
+function resolveSealedKeys(value: Value | undefined): Set<string> {
+  if (value === true) return new Set(SKILL_REPLACE_PROPERTIES);
+  if (!Array.isArray(value)) return new Set();
+  return new Set(
+    value.filter(
+      (entry): entry is string => typeof entry === 'string' && SKILL_REPLACE_PROPERTIES.has(entry)
+    )
+  );
+}
+
+function replacementToBlockContent(
+  replacement: OverrideReplacement,
+  location: SourceLocation,
+  targetPath: string
+): BlockContent {
+  if (replacement.type === 'BlockReplacement') {
+    return blockBodyToContent(replacement.body);
+  }
+
+  const node = replacement.value;
+  const value = valueNodeToValue(node);
+  switch (node.type) {
+    case 'ArrayValueNode':
+      return {
+        type: 'ArrayContent',
+        elements: deepClone(value as Value[]),
+        loc: deepClone(location),
+      };
+    case 'ScalarValueNode':
+      if (typeof node.value === 'string') {
+        return {
+          type: 'TextContent',
+          value: node.value,
+          loc: deepClone(location),
+        };
+      }
+      break;
+    case 'TextValueNode':
+      return {
+        type: 'TextContent',
+        value: node.value,
+        loc: deepClone(node.loc),
+      };
+    case 'ObjectValueNode':
+      return {
+        type: 'ObjectContent',
+        properties: deepClone(value as Record<string, Value>),
+        loc: deepClone(location),
+      };
+    case 'TemplateValueNode':
+    case 'TypeExpressionValueNode':
+      break;
+  }
+
+  const observed = value === null ? 'null' : typeof value;
+  throw new ResolveError(
+    `Cannot replace block "@${targetPath}" with ${observed} content. ` +
+      'Use text, an object, an array, or a regular block body.',
+    location
+  );
+}
+
+function replacementToValue(
+  replacement: OverrideReplacement,
+  location: SourceLocation,
+  targetPath: string
+): Value {
+  if (replacement.type === 'ValueReplacement') {
+    return deepClone(valueNodeToValue(replacement.value));
+  }
+
+  const content = blockBodyToContent(replacement.body);
+  if (content.type === 'TextContent') return deepClone(content);
+  if (content.type === 'ArrayContent') return deepClone(content.elements);
+  if (
+    content.type === 'ObjectContent' &&
+    !content.listItems?.length &&
+    !content.inlineUses?.length
+  ) {
+    return deepClone(content.properties);
+  }
+
+  throw new ResolveError(
+    `Cannot replace nested target "${targetPath}" with mixed block content. ` +
+      'Use one standalone text, object, array, number, boolean, or null value.',
+    location
+  );
+}
+
+function valueReplacementToBlockBody(
+  replacement: OverrideReplacement,
+  content: BlockContent
+): BlockBody {
+  if (replacement.type === 'BlockReplacement') {
+    return deepClone(replacement.body);
+  }
+
+  const node = replacement.value;
+  switch (node.type) {
+    case 'ArrayValueNode':
+      return createBlockBody(
+        node.elements.map((element) => ({
+          type: 'ListEntry',
+          value: deepClone(element.value),
+          loc: deepClone(element.loc),
+        })),
+        node.loc,
+        { projection: 'ArrayContent' }
+      );
+    case 'ObjectValueNode':
+      return createBlockBody(
+        node.fields.map((field) => ({
+          type: 'FieldEntry',
+          name: field.name,
+          value: deepClone(field.value),
+          loc: deepClone(field.loc),
+        })),
+        node.loc,
+        { projection: 'ObjectContent' }
+      );
+    case 'ScalarValueNode':
+    case 'TextValueNode':
+      if (typeof node.value === 'string') {
+        return createBlockBody(
+          [{ type: 'TextEntry', text: node.value, loc: deepClone(node.loc) }],
+          node.loc,
+          { projection: 'TextContent' }
+        );
+      }
+      break;
+    case 'TemplateValueNode':
+    case 'TypeExpressionValueNode':
+      break;
+  }
+  return blockContentToBody(content);
+}
+
+function replaceValueNodeAtPath(
+  node: ValueNode,
+  path: readonly string[],
+  replacement: ValueNode
+): ValueNode {
+  if (path.length === 0) return deepClone(replacement);
+  if (node.type !== 'ObjectValueNode') return deepClone(node);
+
+  const segment = path[0]!;
+  let targetIndex = -1;
+  for (const [index, field] of node.fields.entries()) {
+    if (field.name === segment) targetIndex = index;
+  }
+  if (targetIndex < 0) return deepClone(node);
+
+  return {
+    ...deepClone(node),
+    fields: node.fields.map((field, index) =>
+      index === targetIndex
+        ? {
+            ...deepClone(field),
+            value: replaceValueNodeAtPath(field.value, path.slice(1), replacement),
+            loc: deepClone(path.length === 1 ? replacement.loc : field.loc),
+          }
+        : deepClone(field)
+    ),
+  };
+}
+
+function replaceCanonicalBodyAtPath(
+  block: Block,
+  content: BlockContent,
+  path: readonly string[],
+  replacement: OverrideReplacement
+): BlockBody {
+  const base = block.canonicalBody ?? blockContentToBody(block.content);
+  const reconciled = reconcileBlockBody(base, content);
+  const root = path[0];
+  if (!root) return reconciled;
+
+  let targetIndex = -1;
+  for (const [index, entry] of reconciled.entries.entries()) {
+    if (entry.type === 'FieldEntry' && entry.name === root) targetIndex = index;
+  }
+  if (targetIndex < 0) return reconciled;
+
+  const replacementNode =
+    replacement.type === 'ValueReplacement'
+      ? replacement.value
+      : createValueNodeFromBlockReplacement(replacement);
+
+  return createBlockBody(
+    reconciled.entries.map((entry, index) =>
+      index === targetIndex && entry.type === 'FieldEntry'
+        ? ({
+            ...deepClone(entry),
+            value: replaceValueNodeAtPath(entry.value, path.slice(1), replacementNode),
+          } satisfies FieldEntry)
+        : deepClone(entry)
+    ),
+    reconciled.loc,
+    {
+      ...(reconciled.legacyProjection ? { projection: reconciled.legacyProjection } : {}),
+      ...(reconciled.legacyText ? { text: reconciled.legacyText } : {}),
+    }
+  );
+}
+
+function createValueNodeFromBlockReplacement(replacement: BlockReplacement): ValueNode {
+  const content = blockBodyToContent(replacement.body);
+  const value = replacementToValue(replacement, replacement.loc, '@override');
+  const fallback = createValueNode(value, replacement.loc);
+  if (content.type === 'TextContent') {
+    const text = replacement.body.entries.find((entry) => entry.type === 'TextEntry');
+    return createValueNode(value, text?.loc ?? replacement.loc);
+  }
+  if (fallback.type === 'ArrayValueNode') {
+    const entries = replacement.body.entries.filter((entry) => entry.type === 'ListEntry');
+    return {
+      ...fallback,
+      elements: fallback.elements.map((element, index) => {
+        const entry = entries[index];
+        return entry
+          ? {
+              type: 'ArrayElementNode',
+              value: deepClone(entry.value),
+              loc: deepClone(entry.loc),
+            }
+          : element;
+      }),
+    };
+  }
+  if (fallback.type === 'ObjectValueNode') {
+    const entries = new Map(
+      replacement.body.entries
+        .filter((entry): entry is FieldEntry => entry.type === 'FieldEntry')
+        .map((entry) => [entry.name, entry])
+    );
+    return {
+      ...fallback,
+      fields: fallback.fields.map((field) => {
+        const entry = entries.get(field.name);
+        return entry
+          ? {
+              type: 'ObjectFieldNode',
+              name: field.name,
+              value: deepClone(entry.value),
+              loc: deepClone(entry.loc),
+            }
+          : field;
+      }),
+    };
+  }
+  return fallback;
+}
+
+function missingPathError(
+  targetPath: string,
+  segment: string,
+  location: SourceLocation
+): ResolveError {
+  return new ResolveError(
+    `@override target "${targetPath}" does not exist at segment "${segment}". ` +
+      'Declare or import the complete target before replacing it.',
+    location
+  );
+}
+
+function replaceNestedValue(
+  current: Value,
+  path: readonly string[],
+  replacement: Value,
+  targetPath: string,
+  location: SourceLocation
+): Value {
+  if (path.length === 0) return deepClone(replacement);
+
+  const segment = path[0]!;
+  const record = getRecord(current);
+  if (!record) {
+    throw new ResolveError(
+      `Cannot traverse @override target "${targetPath}" through non-object segment "${segment}".`,
+      location
+    );
+  }
+  if (!Object.hasOwn(record, segment)) {
+    throw missingPathError(targetPath, segment, location);
+  }
+
+  return {
+    ...deepClone(record),
+    [segment]: replaceNestedValue(
+      record[segment]!,
+      path.slice(1),
+      replacement,
+      targetPath,
+      location
+    ),
+  };
+}
+
+function assertSealedSkillReplacement(
+  content: BlockContent,
+  path: readonly string[],
+  replacement: OverrideReplacement,
+  targetPath: string,
+  location: SourceLocation
+): void {
+  const skills = getProperties(content);
+  if (!skills) return;
+
+  if (path.length === 0) {
+    const candidate = getProperties(replacementToBlockContent(replacement, location, targetPath));
+    if (!candidate) {
+      throw new ResolveError(
+        'Cannot replace @skills with non-object content because sealed skill properties must remain enforceable.',
+        location
+      );
+    }
+    for (const [skillName, skillValue] of Object.entries(skills)) {
+      const skill = getRecord(skillValue);
+      if (!skill) continue;
+      const sealed = resolveSealedKeys(skill['sealed']);
+      const candidateSkill = getRecord(candidate[skillName]);
+      if (!candidateSkill) {
+        if (sealed.size === 0) continue;
+        throw new ResolveError(
+          `Cannot remove skill "${skillName}" because it contains sealed properties.`,
+          location
+        );
+      }
+      assertSealedValues(skillName, skill, candidateSkill, sealed, location);
+    }
+    for (const [skillName, skillValue] of Object.entries(candidate)) {
+      if (Object.hasOwn(skills, skillName)) continue;
+      const skill = getRecord(skillValue);
+      if (skill && skill['sealed'] !== undefined) {
+        throw new ResolveError(
+          `Cannot add protected property 'sealed' through @override on skill "${skillName}"`,
+          location
+        );
+      }
+    }
+    return;
+  }
+
+  const skillName = path[0]!;
+  const existingSkill = getRecord(skills[skillName]);
+  if (!existingSkill) return;
+  const sealed = resolveSealedKeys(existingSkill['sealed']);
+
+  if (path.length === 1) {
+    const candidateSkill = getRecord(replacementToValue(replacement, location, targetPath));
+    if (!candidateSkill) {
+      throw new ResolveError(
+        `Cannot replace skill "${skillName}" with non-object content because sealed properties must remain enforceable.`,
+        location
+      );
+    }
+    assertSealedValues(skillName, existingSkill, candidateSkill, sealed, location);
+    return;
+  }
+
+  const propertyName = path[1]!;
+  if (propertyName === 'sealed') {
+    throw new ResolveError("Cannot override protected property 'sealed' on skill", location);
+  }
+  if (sealed.has(propertyName)) {
+    throw new ResolveError(
+      `Cannot override sealed property '${propertyName}' on skill "${skillName}"`,
+      location
+    );
+  }
+}
+
+function assertSealedValues(
+  skillName: string,
+  existing: Record<string, Value>,
+  candidate: Record<string, Value>,
+  sealed: ReadonlySet<string>,
+  location: SourceLocation
+): void {
+  if (!semanticValuesEqual(candidate['sealed'], existing['sealed'], location)) {
+    throw new ResolveError(
+      `Cannot change protected property 'sealed' on skill "${skillName}"`,
+      location
+    );
+  }
+  for (const propertyName of sealed) {
+    if (!semanticValuesEqual(candidate[propertyName], existing[propertyName], location)) {
+      throw new ResolveError(
+        `Cannot change sealed property '${propertyName}' on skill "${skillName}"`,
+        location
+      );
+    }
+  }
+}
+
+function semanticValuesEqual(
+  left: Value | undefined,
+  right: Value | undefined,
+  location: SourceLocation
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return (
+    JSON.stringify(withoutCanonicalLocations(createValueNode(left, location))) ===
+    JSON.stringify(withoutCanonicalLocations(createValueNode(right, location)))
+  );
+}
+
+function withoutCanonicalLocations(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutCanonicalLocations);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'loc')
+      .map(([key, entry]) => [key, withoutCanonicalLocations(entry)])
+  );
+}
+
+function replaceNestedContent(
+  content: BlockContent,
+  path: readonly string[],
+  replacement: Value,
+  targetPath: string,
+  location: SourceLocation
+): BlockContent {
+  const segment = path[0];
+  if ((content.type !== 'ObjectContent' && content.type !== 'MixedContent') || !segment) {
+    throw new ResolveError(
+      `Cannot traverse @override target "${targetPath}" because its root block is not object-shaped.`,
+      location
+    );
+  }
+  const properties = content.properties;
+  if (!Object.hasOwn(properties, segment)) {
+    throw missingPathError(targetPath, segment, location);
+  }
+
+  return {
+    ...deepClone(content),
+    properties: {
+      ...deepClone(properties),
+      [segment]: replaceNestedValue(
+        properties[segment]!,
+        path.slice(1),
+        replacement,
+        targetPath,
+        location
+      ),
+    },
+  };
+}
+
+export interface ApplyOverrideOptions {
+  readonly importMarkerPrefix?: string;
+}
+
+/**
+ * Atomically replace one existing block or nested value.
+ */
+export function applyOverride(
+  ast: Program,
+  override: OverrideBlock,
+  options: ApplyOverrideOptions = {}
+): Program {
+  const markerPrefix = options.importMarkerPrefix ?? DEFAULT_IMPORT_MARKER_PREFIX;
+  const parts = override.targetPath.split('.');
+  const root = parts[0]!;
+  const marker = ast.blocks.find((block) => block.name === `${markerPrefix}${root}`);
+  const targetName = marker && parts.length > 1 ? parts[1]! : root;
+  const path = marker && parts.length > 1 ? parts.slice(2) : parts.slice(1);
+  const markerBlocks = marker ? getProperties(marker.content)?.['__blocks'] : undefined;
+  if (marker && Array.isArray(markerBlocks) && !markerBlocks.some((name) => name === targetName)) {
+    throw new ResolveError(
+      `@override target "${override.targetPath}" is not exported by alias "${root}".`,
+      override.loc
+    );
+  }
+  const index = ast.blocks.findIndex((block) => block.name === targetName);
+
+  if (index < 0) {
+    throw new ResolveError(
+      `@override target "${override.targetPath}" does not exist. ` +
+        'Declare or import it before replacing it.',
+      override.loc
+    );
+  }
+
+  const target = ast.blocks[index]!;
+  if (target.name === 'skills') {
+    assertSealedSkillReplacement(
+      target.content,
+      path,
+      override.replacement,
+      override.targetPath,
+      override.loc
+    );
+  }
+
+  const content =
+    path.length === 0
+      ? replacementToBlockContent(override.replacement, override.loc, override.targetPath)
+      : replaceNestedContent(
+          target.content,
+          path,
+          replacementToValue(override.replacement, override.loc, override.targetPath),
+          override.targetPath,
+          override.loc
+        );
+  const replacementBlock: Block = {
+    ...deepClone(target),
+    content,
+    canonicalBody:
+      path.length === 0
+        ? valueReplacementToBlockBody(override.replacement, content)
+        : replaceCanonicalBodyAtPath(target, content, path, override.replacement),
+  };
+
+  return {
+    ...ast,
+    blocks: [...ast.blocks.slice(0, index), replacementBlock, ...ast.blocks.slice(index + 1)],
+  };
+}

--- a/packages/core/src/canonical-ast.ts
+++ b/packages/core/src/canonical-ast.ts
@@ -9,6 +9,7 @@ import type {
   BlockInput,
   CanonicalBlock,
   CanonicalExtendBlock,
+  CanonicalOverrideBlock,
   CanonicalProgram,
   DeepReadonly,
   ExtendBlock,
@@ -21,6 +22,8 @@ import type {
   ObjectContent,
   ObjectFieldNode,
   ObjectValueNode,
+  OverrideBlock,
+  OverrideReplacement,
   Program,
   ProgramInput,
   ProgramOperation,
@@ -1322,6 +1325,19 @@ export function createCanonicalExtendBlock(
   return deepFreeze(extension);
 }
 
+export function createCanonicalOverrideBlock(
+  targetPath: string,
+  replacement: OverrideReplacement,
+  loc: SourceLocation
+): CanonicalOverrideBlock {
+  return deepFreeze({
+    type: 'CanonicalOverrideBlock',
+    targetPath,
+    replacement: deepClone(replacement),
+    loc: deepClone(loc),
+  });
+}
+
 export function createCanonicalProgram(options: CanonicalProgramOptions): CanonicalProgram {
   const operations = deepClone(options.operations) as ProgramOperation[];
   const inherit = operations.find(
@@ -1336,12 +1352,16 @@ export function createCanonicalProgram(options: CanonicalProgramOptions): Canoni
   const extensions = operations
     .filter((operation) => operation.type === 'ExtendOperation')
     .map((operation) => operation.extension);
+  const overrides = operations
+    .filter((operation) => operation.type === 'OverrideOperation')
+    .map((operation) => operation.override);
 
   const program: CanonicalProgram = {
     type: 'CanonicalProgram',
     uses,
     blocks,
     extends: extensions,
+    overrides,
     operations,
     loc: deepClone(options.loc),
   };
@@ -1392,6 +1412,10 @@ function normalizeExtension(extension: ExtendBlock): CanonicalExtendBlock {
   );
 }
 
+function normalizeOverride(override: OverrideBlock): CanonicalOverrideBlock {
+  return createCanonicalOverrideBlock(override.targetPath, override.replacement, override.loc);
+}
+
 export function normalizeProgram(input: ProgramInput): CanonicalProgram {
   if (isCanonicalProgram(input)) {
     return createCanonicalProgram({
@@ -1433,6 +1457,14 @@ export function normalizeProgram(input: ProgramInput): CanonicalProgram {
       extension: normalizeExtension(extension),
       sourceLayerId: extension.loc.file,
       loc: deepClone(extension.loc),
+    });
+  }
+  for (const override of input.overrides ?? []) {
+    operations.push({
+      type: 'OverrideOperation',
+      override: normalizeOverride(override),
+      sourceLayerId: override.loc.file,
+      loc: deepClone(override.loc),
     });
   }
   for (let start = 0; start < operations.length; ) {
@@ -1498,6 +1530,12 @@ export function toLegacyProgram(
       }
       return result;
     }),
+    overrides: (program.overrides ?? []).map((override) => ({
+      type: 'OverrideBlock',
+      targetPath: override.targetPath,
+      replacement: deepClone(override.replacement) as OverrideReplacement,
+      loc: deepClone(override.loc),
+    })),
     loc: deepClone(program.loc),
   };
   if (program.meta) legacy.meta = deepClone(program.meta) as MetaBlock;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,9 @@ export * from './canonical-ast.js';
 export * from './block-merge.js';
 export * from './block-shapes.js';
 export * from './block-aliases.js';
+export * from './block-override.js';
+export * from './block-import.js';
+export * from './inline-uses.js';
 export * from './presentation.js';
 
 // Syntax version registry

--- a/packages/core/src/inline-uses.ts
+++ b/packages/core/src/inline-uses.ts
@@ -1,0 +1,28 @@
+import type { ObjectContent, Program } from './types/index.js';
+
+/**
+ * Consume pending inline uses after a composition attempt fails.
+ */
+export function consumeInlineUses(ast: Program): Program {
+  let changed = false;
+  const blocks = ast.blocks.map((block) => {
+    if (
+      block.name !== 'skills' ||
+      block.content.type !== 'ObjectContent' ||
+      !block.content.inlineUses?.length
+    ) {
+      return block;
+    }
+
+    changed = true;
+    return {
+      ...block,
+      content: {
+        ...block.content,
+        inlineUses: undefined,
+      } satisfies ObjectContent,
+    };
+  });
+
+  return changed ? { ...ast, blocks } : ast;
+}

--- a/packages/core/src/section-registry.ts
+++ b/packages/core/src/section-registry.ts
@@ -2,6 +2,7 @@
  * Browser-safe contract for a generated human-readable section.
  */
 export const CONTEXTUAL_DIRECTIVES = ['@header'] as const;
+export const CONTEXTUAL_OPERATION_DIRECTIVES = ['@override'] as const;
 
 export interface SectionContract {
   readonly id: string;

--- a/packages/core/src/syntax-versions.ts
+++ b/packages/core/src/syntax-versions.ts
@@ -1,4 +1,4 @@
-import { compareVersions } from './utils/version.js';
+import { compareVersions, isValidVersion } from './utils/version.js';
 import type { Program, SourceLocation } from './types/index.js';
 
 /**
@@ -7,6 +7,7 @@ import type { Program, SourceLocation } from './types/index.js';
 export const SYNTAX_FEATURES = {
   REGULAR_BLOCK_REPLACE: 'regular-block-replace',
   SECTION_HEADER_OVERRIDE: 'section-header-override',
+  EXPLICIT_OVERRIDE: 'explicit-override',
 } as const;
 
 export type SyntaxFeature = (typeof SYNTAX_FEATURES)[keyof typeof SYNTAX_FEATURES];
@@ -155,10 +156,37 @@ export const SYNTAX_VERSIONS: Readonly<Record<string, SyntaxVersionDef>> = {
     ],
     features: [SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE, SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE],
   },
+  '1.6.0': {
+    blocks: [
+      'identity',
+      'context',
+      'standards',
+      'restrictions',
+      'knowledge',
+      'shortcuts',
+      'commands',
+      'guards',
+      'params',
+      'skills',
+      'local',
+      'agents',
+      'workflows',
+      'hooks',
+      'mcpServers',
+      'plugins',
+      'prompts',
+      'examples',
+    ],
+    features: [
+      SYNTAX_FEATURES.REGULAR_BLOCK_REPLACE,
+      SYNTAX_FEATURES.SECTION_HEADER_OVERRIDE,
+      SYNTAX_FEATURES.EXPLICIT_OVERRIDE,
+    ],
+  },
 };
 
 /** Latest known syntax version. */
-export const LATEST_SYNTAX_VERSION = '1.5.0';
+export const LATEST_SYNTAX_VERSION = '1.6.0';
 
 /**
  * Get the latest known syntax version.
@@ -219,6 +247,22 @@ export function getMinimumVersionForFeature(feature: SyntaxFeature): string | un
 }
 
 /**
+ * Select declaration-ordered resolution for syntax 1.6.0+ or explicit override usage.
+ */
+export function usesSequentialOperations(ast: Program): boolean {
+  if ((ast.overrides?.length ?? 0) > 0) return true;
+
+  const syntaxVersion = ast.meta?.fields['syntax'];
+  const minimumVersion = getMinimumVersionForFeature(SYNTAX_FEATURES.EXPLICIT_OVERRIDE);
+  return (
+    typeof syntaxVersion === 'string' &&
+    isValidVersion(syntaxVersion) &&
+    minimumVersion !== undefined &&
+    compareVersions(syntaxVersion, minimumVersion) >= 0
+  );
+}
+
+/**
  * Find all versioned non-block syntax features used by a parsed program.
  */
 export function getSyntaxFeatureUsages(ast: Program): SyntaxFeatureUsage[] {
@@ -230,6 +274,12 @@ export function getSyntaxFeatureUsages(ast: Program): SyntaxFeatureUsage[] {
         location: modifier.loc,
       });
     }
+  }
+  for (const override of ast.overrides ?? []) {
+    usages.push({
+      feature: SYNTAX_FEATURES.EXPLICIT_OVERRIDE,
+      location: override.loc,
+    });
   }
 
   const seen = new Set<string>();

--- a/packages/core/src/types/ast.ts
+++ b/packages/core/src/types/ast.ts
@@ -116,6 +116,8 @@ export interface Program extends BaseNode {
   blocks: Block[];
   /** Extension blocks (@extend) */
   extends: ExtendBlock[];
+  /** Explicit replacement blocks (@override) */
+  overrides?: OverrideBlock[];
   /** Versioned syntax features retained after destructive resolution passes */
   syntaxFeatures?: SyntaxFeatureUsage[];
 }
@@ -314,6 +316,35 @@ export interface ExtendBlock extends BaseNode {
   canonicalBody?: BlockBody;
   /** Fields whose complete prior values must be replaced */
   replacements?: ReplaceModifier[];
+}
+
+/**
+ * Complete replacement for a block body.
+ */
+export interface BlockReplacement extends BaseNode {
+  readonly type: 'BlockReplacement';
+  body: BlockBody;
+}
+
+/**
+ * Complete replacement for a nested value.
+ */
+export interface ValueReplacement extends BaseNode {
+  readonly type: 'ValueReplacement';
+  value: ValueNode;
+}
+
+export type OverrideReplacement = BlockReplacement | ValueReplacement;
+
+/**
+ * Explicit replacement of an existing block or nested value.
+ */
+export interface OverrideBlock extends BaseNode {
+  readonly type: 'OverrideBlock';
+  /** Dot-separated path to an existing target */
+  targetPath: string;
+  /** Complete replacement value */
+  replacement: OverrideReplacement;
 }
 
 /**
@@ -600,6 +631,15 @@ export interface CanonicalExtendBlock extends CanonicalNode {
 }
 
 /**
+ * Immutable canonical override block.
+ */
+export interface CanonicalOverrideBlock extends CanonicalNode {
+  readonly type: 'CanonicalOverrideBlock';
+  readonly targetPath: string;
+  readonly replacement: DeepReadonly<OverrideReplacement>;
+}
+
+/**
  * Canonical inheritance operation.
  */
 export interface InheritOperation extends CanonicalNode {
@@ -636,9 +676,23 @@ export interface ExtendOperation extends CanonicalNode {
 }
 
 /**
+ * Canonical explicit replacement operation.
+ */
+export interface OverrideOperation extends CanonicalNode {
+  readonly type: 'OverrideOperation';
+  readonly override: CanonicalOverrideBlock;
+  readonly sourceLayerId: string;
+}
+
+/**
  * Ordered semantic declaration in a canonical program.
  */
-export type ProgramOperation = InheritOperation | UseOperation | BlockOperation | ExtendOperation;
+export type ProgramOperation =
+  | InheritOperation
+  | UseOperation
+  | BlockOperation
+  | ExtendOperation
+  | OverrideOperation;
 
 /**
  * Immutable canonical program. Legacy collection fields are derived projections.
@@ -650,6 +704,7 @@ export interface CanonicalProgram extends CanonicalNode {
   readonly uses: readonly DeepReadonly<UseDeclaration>[];
   readonly blocks: readonly CanonicalBlock[];
   readonly extends: readonly CanonicalExtendBlock[];
+  readonly overrides?: readonly CanonicalOverrideBlock[];
   readonly syntaxFeatures?: readonly DeepReadonly<SyntaxFeatureUsage>[];
   readonly operations: readonly ProgramOperation[];
 }

--- a/packages/parser/src/__tests__/canonical-ast.spec.ts
+++ b/packages/parser/src/__tests__/canonical-ast.spec.ts
@@ -24,6 +24,88 @@ describe('canonical AST', () => {
     expect(ast.extends).toHaveLength(1);
   });
 
+  it('preserves explicit overrides in declaration order and legacy projections', () => {
+    const source = `
+      @meta { id: "override-order" syntax: "1.6.0" }
+      @standards { testing: ["Old"] }
+      @override standards.testing { ["Use Vitest"] }
+      @extend standards.testing { - "Require coverage" }
+    `;
+    const canonical = parseCanonicalOrThrow(source, { filename: 'override.prs' });
+    const legacy = parseOrThrow(source, { filename: 'override.prs' });
+
+    expect(canonical.operations.map((operation) => operation.type)).toEqual([
+      'BlockOperation',
+      'OverrideOperation',
+      'ExtendOperation',
+    ]);
+    expect(canonical.overrides).toHaveLength(1);
+    expect(canonical.overrides?.[0]?.replacement.type).toBe('ValueReplacement');
+    expect(legacy.overrides).toHaveLength(1);
+    expect(legacy.overrides?.[0]?.targetPath).toBe('standards.testing');
+  });
+
+  it('parses regular block bodies and standalone override values', () => {
+    const ast = parseCanonicalOrThrow(`
+      @meta { id: "override-values" syntax: "1.6.0" }
+      @standards { testing: ["Old"] }
+      @override standards { testing: ["New"] }
+      @override standards.testing { { runner: "vitest" } }
+      @override standards.testing.runner { "node" }
+      @override standards.testing.enabled { true }
+      @override standards.testing.retries { 3 }
+      @override standards.testing.optional { null }
+    `);
+
+    expect(ast.overrides?.map((operation) => operation.replacement.type)).toEqual([
+      'BlockReplacement',
+      'ValueReplacement',
+      'ValueReplacement',
+      'ValueReplacement',
+      'ValueReplacement',
+      'ValueReplacement',
+    ]);
+  });
+
+  it('keeps @override without a target as a custom block', () => {
+    const ast = parseCanonicalOrThrow(`
+      @meta { id: "custom-override" syntax: "1.0.0" }
+      @override { mode: "custom" }
+    `);
+
+    expect(ast.blocks.map((block) => block.name)).toEqual(['override']);
+    expect(ast.overrides).toEqual([]);
+    expect(ast.syntaxFeatures).toEqual([]);
+  });
+
+  it('keeps override legal in fields, aliases, parameters, and path segments', () => {
+    const ast = parseCanonicalOrThrow(`
+      @meta { id: "override-identifiers" syntax: "1.6.0" }
+      @params { override: "default" }
+      @use ./shared as override
+      @standards { override: true }
+      @override standards.override { false }
+    `);
+
+    expect(ast.uses[0]?.alias).toBe('override');
+    expect(ast.blocks.map((block) => block.name)).toEqual(['params', 'standards']);
+    expect(ast.overrides?.[0]?.targetPath).toBe('standards.override');
+  });
+
+  it('reports an empty explicit override body', () => {
+    const result = parse('@override standards {}', {
+      recovery: true,
+      filename: 'empty-override.prs',
+    });
+
+    expect(result.ast?.overrides).toHaveLength(1);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: '@override requires a non-empty replacement body.',
+      }),
+    ]);
+  });
+
   it('uses one ordered body for text, fields, lists, and inline imports', () => {
     const ast = parseCanonicalOrThrow(
       `

--- a/packages/parser/src/__tests__/canonical-ast.spec.ts
+++ b/packages/parser/src/__tests__/canonical-ast.spec.ts
@@ -106,6 +106,21 @@ describe('canonical AST', () => {
     ]);
   });
 
+  it('reports redundant replace modifiers inside explicit overrides', () => {
+    const result = parse('@override standards { testing!: ["Use Vitest"] }', {
+      recovery: true,
+      filename: 'replace-modifier.prs',
+    });
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "The '!' replace modifier is unnecessary inside @override"
+        ),
+      }),
+    ]);
+  });
+
   it('uses one ordered body for text, fields, lists, and inline imports', () => {
     const ast = parseCanonicalOrThrow(
       `

--- a/packages/parser/src/grammar/parser.ts
+++ b/packages/parser/src/grammar/parser.ts
@@ -59,7 +59,7 @@ export class PromptScriptParser extends CstParser {
 
   /**
    * program
-   *   : metaBlock? (inheritDecl | useDecl | extendBlock | block)*
+   *   : metaBlock? (inheritDecl | useDecl | extendBlock | overrideBlock | block)*
    */
   public program = this.RULE('program', () => {
     this.OPTION(() => this.SUBRULE(this.metaBlock));
@@ -68,6 +68,10 @@ export class PromptScriptParser extends CstParser {
         { ALT: () => this.SUBRULE(this.inheritDecl) },
         { ALT: () => this.SUBRULE(this.useDecl) },
         { ALT: () => this.SUBRULE(this.extendBlock) },
+        {
+          ALT: () => this.SUBRULE(this.overrideBlock),
+          GATE: () => this.isOverrideDirectiveAhead(),
+        },
         { ALT: () => this.SUBRULE(this.block) },
       ])
     );
@@ -140,6 +144,33 @@ export class PromptScriptParser extends CstParser {
     this.CONSUME(LBrace);
     this.SUBRULE(this.blockContent);
     this.CONSUME(RBrace);
+  });
+
+  /**
+   * overrideBlock
+   *   : '@' Identifier dotPath '{' overrideBody '}'
+   */
+  private overrideBlock = this.RULE('overrideBlock', () => {
+    this.CONSUME(At);
+    this.CONSUME(Identifier);
+    this.SUBRULE(this.dotPath);
+    this.CONSUME(LBrace);
+    this.SUBRULE(this.overrideBody);
+    this.CONSUME(RBrace);
+  });
+
+  /**
+   * overrideBody
+   *   : blockContent | value
+   */
+  private overrideBody = this.RULE('overrideBody', () => {
+    this.OR([
+      {
+        ALT: () => this.SUBRULE(this.blockContent),
+        GATE: () => this.isOverrideBlockBodyAhead(),
+      },
+      { ALT: () => this.SUBRULE(this.value) },
+    ]);
   });
 
   /**
@@ -268,6 +299,38 @@ export class PromptScriptParser extends CstParser {
     if (!first || first.tokenType?.name !== 'At') return false;
     const second = this.LA(2);
     return second?.tokenType?.name === 'Identifier' && second.image === 'header';
+  }
+
+  private isOverrideDirectiveAhead(): boolean {
+    const at = this.LA(1);
+    const directive = this.LA(2);
+    const target = this.LA(3);
+    return (
+      at?.tokenType?.name === 'At' &&
+      directive?.tokenType?.name === 'Identifier' &&
+      directive.image === 'override' &&
+      target?.tokenType?.name !== 'LBrace'
+    );
+  }
+
+  private isOverrideBlockBodyAhead(): boolean {
+    const first = this.LA(1);
+    if (!first) return false;
+    const firstType = first.tokenType?.name;
+    if (['RBrace', 'Dash', 'At', 'TextBlock'].includes(firstType ?? '')) {
+      return true;
+    }
+
+    if (
+      ['Identifier', 'StringLiteral', 'StringType', 'NumberType', 'BooleanType'].includes(
+        firstType ?? ''
+      )
+    ) {
+      const secondType = this.LA(2)?.tokenType?.name;
+      return ['Colon', 'Question', 'Bang'].includes(secondType ?? '');
+    }
+
+    return false;
   }
 
   /**

--- a/packages/parser/src/grammar/visitor.ts
+++ b/packages/parser/src/grammar/visitor.ts
@@ -7,9 +7,11 @@ import type {
   BlockEntry,
   CanonicalBlock,
   CanonicalExtendBlock,
+  CanonicalOverrideBlock,
   CanonicalProgram,
   FieldEntry,
   PresentationEntry,
+  OverrideReplacement,
   ProgramOperation,
   MetaBlock,
   InheritDeclaration,
@@ -32,6 +34,7 @@ import {
   createBlockBody,
   createCanonicalBlock,
   createCanonicalExtendBlock,
+  createCanonicalOverrideBlock,
   createCanonicalProgram,
   createValueNode,
   normalizeLegacyHeadingEntries,
@@ -53,6 +56,7 @@ interface ProgramCstCtx {
   useDecl?: CstNode[];
   block?: CstNode[];
   extendBlock?: CstNode[];
+  overrideBlock?: CstNode[];
 }
 
 interface MetaBlockCstCtx {
@@ -94,6 +98,18 @@ interface ExtendBlockCstCtx {
   dotPath: CstNode[];
   LBrace: IToken[];
   blockContent: CstNode[];
+}
+
+interface OverrideBlockCstCtx {
+  At: IToken[];
+  dotPath: CstNode[];
+  LBrace: IToken[];
+  overrideBody: CstNode[];
+}
+
+interface OverrideBodyCstCtx {
+  blockContent?: CstNode[];
+  value?: CstNode[];
 }
 
 interface BlockContentCstCtx {
@@ -357,6 +373,7 @@ class PromptScriptVisitor extends BaseVisitor {
       ...(ctx.useDecl ?? []),
       ...(ctx.block ?? []),
       ...(ctx.extendBlock ?? []),
+      ...(ctx.overrideBlock ?? []),
     ]
       .map(
         (node) =>
@@ -365,6 +382,7 @@ class PromptScriptVisitor extends BaseVisitor {
             | UseDeclaration
             | CanonicalBlock
             | CanonicalExtendBlock
+            | CanonicalOverrideBlock
       )
       .sort((left, right) => (left.loc.offset ?? 0) - (right.loc.offset ?? 0));
     const operations: ProgramOperation[] = declarations.map((declaration) => {
@@ -394,6 +412,13 @@ class PromptScriptVisitor extends BaseVisitor {
           return {
             type: 'ExtendOperation',
             extension: declaration,
+            sourceLayerId,
+            loc: declaration.loc,
+          };
+        case 'CanonicalOverrideBlock':
+          return {
+            type: 'OverrideOperation',
+            override: declaration,
             sourceLayerId,
             loc: declaration.loc,
           };
@@ -594,6 +619,64 @@ class PromptScriptVisitor extends BaseVisitor {
       replacements,
       this.loc(ctx.At[0]!)
     );
+  }
+
+  /**
+   * overrideBlock → CanonicalOverrideBlock
+   */
+  overrideBlock(ctx: OverrideBlockCstCtx): CanonicalOverrideBlock {
+    const targetPath = this.visit(ctx.dotPath[0]!) as string;
+    const replacement = this.visit(ctx.overrideBody[0]!) as OverrideReplacement;
+    const directiveLoc = this.loc(ctx.At[0]!);
+    this.syntaxFeatures.push({
+      feature: SYNTAX_FEATURES.EXPLICIT_OVERRIDE,
+      location: directiveLoc,
+    });
+    if (replacement.type === 'BlockReplacement' && replacement.body.entries.length === 0) {
+      this.diagnostics.push({
+        message: '@override requires a non-empty replacement body.',
+        loc: directiveLoc,
+      });
+    }
+    return createCanonicalOverrideBlock(targetPath, replacement, directiveLoc);
+  }
+
+  /**
+   * overrideBody → OverrideReplacement
+   */
+  overrideBody(ctx: OverrideBodyCstCtx): OverrideReplacement {
+    if (ctx.blockContent) {
+      const { body, replacements } = this.visit(ctx.blockContent[0]!) as ParsedBlockContent;
+      for (const replacement of replacements) {
+        this.diagnostics.push({
+          message: "The '!' replace modifier is unnecessary inside @override. Remove the modifier.",
+          loc: replacement.loc,
+        });
+      }
+      return {
+        type: 'BlockReplacement',
+        body,
+        loc: body.loc,
+      };
+    }
+
+    const valueCst = ctx.value?.[0];
+    if (!valueCst) {
+      throw new Error('@override replacement value is unavailable');
+    }
+    const value = this.visit(valueCst) as Value;
+    const fallbackLoc = {
+      file: this.filename,
+      line: 1,
+      column: 1,
+      offset: 0,
+    };
+    const valueNode = this.createValueNodeFromCst(valueCst, value, fallbackLoc);
+    return {
+      type: 'ValueReplacement',
+      value: valueNode,
+      loc: valueNode.loc,
+    };
   }
 
   /**

--- a/packages/parser/src/grammar/visitor.ts
+++ b/packages/parser/src/grammar/visitor.ts
@@ -662,6 +662,7 @@ class PromptScriptVisitor extends BaseVisitor {
 
     const valueCst = ctx.value?.[0];
     if (!valueCst) {
+      /* v8 ignore next -- grammar requires one replacement value */
       throw new Error('@override replacement value is unavailable');
     }
     const value = this.visit(valueCst) as Value;

--- a/packages/playground/src/__tests__/prs-language.spec.ts
+++ b/packages/playground/src/__tests__/prs-language.spec.ts
@@ -81,8 +81,20 @@ describe('prs-language', () => {
       expect(directives).toContain('@examples');
       expect(directives).toContain('@hooks');
       expect(directives).toContain('@mcpServers');
+      expect(prsLanguageDefinition.operationDirectives).toContain('@override');
       expect(directives).toContain('@plugins');
       expect(BLOCK_TYPES.every((blockType) => directives.includes(`@${blockType}`))).toBe(true);
+    });
+
+    it('should highlight override only when it has a target', () => {
+      expect(resolveRootToken('@override standards.testing {')).toEqual({
+        image: '@override',
+        token: 'keyword.directive',
+      });
+      expect(resolveRootToken('@override {')).toEqual({
+        image: '@override',
+        token: 'identifier.directive',
+      });
     });
 
     it('should have root tokenizer rules', () => {

--- a/packages/playground/src/utils/prs-language.ts
+++ b/packages/playground/src/utils/prs-language.ts
@@ -3,7 +3,11 @@
  */
 
 import type * as Monaco from 'monaco-editor';
-import { BLOCK_TYPES, CONTEXTUAL_DIRECTIVES } from '@promptscript/core';
+import {
+  BLOCK_TYPES,
+  CONTEXTUAL_DIRECTIVES,
+  CONTEXTUAL_OPERATION_DIRECTIVES,
+} from '@promptscript/core';
 
 export const PRS_LANGUAGE_ID = 'promptscript';
 const CONTROL_DIRECTIVES = ['@meta', '@inherit', '@extend', '@use', ...CONTEXTUAL_DIRECTIVES];
@@ -20,6 +24,7 @@ export const prsLanguageDefinition: Monaco.languages.IMonarchLanguage = {
 
   // Directive names
   directives: [...CONTROL_DIRECTIVES, ...BLOCK_DIRECTIVES],
+  operationDirectives: [...CONTEXTUAL_OPERATION_DIRECTIVES],
 
   // Operators and symbols
   operators: [':', '!'],
@@ -36,6 +41,9 @@ export const prsLanguageDefinition: Monaco.languages.IMonarchLanguage = {
 
       // Registry paths (@scope/path@version)
       [/@[a-zA-Z_][a-zA-Z0-9_-]*\/[a-zA-Z0-9_/.-]*(?:@[a-zA-Z0-9^~./-]+)?/, 'string.url'],
+
+      // Contextual operations require a target path before the body.
+      [/@override(?=\s+[a-zA-Z_][\w-]*(?:\.[a-zA-Z_][\w-]*)*\s*\{)/, 'keyword.directive'],
 
       // Directives
       [

--- a/packages/resolver/src/__tests__/override.spec.ts
+++ b/packages/resolver/src/__tests__/override.spec.ts
@@ -2,7 +2,13 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { SYNTAX_FEATURES, type Block, type ObjectContent, type Value } from '@promptscript/core';
+import {
+  SYNTAX_FEATURES,
+  type Block,
+  type Logger,
+  type ObjectContent,
+  type Value,
+} from '@promptscript/core';
 import { Resolver } from '../resolver.js';
 
 const testDirectories: string[] = [];
@@ -450,6 +456,34 @@ describe('explicit override resolution', () => {
     expect(result.errors).toHaveLength(2);
     expect(result.errors.map((error) => error.message).join(' ')).toContain('missing');
     expect((skills?.content as ObjectContent).inlineUses).toBeUndefined();
+  });
+
+  it('normalizes unexpected ordered extension failures', async () => {
+    const directory = await createProject(`
+      @meta { id: "extension-error" syntax: "1.6.0" }
+      @extend missing { enabled: true }
+    `);
+    const logger: Logger = {
+      verbose: () => {},
+      debug: () => {},
+      warn: () => {
+        throw new Error('logger failure');
+      },
+    };
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      logger,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: 'Extension resolution failed: logger failure',
+      }),
+    ]);
   });
 
   it('returns actionable errors without partially applying invalid overrides', async () => {

--- a/packages/resolver/src/__tests__/override.spec.ts
+++ b/packages/resolver/src/__tests__/override.spec.ts
@@ -1,0 +1,543 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SYNTAX_FEATURES, type Block, type ObjectContent, type Value } from '@promptscript/core';
+import { Resolver } from '../resolver.js';
+
+const testDirectories: string[] = [];
+
+async function createProject(source: string, files: Record<string, string> = {}): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'prs-override-'));
+  testDirectories.push(directory);
+  await writeFile(join(directory, 'project.prs'), source);
+  await Promise.all(
+    Object.entries(files).map(([name, content]) => writeFile(join(directory, name), content))
+  );
+  return directory;
+}
+
+function properties(blocks: Block[], name: string): Record<string, Value> {
+  const block = blocks.find((candidate) => candidate.name === name);
+  if (block?.content.type !== 'ObjectContent') {
+    throw new Error(`Expected @${name} object content`);
+  }
+  return (block.content as ObjectContent).properties;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    testDirectories.splice(0).map((directory) => rm(directory, { recursive: true }))
+  );
+});
+
+describe('explicit override resolution', () => {
+  it('replaces nested values and lets later extensions merge the replacement', async () => {
+    const directory = await createProject(`
+      @meta { id: "ordered" syntax: "1.6.0" }
+      @standards {
+        testing: ["Use Jest"]
+        config: { runner: "jest" coverage: 80 }
+      }
+      @override standards.testing { ["Use Vitest"] }
+      @extend standards { testing: ["Require coverage"] }
+      @override standards.config.runner { "vitest" }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+    const standards = properties(result.ast?.blocks ?? [], 'standards');
+
+    expect(result.errors).toEqual([]);
+    expect(standards['testing']).toEqual(['Use Vitest', 'Require coverage']);
+    expect(standards['config']).toEqual({ runner: 'vitest', coverage: 80 });
+    expect(result.ast?.overrides).toEqual([]);
+    expect(result.ast?.extends).toEqual([]);
+  });
+
+  it('replaces inherited and aliased imported targets', async () => {
+    const directory = await createProject(
+      `
+        @meta { id: "child" syntax: "1.6.0" }
+        @inherit ./parent
+        @use ./shared as shared
+        @override context.runtime { "bun" }
+        @override shared.standards.testing { ["Use Vitest"] }
+      `,
+      {
+        'parent.prs': `
+          @meta { id: "parent" syntax: "1.6.0" }
+          @context { runtime: "node" }
+        `,
+        'shared.prs': `
+          @meta { id: "shared" syntax: "1.6.0" }
+          @standards { testing: ["Use Jest"] }
+        `,
+      }
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(properties(result.ast?.blocks ?? [], 'context')['runtime']).toBe('bun');
+    expect(properties(result.ast?.blocks ?? [], 'standards')['testing']).toEqual(['Use Vitest']);
+    expect(result.ast?.blocks.some((block) => block.name.startsWith('__import__'))).toBe(false);
+  });
+
+  it('uses declaration order when override syntax enables sequential operations', async () => {
+    const directory = await createProject(`
+      @meta { id: "sequential" syntax: "1.6.0" }
+      @standards { testing: ["First"] }
+      @override standards.testing { ["Second"] }
+      @standards { linting: ["Keep duplicate layer"] }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(result.ast?.blocks).toHaveLength(2);
+    expect(properties(result.ast?.blocks ?? [], 'standards')['testing']).toEqual(['Second']);
+  });
+
+  it('lets later inherit operations replace earlier block values', async () => {
+    const directory = await createProject(
+      `
+        @meta { id: "sequential-inherit" syntax: "1.6.0" }
+        @context { runtime: "local" localOnly: true }
+        @inherit ./parent
+      `,
+      {
+        'parent.prs': `
+          @meta { id: "parent" syntax: "1.6.0" }
+          @context { runtime: "parent" parentOnly: true }
+        `,
+      }
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(properties(result.ast?.blocks ?? [], 'context')).toEqual({
+      runtime: 'parent',
+      localOnly: true,
+      parentOnly: true,
+    });
+  });
+
+  it('imports skills whose names collide with object prototypes', async () => {
+    const directory = await createProject(
+      `
+        @meta { id: "prototype-skill" syntax: "1.6.0" }
+        @skills { review: { description: "Review" content: "Review code" } }
+        @use ./shared
+      `,
+      {
+        'shared.prs': `
+          @meta { id: "shared" syntax: "1.6.0" }
+          @skills {
+            toString: { description: "Stringify" content: "Stringify output" }
+          }
+        `,
+      }
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(Object.hasOwn(properties(result.ast?.blocks ?? [], 'skills'), 'toString')).toBe(true);
+  });
+
+  it('keeps block aliases in declaration order', async () => {
+    const directory = await createProject(`
+      @meta { id: "alias-order" syntax: "1.6.0" }
+      @shortcuts { test: { description: "Old" } }
+      @override shortcuts.test { { description: "New" } }
+      @commands { build: { description: "Build" } }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(result.ast?.blocks.map((block) => block.name)).toEqual(['shortcuts', 'shortcuts']);
+    expect(properties(result.ast?.blocks ?? [], 'shortcuts')['test']).toEqual({
+      description: 'New',
+    });
+  });
+
+  it('does not let later import aliases reinterpret earlier override targets', async () => {
+    const directory = await createProject(
+      `
+        @meta { id: "future-alias" syntax: "1.6.0" }
+        @commands { test: { description: "Old" } }
+        @override commands.test { { description: "New" } }
+        @use ./shared as commands
+      `,
+      {
+        'shared.prs': `
+          @meta { id: "shared" syntax: "1.6.0" }
+          @standards { testing: ["Use Vitest"] }
+        `,
+      }
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(properties(result.ast?.blocks ?? [], 'shortcuts')['test']).toEqual({
+      description: 'New',
+    });
+  });
+
+  it('keeps legacy phase order before syntax 1.6.0 without overrides', async () => {
+    const legacyDirectory = await createProject(`
+      @meta { id: "legacy" syntax: "1.5.0" }
+      @extend standards { testing: ["Extended first"] }
+      @standards { testing: ["Declared later"] }
+    `);
+    const sequentialDirectory = await createProject(`
+      @meta { id: "sequential" syntax: "1.6.0" }
+      @extend standards { testing: ["Ignored before target"] }
+      @standards { testing: ["Declared later"] }
+    `);
+    const legacyResolver = new Resolver({
+      registryPath: legacyDirectory,
+      localPath: legacyDirectory,
+      cache: false,
+    });
+    const sequentialResolver = new Resolver({
+      registryPath: sequentialDirectory,
+      localPath: sequentialDirectory,
+      cache: false,
+    });
+
+    const legacy = await legacyResolver.resolve(join(legacyDirectory, 'project.prs'));
+    const sequential = await sequentialResolver.resolve(join(sequentialDirectory, 'project.prs'));
+
+    expect(legacy.errors).toEqual([]);
+    expect(properties(legacy.ast?.blocks ?? [], 'standards')['testing']).toEqual([
+      'Declared later',
+      'Extended first',
+    ]);
+    expect(sequential.errors).toEqual([]);
+    expect(properties(sequential.ast?.blocks ?? [], 'standards')['testing']).toEqual([
+      'Declared later',
+    ]);
+  });
+
+  it('requires imports to precede overrides', async () => {
+    const directory = await createProject(
+      `
+        @meta { id: "ordered-import" syntax: "1.6.0" }
+        @override standards.testing { ["Too early"] }
+        @use ./shared
+      `,
+      {
+        'shared.prs': `
+          @meta { id: "shared" syntax: "1.6.0" }
+          @standards { testing: ["Imported"] }
+        `,
+      }
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('@override target "standards.testing" does not exist'),
+      }),
+    ]);
+    expect(properties(result.ast?.blocks ?? [], 'standards')['testing']).toEqual(['Imported']);
+  });
+
+  it('supports root bodies, nested primitives, and complete replacement', async () => {
+    const directory = await createProject(`
+      @meta { id: "shapes" syntax: "1.6.0" }
+      @identity { """Old identity""" }
+      @restrictions { - "Old restriction" }
+      @standards {
+        config: { enabled: true retries: 1 optional: "value" }
+        old: true
+      }
+      @override identity { "New identity" }
+      @override restrictions { ["New restriction"] }
+      @override standards {
+        """Required engineering rules."""
+        config: { enabled: true retries: 1 optional: "value" }
+        - "Document failures"
+      }
+      @override standards.config.enabled { false }
+      @override standards.config.retries { 3 }
+      @override standards.config.optional { null }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+    const standardsBlock = result.ast?.blocks.find((block) => block.name === 'standards');
+
+    expect(result.errors).toEqual([]);
+    expect(result.ast?.blocks.find((block) => block.name === 'identity')?.content).toMatchObject({
+      type: 'TextContent',
+      value: 'New identity',
+    });
+    expect(
+      result.ast?.blocks.find((block) => block.name === 'restrictions')?.content
+    ).toMatchObject({
+      type: 'ArrayContent',
+      elements: ['New restriction'],
+    });
+    expect(standardsBlock?.content).toMatchObject({
+      type: 'MixedContent',
+      text: expect.objectContaining({ value: 'Required engineering rules.' }),
+      properties: {
+        config: { enabled: false, retries: 3, optional: null },
+        items: ['Document failures'],
+      },
+    });
+  });
+
+  it('composes each replacement before later ordered operations', async () => {
+    const directory = await createProject(
+      `
+        @meta { id: "composition" syntax: "1.6.0" }
+        @skills {
+          workflow: { description: "Old" content: "Old workflow" }
+          @use ./old-phase
+        }
+        @override skills {
+          workflow: { description: "New" content: "New workflow" }
+          @use ./phase
+        }
+      `,
+      {
+        'old-phase.prs': `
+          @meta { id: "old-phase" syntax: "1.6.0" }
+          @skills {
+            old-phase: { description: "Old phase" content: "Run old phase" }
+          }
+        `,
+        'phase.prs': `
+          @meta { id: "phase" syntax: "1.6.0" }
+          @skills {
+            phase: { description: "Phase" content: "Run phase" }
+          }
+        `,
+      }
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+    const workflow = properties(result.ast?.blocks ?? [], 'skills')['workflow'] as Record<
+      string,
+      Value
+    >;
+
+    expect(result.errors).toEqual([]);
+    expect(workflow['description']).toBe('New');
+    expect(workflow['__composedFrom']).toEqual([expect.objectContaining({ name: 'phase' })]);
+    expect(
+      (result.ast?.blocks.find((block) => block.name === 'skills')?.content as ObjectContent)
+        .inlineUses
+    ).toBeUndefined();
+  });
+
+  it('lets later overrides replace composed skill content', async () => {
+    const directory = await createProject(
+      `
+        @meta { id: "composition-override" syntax: "1.6.0" }
+        @skills {
+          workflow: { description: "Workflow" content: "Parent workflow" }
+          @use ./phase
+        }
+        @override skills.workflow.content { "Final workflow" }
+      `,
+      {
+        'phase.prs': `
+          @meta { id: "phase" syntax: "1.6.0" }
+          @skills {
+            phase: { description: "Phase" content: "Run phase" }
+          }
+        `,
+      }
+    );
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+    const workflow = properties(result.ast?.blocks ?? [], 'skills')['workflow'] as Record<
+      string,
+      Value
+    >;
+
+    expect(result.errors).toEqual([]);
+    expect(workflow['content']).toBe('Final workflow');
+    expect(workflow['__composedFrom']).toEqual([expect.objectContaining({ name: 'phase' })]);
+  });
+
+  it('does not retry failed inline composition after later operations', async () => {
+    const directory = await createProject(`
+      @meta { id: "failed-composition" syntax: "1.6.0" }
+      @skills {
+        workflow: { description: "Workflow" content: "Parent workflow" }
+        @use ./missing
+      }
+      @standards { testing: ["Use Vitest"] }
+      @override standards.testing { ["Use Node test"] }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+    const skills = result.ast?.blocks.find((block) => block.name === 'skills');
+
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors.map((error) => error.message).join(' ')).toContain('missing');
+    expect((skills?.content as ObjectContent).inlineUses).toBeUndefined();
+  });
+
+  it('returns actionable errors without partially applying invalid overrides', async () => {
+    const directory = await createProject(`
+      @meta { id: "invalid" syntax: "1.5.0" }
+      @standards { testing: { runner: "jest" } }
+      @override standards.missing { true }
+      @override standards.testing.runner.name { "invalid" }
+      @override standards { false }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors.map((error) => error.message)).toEqual([
+      expect.stringContaining('does not exist at segment "missing"'),
+      expect.stringContaining('through non-object segment "name"'),
+      expect.stringContaining('Cannot replace block "@standards" with boolean content'),
+    ]);
+    expect(properties(result.ast?.blocks ?? [], 'standards')['testing']).toEqual({
+      runner: 'jest',
+    });
+    expect(result.ast?.syntaxFeatures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ feature: SYNTAX_FEATURES.EXPLICIT_OVERRIDE }),
+      ])
+    );
+  });
+
+  it('cannot bypass sealed skill properties', async () => {
+    const directory = await createProject(`
+      @meta { id: "sealed" syntax: "1.6.0" }
+      @skills {
+        review: {
+          description: "Review code"
+          content: "Critical instructions"
+          sealed: ["content"]
+        }
+      }
+      @override skills.review.content { "Changed" }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.message).toContain("Cannot override sealed property 'content'");
+    expect(
+      (properties(result.ast?.blocks ?? [], 'skills')['review'] as Record<string, Value>)['content']
+    ).toBe('Critical instructions');
+  });
+
+  it('rejects complete skill replacement that changes sealed contracts', async () => {
+    const directory = await createProject(`
+      @meta { id: "sealed-root" syntax: "1.6.0" }
+      @skills {
+        review: {
+          description: "Review code"
+          content: "Critical instructions"
+          sealed: ["content"]
+        }
+      }
+      @override skills {
+        review: {
+          description: "Review code"
+          content: "Changed"
+          sealed: ["content"]
+        }
+      }
+    `);
+    const resolver = new Resolver({
+      registryPath: directory,
+      localPath: directory,
+      cache: false,
+    });
+
+    const result = await resolver.resolve(join(directory, 'project.prs'));
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("Cannot change sealed property 'content'"),
+      }),
+    ]);
+    expect(
+      (properties(result.ast?.blocks ?? [], 'skills')['review'] as Record<string, Value>)['content']
+    ).toBe('Critical instructions');
+  });
+});

--- a/packages/resolver/src/__tests__/override.spec.ts
+++ b/packages/resolver/src/__tests__/override.spec.ts
@@ -37,10 +37,14 @@ describe('explicit override resolution', () => {
       @meta { id: "ordered" syntax: "1.6.0" }
       @standards {
         testing: ["Use Jest"]
+        linting: ["Use Biome"]
         config: { runner: "jest" coverage: 80 }
       }
       @override standards.testing { ["Use Vitest"] }
-      @extend standards { testing: ["Require coverage"] }
+      @extend standards {
+        testing: ["Require coverage"]
+        linting!: ["Use ESLint"]
+      }
       @override standards.config.runner { "vitest" }
     `);
     const resolver = new Resolver({
@@ -54,6 +58,7 @@ describe('explicit override resolution', () => {
 
     expect(result.errors).toEqual([]);
     expect(standards['testing']).toEqual(['Use Vitest', 'Require coverage']);
+    expect(standards['linting']).toEqual(['Use ESLint']);
     expect(standards['config']).toEqual({ runner: 'vitest', coverage: 80 });
     expect(result.ast?.overrides).toEqual([]);
     expect(result.ast?.extends).toEqual([]);

--- a/packages/resolver/src/extensions.ts
+++ b/packages/resolver/src/extensions.ts
@@ -19,23 +19,14 @@ import {
   composeBlockBodies,
   prepareBlockContentForMerge,
   reconcileBlockBodyAtPath,
+  SKILL_REPLACE_PROPERTY_NAMES,
 } from '@promptscript/core';
 import { IMPORT_MARKER_PREFIX, getOriginalBlockName } from './imports.js';
 
 // ── Skill-aware merge strategy sets ──────────────────────────────────
 
 /** Properties where the extension value replaces the base value. */
-const SKILL_REPLACE_PROPERTIES = new Set([
-  'content',
-  'description',
-  'trigger',
-  'userInvocable',
-  'allowedTools',
-  'disableModelInvocation',
-  'context',
-  'agent',
-  'license',
-]);
+const SKILL_REPLACE_PROPERTIES = new Set<string>(SKILL_REPLACE_PROPERTY_NAMES);
 
 /** Properties where array elements are appended (deduplicated). */
 const SKILL_APPEND_PROPERTIES = new Set(['references', 'examples', 'requires', 'scripts']);
@@ -162,7 +153,7 @@ export function applyExtends(ast: Program, logger?: Logger): Program {
 /**
  * Apply a single @extend block.
  */
-function applyExtend(blocks: Block[], ext: ExtendBlock, logger?: Logger): Block[] {
+export function applyExtend(blocks: Block[], ext: ExtendBlock, logger?: Logger): Block[] {
   const pathParts = ext.targetPath.split('.');
   const rootName = pathParts[0];
 

--- a/packages/resolver/src/imports.ts
+++ b/packages/resolver/src/imports.ts
@@ -1,126 +1,13 @@
-import type {
-  Program,
-  UseDeclaration,
-  Block,
-  ObjectContent,
-  Value,
-  ParamArgument,
-} from '@promptscript/core';
+import type { Program, Block, ObjectContent, Value, ParamArgument } from '@promptscript/core';
 import {
   deepClone,
-  ResolveError,
   getCanonicalBlockName,
-  getSyntaxFeatureUsages,
-  IMPORT_MERGE_POLICY,
-  mergeBlockCollections,
+  IMPORT_MARKER_PREFIX,
+  resolveUseImport,
 } from '@promptscript/core';
 
-/**
- * Import marker block prefix for storing imported content.
- * Used for @extend access when alias is provided.
- */
-export const IMPORT_MARKER_PREFIX = '__import__';
-
-/**
- * Resolve @use imports by merging blocks into target.
- *
- * New behavior (v0.2.0):
- * - Blocks from source are merged into target (like inheritance)
- * - If alias is provided, blocks are also stored with prefix for @extend access
- *
- * @param target - Target program AST
- * @param use - Use declaration being resolved
- * @param source - Source program AST (imported content)
- * @returns Updated program with merged blocks
- */
-export function resolveUses(target: Program, use: UseDeclaration, source: Program): Program {
-  // If the @use carries an inline output directory, attach it to every skill
-  // brought in by this import. We operate on a clone so cached source ASTs are
-  // never mutated.
-  if (use.outputDir) {
-    source = deepClone(source);
-    const skillsBlock = source.blocks.find((b) => b.name === 'skills');
-    if (skillsBlock?.content.type === 'ObjectContent') {
-      const props = (skillsBlock.content as ObjectContent).properties;
-      for (const [name, value] of Object.entries(props)) {
-        const isObj = typeof value === 'object' && value !== null && !Array.isArray(value);
-        if (isObj) {
-          (value as Record<string, Value>)['__outputDir'] = use.outputDir;
-        } else {
-          props[name] = { __outputDir: use.outputDir } as unknown as Value;
-        }
-      }
-    }
-  }
-
-  // Pre-merge duplicate skill check: detect collisions in @skills block
-  const targetSkillsBlock = target.blocks.find((b) => b.name === 'skills');
-  const sourceSkillsBlock = source.blocks.find((b) => b.name === 'skills');
-
-  if (
-    targetSkillsBlock?.content.type === 'ObjectContent' &&
-    sourceSkillsBlock?.content.type === 'ObjectContent'
-  ) {
-    const targetProps = (targetSkillsBlock.content as ObjectContent).properties;
-    const sourceProps = (sourceSkillsBlock.content as ObjectContent).properties;
-
-    const duplicates = Object.keys(sourceProps).filter(
-      (key) =>
-        key in targetProps && JSON.stringify(sourceProps[key]) !== JSON.stringify(targetProps[key])
-    );
-
-    if (duplicates.length > 0) {
-      throw new ResolveError(
-        `Duplicate skill name(s) detected when importing '${use.path.raw}': ${duplicates.join(', ')}`,
-        use.loc
-      );
-    }
-  }
-
-  // Merge blocks from source into target
-  const mergedBlocks = mergeBlockCollections(source.blocks, target.blocks, {
-    content: IMPORT_MERGE_POLICY,
-    outputOrder: 'incoming',
-  });
-
-  // If alias is provided, also add aliased blocks for @extend access
-  const aliasedBlocks: Block[] = [];
-  if (use.alias) {
-    const alias = use.alias;
-    const markerName = `${IMPORT_MARKER_PREFIX}${alias}`;
-
-    // Create import marker block
-    const marker: Block = {
-      type: 'Block',
-      name: markerName,
-      content: {
-        type: 'ObjectContent',
-        properties: {
-          __source: use.path.raw,
-          __blocks: source.blocks.map((b) => b.name),
-        },
-        loc: use.loc,
-      } as ObjectContent,
-      loc: use.loc,
-    };
-
-    aliasedBlocks.push(marker);
-
-    // Store source blocks with alias prefix for @extend access
-    for (const block of source.blocks) {
-      aliasedBlocks.push({
-        ...block,
-        name: `${IMPORT_MARKER_PREFIX}${alias}.${block.name}`,
-      });
-    }
-  }
-
-  return {
-    ...target,
-    blocks: [...mergedBlocks, ...aliasedBlocks],
-    syntaxFeatures: [...getSyntaxFeatureUsages(target), ...getSyntaxFeatureUsages(source)],
-  };
-}
+export { IMPORT_MARKER_PREFIX };
+export const resolveUses = resolveUseImport;
 
 /**
  * Check if a block name is an import marker.

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -6,6 +6,8 @@ import {
   noopLogger,
   type Logger,
   type CanonicalProgram,
+  type ExtendBlock,
+  type OverrideBlock,
   type Program,
   type Value,
   type Lockfile,
@@ -14,8 +16,17 @@ import {
   FileNotFoundError,
   ErrorCode,
   bindParams,
+  applyOverride,
+  blockBodyToContent,
+  consumeInlineUses,
+  deepClone,
+  getSyntaxFeatureUsages,
+  INHERITANCE_MERGE_POLICY,
   interpolateAST,
+  mergeBlockCollections,
   normalizeProgram,
+  toLegacyBlock,
+  usesSequentialOperations,
   type TemplateContext,
 } from '@promptscript/core';
 import {
@@ -25,8 +36,14 @@ import {
   parseRegistryMarker,
 } from './loader.js';
 import { resolveInheritance } from './inheritance.js';
-import { resolveUses, extractReservedParams, filterBlocks, filterSkillsBlock } from './imports.js';
-import { applyExtends } from './extensions.js';
+import {
+  IMPORT_MARKER_PREFIX,
+  resolveUses,
+  extractReservedParams,
+  filterBlocks,
+  filterSkillsBlock,
+} from './imports.js';
+import { applyExtend, applyExtends } from './extensions.js';
 import {
   resolveNativeSkills,
   resolveNativeCommands,
@@ -193,23 +210,33 @@ export class Resolver {
       return { ast: null, sources, errors };
     }
 
-    let ast = normalizeBlockAliases(parseData.ast);
+    let ast = parseData.ast;
+    const sequentialOperations = usesSequentialOperations(ast);
+    ast = normalizeBlockAliases(ast, {
+      preserveDeclarationOrder: sequentialOperations,
+    });
     this.logger.debug(`AST node count: ${this.countNodes(ast)}`);
 
-    // Resolve inheritance
-    ast = await this.resolveInherit(ast, absPath, sources, errors);
+    if (sequentialOperations) {
+      ast = await this.resolveSequentialOperations(ast, absPath, sources, errors);
+    } else {
+      // Preserve legacy phase ordering through syntax 1.5.x.
+      ast = await this.resolveInherit(ast, absPath, sources, errors);
+      ast = await this.resolveImports(ast, absPath, sources, errors);
+    }
 
-    // Resolve imports
-    ast = await this.resolveImports(ast, absPath, sources, errors);
-
-    // Resolve skill composition (inline @use within @skills blocks)
-    ast = await this.resolveComposition(ast, absPath, sources, errors);
+    // Legacy phase order resolves inline composition after top-level imports.
+    if (!sequentialOperations) {
+      ast = await this.resolveComposition(ast, absPath, sources, errors);
+    }
 
     // Apply extensions
-    if (ast.extends.length > 0) {
+    if (!sequentialOperations && ast.extends.length > 0) {
       this.logger.debug(`Applying ${ast.extends.length} extension(s)`);
     }
-    ast = applyExtends(ast, this.logger);
+    if (!sequentialOperations) {
+      ast = applyExtends(ast, this.logger);
+    }
 
     // Resolve guard requires dependencies
     ast = resolveGuardRequires(ast, {
@@ -246,6 +273,147 @@ export class Resolver {
     };
   }
 
+  private async resolveSequentialOperations(
+    ast: Program,
+    absPath: string,
+    sources: string[],
+    errors: ResolveError[]
+  ): Promise<Program> {
+    const operations = normalizeProgram(ast).operations;
+    const localBlockNames = new Set<string>();
+    let result: Program = {
+      ...ast,
+      inherit: undefined,
+      uses: [],
+      blocks: [],
+      extends: [],
+      overrides: [],
+      syntaxFeatures: getSyntaxFeatureUsages(ast),
+    };
+
+    for (const operation of operations) {
+      switch (operation.type) {
+        case 'InheritOperation':
+          result = await this.resolveInherit(
+            {
+              ...result,
+              inherit: deepClone(operation.declaration) as unknown as NonNullable<
+                Program['inherit']
+              >,
+            },
+            absPath,
+            sources,
+            errors,
+            true
+          );
+          break;
+        case 'UseOperation':
+          result = await this.resolveImports(
+            {
+              ...result,
+              uses: [deepClone(operation.declaration) as unknown as Program['uses'][number]],
+            },
+            absPath,
+            sources,
+            errors
+          );
+          result = { ...result, uses: [] };
+          break;
+        case 'BlockOperation': {
+          const block = toLegacyBlock(operation.block, { preserveCanonicalBody: true });
+          result = {
+            ...result,
+            blocks: localBlockNames.has(block.name)
+              ? [...result.blocks, block]
+              : mergeBlockCollections(result.blocks, [block], {
+                  content: INHERITANCE_MERGE_POLICY,
+                  outputOrder: 'base',
+                }),
+          };
+          localBlockNames.add(block.name);
+          result = await this.resolveComposition(result, absPath, sources, errors);
+          break;
+        }
+        case 'ExtendOperation': {
+          const extension: ExtendBlock = {
+            type: 'ExtendBlock',
+            targetPath: operation.extension.targetPath,
+            content: blockBodyToContent(operation.extension.body),
+            canonicalBody: deepClone(operation.extension.body),
+            ...(operation.extension.replacements
+              ? {
+                  replacements: operation.extension.replacements.map(
+                    (replacement) =>
+                      deepClone(replacement) as unknown as NonNullable<
+                        ExtendBlock['replacements']
+                      >[number]
+                  ),
+                }
+              : {}),
+            loc: deepClone(operation.extension.loc),
+          };
+          try {
+            result = {
+              ...result,
+              blocks: applyExtend(result.blocks, extension, this.logger),
+            };
+            result = await this.resolveComposition(result, absPath, sources, errors);
+          } catch (error) {
+            errors.push(
+              error instanceof ResolveError
+                ? error
+                : new ResolveError(
+                    `Extension resolution failed: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                    extension.loc
+                  )
+            );
+          }
+          break;
+        }
+        case 'OverrideOperation': {
+          const override: OverrideBlock = {
+            type: 'OverrideBlock',
+            targetPath: operation.override.targetPath,
+            replacement: deepClone(
+              operation.override.replacement
+            ) as unknown as OverrideBlock['replacement'],
+            loc: deepClone(operation.override.loc),
+          };
+          try {
+            result = applyOverride(result, override, {
+              importMarkerPrefix: IMPORT_MARKER_PREFIX,
+            });
+            result = await this.resolveComposition(result, absPath, sources, errors);
+          } catch (error) {
+            errors.push(
+              error instanceof ResolveError
+                ? error
+                : new ResolveError(
+                    `Override resolution failed: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                    override.loc
+                  )
+            );
+          }
+          break;
+        }
+      }
+    }
+
+    return {
+      ...result,
+      blocks: result.blocks.filter((block) => !block.name.startsWith(IMPORT_MARKER_PREFIX)),
+      inherit: undefined,
+      uses: [],
+      extends: [],
+      overrides: [],
+      syntaxFeatures: getSyntaxFeatureUsages(result),
+    };
+  }
+
   /**
    * Count nodes in AST for debug output.
    */
@@ -256,6 +424,7 @@ export class Resolver {
     count += ast.uses.length;
     count += ast.blocks.length;
     count += ast.extends.length;
+    count += ast.overrides?.length ?? 0;
     return count;
   }
 
@@ -417,7 +586,8 @@ export class Resolver {
     ast: Program,
     absPath: string,
     sources: string[],
-    errors: ResolveError[]
+    errors: ResolveError[],
+    parentWins = false
   ): Promise<Program> {
     if (!ast.inherit) {
       return ast;
@@ -464,7 +634,16 @@ export class Resolver {
         }
 
         this.logger.debug(`Merging with parent AST`);
-        return resolveInheritance(resolvedParent, ast);
+        const inherited = resolveInheritance(resolvedParent, ast);
+        return parentWins
+          ? {
+              ...inherited,
+              blocks: mergeBlockCollections(ast.blocks, resolvedParent.blocks, {
+                content: INHERITANCE_MERGE_POLICY,
+                outputOrder: 'base',
+              }),
+            }
+          : inherited;
       }
     } catch (err) {
       if (err instanceof CircularDependencyError) {
@@ -647,6 +826,7 @@ export class Resolver {
           )
         );
       }
+      ast = consumeInlineUses(ast);
     }
 
     return ast;

--- a/packages/validator/src/__tests__/rules/syntax-version-compat.spec.ts
+++ b/packages/validator/src/__tests__/rules/syntax-version-compat.spec.ts
@@ -58,7 +58,7 @@ describe('PS018: syntax-version-compat', () => {
     const messages = validate(makeAst('1.5.7'));
     expect(messages).toHaveLength(1);
     expect(messages[0]!.message).toContain('Unknown syntax version "1.5.7"');
-    expect(messages[0]!.message).toContain('1.5.0');
+    expect(messages[0]!.message).toContain('1.6.0');
   });
 
   it('should warn when block requires higher version', () => {
@@ -150,6 +150,26 @@ describe('PS018: syntax-version-compat', () => {
     ];
 
     expect(validate(ast)).toHaveLength(0);
+  });
+
+  it('should report explicit override usage at its directive location', () => {
+    const overrideLoc = { ...loc, line: 4, column: 1, offset: 72 };
+    const ast = makeAst('1.5.0');
+    ast.syntaxFeatures = [
+      {
+        feature: 'explicit-override',
+        location: overrideLoc,
+      },
+    ];
+
+    const messages = validate(ast);
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('explicit-override'),
+        location: overrideLoc,
+      }),
+    ]);
   });
 
   it('should report section header overrides at their exact usage location', () => {

--- a/packages/validator/src/rules/__tests__/valid-sealed-property.spec.ts
+++ b/packages/validator/src/rules/__tests__/valid-sealed-property.spec.ts
@@ -89,7 +89,7 @@ describe('valid-sealed-property (PS029)', () => {
         makeSkillsBlock({
           expert: {
             description: 'test',
-            sealed: ['content', 'description'],
+            sealed: ['content', 'description', 'license'],
           },
         }),
       ],

--- a/packages/validator/src/rules/valid-sealed-property.ts
+++ b/packages/validator/src/rules/valid-sealed-property.ts
@@ -1,17 +1,9 @@
 import type { ValidationRule } from '../types.js';
 import type { ObjectContent } from '@promptscript/core';
+import { SKILL_REPLACE_PROPERTY_NAMES } from '@promptscript/core';
 
 /** Replace-strategy properties that can be sealed. */
-const REPLACE_PROPERTIES = new Set([
-  'content',
-  'description',
-  'trigger',
-  'userInvocable',
-  'allowedTools',
-  'disableModelInvocation',
-  'context',
-  'agent',
-]);
+const REPLACE_PROPERTIES = new Set<string>(SKILL_REPLACE_PROPERTY_NAMES);
 
 /**
  * PS029: Valid sealed property.

--- a/scripts/check-grammar.mts
+++ b/scripts/check-grammar.mts
@@ -11,7 +11,10 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { BLOCK_TYPES } from '../packages/core/src/types/constants.js';
-import { CONTEXTUAL_DIRECTIVES } from '../packages/core/src/section-registry.js';
+import {
+  CONTEXTUAL_DIRECTIVES,
+  CONTEXTUAL_OPERATION_DIRECTIVES,
+} from '../packages/core/src/section-registry.js';
 // Uses .js extension per swc-node convention (see validate-docs-examples.mts for reference)
 import { allTokens } from '../packages/parser/src/lexer/tokens.js';
 import {
@@ -265,10 +268,17 @@ for (const token of allTokens) {
 
 const expectedBlockDirectives = BLOCK_TYPES.map((blockType) => `@${blockType}`);
 const expectedContextualDirectives = [...CONTEXTUAL_DIRECTIVES];
+const expectedContextualOperations = [...CONTEXTUAL_OPERATION_DIRECTIVES];
 const monacoDirectives = new Set(prsLanguageDefinition.directives as string[]);
 for (const directive of [...expectedBlockDirectives, ...expectedContextualDirectives]) {
   if (!monacoDirectives.has(directive)) {
     syncErrors.push(`Monaco grammar is missing directive ${directive}`);
+  }
+}
+const monacoOperations = new Set(prsLanguageDefinition.operationDirectives as string[]);
+for (const directive of expectedContextualOperations) {
+  if (!monacoOperations.has(directive)) {
+    syncErrors.push(`Monaco grammar is missing contextual operation ${directive}`);
   }
 }
 
@@ -291,6 +301,22 @@ if (!pygmentsBlockMatch) {
   }
 }
 
+const pygmentsOperationMatch = pygmentsSource.match(
+  /CONTEXTUAL_OPERATION_DIRECTIVES = \(([\s\S]*?)\)\n\n/
+);
+if (!pygmentsOperationMatch) {
+  syncErrors.push('Pygments lexer does not expose CONTEXTUAL_OPERATION_DIRECTIVES');
+} else {
+  const pygmentsOperations = new Set(
+    [...pygmentsOperationMatch[1]!.matchAll(/"([^"]+)"/g)].map((match) => `@${match[1]!}`)
+  );
+  for (const directive of expectedContextualOperations) {
+    if (!pygmentsOperations.has(directive)) {
+      syncErrors.push(`Pygments lexer is missing contextual operation ${directive}`);
+    }
+  }
+}
+
 const pygmentsContextualMatch = pygmentsSource.match(/CONTEXTUAL_DIRECTIVES = \(([\s\S]*?)\)\n\n/);
 if (!pygmentsContextualMatch) {
   syncErrors.push('Pygments lexer does not expose CONTEXTUAL_DIRECTIVES');
@@ -301,6 +327,18 @@ if (!pygmentsContextualMatch) {
   for (const directive of expectedContextualDirectives) {
     if (!pygmentsContextual.has(directive)) {
       syncErrors.push(`Pygments lexer is missing contextual directive ${directive}`);
+    }
+  }
+}
+
+const textMateOperationPattern = grammar.repository?.['override-directive']?.match;
+if (!textMateOperationPattern) {
+  syncErrors.push('TextMate grammar does not define override-directive.match');
+} else {
+  const operationRegex = new RegExp(`^(?:${textMateOperationPattern})`);
+  for (const directive of expectedContextualOperations) {
+    if (!operationRegex.test(`${directive} standards.testing {`)) {
+      syncErrors.push(`TextMate grammar does not match contextual operation ${directive}`);
     }
   }
 }

--- a/skills/promptscript/SKILL.md
+++ b/skills/promptscript/SKILL.md
@@ -747,16 +747,38 @@ Replacement works after `@inherit` and `@use`, including aliases and nested targ
 A missing field is set. The modifier is rejected for `@skills`, which retain their dedicated
 merge and sealing semantics.
 
+#### Replacing complete targets with @override
+
+Syntax `1.6.0` adds atomic replacement for an existing block or nested value:
+
+```
+@meta { id: "project" syntax: "1.6.0" }
+
+@standards {
+  testing: ["Use Jest", "Use Mocha"]
+}
+
+@override standards.testing {
+  ["Use Vitest"]
+}
+```
+
+`@override` requires the complete target path to exist, applies in declaration
+order, and cannot bypass sealed skill properties. Later `@extend` declarations
+merge into the replacement. Use `@extend` for additive changes, `field!` for
+compatibility replacement of one direct regular field, and `@override` for
+intentional complete replacement.
+
 #### Skill-aware @extend semantics
 
 When extending a skill definition via `@extend`, individual skill properties follow specific merge
 strategies rather than the generic block merge rules:
 
-| Strategy          | Properties                                                                                         |
-| ----------------- | -------------------------------------------------------------------------------------------------- |
-| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent |
-| **Append**        | references, examples, requires                                                                     |
-| **Shallow merge** | params, inputs, outputs                                                                            |
+| Strategy          | Properties                                                                                                  |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Replace**       | content, description, trigger, userInvocable, allowedTools, disableModelInvocation, context, agent, license |
+| **Append**        | references, examples, requires                                                                              |
+| **Shallow merge** | params, inputs, outputs                                                                                     |
 
 Example — extending a base skill to add references and override content:
 
@@ -1007,6 +1029,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 | `1.3.0` | Adds explicit regular block field replacement in `@extend`                                                              |
 | `1.4.0` | Adds `@hooks`, `@mcpServers`, and `@plugins`                                                                            |
 | `1.5.0` | Adds generated section title overrides with contextual `@header`                                                        |
+| `1.6.0` | Adds atomic block and nested value replacement with contextual `@override`                                              |
 
 ### Block Version Requirements
 
@@ -1022,6 +1045,7 @@ The `syntax` field in `@meta` declares the PromptScript language version (semver
 All other built-in blocks are available from `1.0.0`.
 Regular block field replacement with `field!: value` requires syntax `1.3.0`.
 Generated section title overrides with `@header` require syntax `1.5.0`.
+Atomic replacement with `@override` requires syntax `1.6.0`.
 
 ### Generated Section Headers
 


### PR DESCRIPTION
## Summary

- add contextual `@override <dot-path> { replacement }` syntax for 1.6.0
- resolve inherit, use, block, extend, and override operations in declaration order while preserving legacy behavior
- enforce atomic replacement, sealed skill contracts, alias visibility, and Node/browser parity
- add PS018 compatibility diagnostics, syntax highlighting, docs, skill guidance, and regression coverage

## Verification

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm docs:validate:check`
- `pnpm docs:build`
- `pnpm nx affected -t test --coverage --base=96bfff1a9a`

Closes #349
