### PR TITLE
feat(vscode): highlight fenced code inside text blocks

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -26,6 +26,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # The grammar check asks the Pygments lexer which fence languages it can
+      # highlight, so the docs lexer has to be importable here too.
+      - run: python3 -m pip install --quiet --disable-pip-version-check pygments
+
       - run: pnpm grammar:check
 
       - run: pnpm nx package vscode

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -5,6 +5,7 @@ Syntax highlighting and language support for [PromptScript](https://getpromptscr
 ## Features
 
 - Syntax highlighting for all PromptScript constructs
+- Embedded highlighting for fenced code inside `"""` text blocks
 - Bracket matching and auto-closing for `{}`, `[]`, `()`, `""`, `''`, `{{}}`
 - Code folding for `@block { }` directives
 - Comment toggling with `Cmd+/` / `Ctrl+/`
@@ -24,6 +25,7 @@ Syntax highlighting and language support for [PromptScript](https://getpromptscr
 | Constants             | `true`, `false`, `null`                                  |
 | Types                 | `string`, `number`, `boolean`, `enum(...)`, `range(...)` |
 | Comments              | `# line comment`                                         |
+| Fenced code           | ` ```ts ` … ` ``` ` inside a `"""` block                 |
 
 ## Learn More
 

--- a/apps/vscode/syntaxes/promptscript.tmLanguage.json
+++ b/apps/vscode/syntaxes/promptscript.tmLanguage.json
@@ -66,13 +66,209 @@
       "end": "\"\"\"",
       "name": "string.quoted.triple.prs",
       "patterns": [
+        { "include": "#fenced-code" },
         { "include": "#template-in-string" },
         { "include": "#env-variable" },
         {
-          "match": "[^\"{}$]+",
+          "match": "[^\"{}$`]+",
           "name": "string.quoted.triple.prs"
         }
       ]
+    },
+    "fenced-code": {
+      "patterns": [
+        { "include": "#fenced-typescript" },
+        { "include": "#fenced-tsx" },
+        { "include": "#fenced-javascript" },
+        { "include": "#fenced-json" },
+        { "include": "#fenced-yaml" },
+        { "include": "#fenced-shell" },
+        { "include": "#fenced-python" },
+        { "include": "#fenced-sql" },
+        { "include": "#fenced-go" },
+        { "include": "#fenced-rust" },
+        { "include": "#fenced-html" },
+        { "include": "#fenced-css" },
+        { "include": "#fenced-xml" },
+        { "include": "#fenced-diff" },
+        { "include": "#fenced-markdown" },
+        { "include": "#fenced-plain" }
+      ]
+    },
+    "fenced-typescript": {
+      "begin": "(`{3,})(typescript|ts)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.typescript",
+      "patterns": [{ "include": "source.ts" }]
+    },
+    "fenced-tsx": {
+      "begin": "(`{3,})(tsx)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.typescriptreact",
+      "patterns": [{ "include": "source.tsx" }]
+    },
+    "fenced-javascript": {
+      "begin": "(`{3,})(javascript|js|mjs|cjs)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.javascript",
+      "patterns": [{ "include": "source.js" }]
+    },
+    "fenced-json": {
+      "begin": "(`{3,})(json|jsonc)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.json",
+      "patterns": [{ "include": "source.json" }]
+    },
+    "fenced-yaml": {
+      "begin": "(`{3,})(yaml|yml)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.yaml",
+      "patterns": [{ "include": "source.yaml" }]
+    },
+    "fenced-shell": {
+      "begin": "(`{3,})(bash|sh|shell|zsh|console)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.shellscript",
+      "patterns": [{ "include": "source.shell" }]
+    },
+    "fenced-python": {
+      "begin": "(`{3,})(python|py)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.python",
+      "patterns": [{ "include": "source.python" }]
+    },
+    "fenced-sql": {
+      "begin": "(`{3,})(sql)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.sql",
+      "patterns": [{ "include": "source.sql" }]
+    },
+    "fenced-go": {
+      "begin": "(`{3,})(go|golang)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.go",
+      "patterns": [{ "include": "source.go" }]
+    },
+    "fenced-rust": {
+      "begin": "(`{3,})(rust|rs)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.rust",
+      "patterns": [{ "include": "source.rust" }]
+    },
+    "fenced-html": {
+      "begin": "(`{3,})(html)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.html",
+      "patterns": [{ "include": "text.html.basic" }]
+    },
+    "fenced-css": {
+      "begin": "(`{3,})(css)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.css",
+      "patterns": [{ "include": "source.css" }]
+    },
+    "fenced-xml": {
+      "begin": "(`{3,})(xml)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.xml",
+      "patterns": [{ "include": "text.xml" }]
+    },
+    "fenced-diff": {
+      "begin": "(`{3,})(diff|patch)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.diff",
+      "patterns": [{ "include": "source.diff" }]
+    },
+    "fenced-markdown": {
+      "begin": "(`{3,})(markdown|md)\\b[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.markdown",
+      "patterns": [{ "include": "text.html.markdown" }]
+    },
+    "fenced-plain": {
+      "begin": "(`{3,})([\\w+#.-]*)[^\\n]*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.fence.prs" },
+        "2": { "name": "fenced_code.block.language.prs" }
+      },
+      "end": "(`{3,})",
+      "endCaptures": { "1": { "name": "punctuation.definition.fence.prs" } },
+      "contentName": "meta.embedded.block.prs"
     },
     "double-string": {
       "begin": "\"",

--- a/docs_extensions/promptscript_lexer.py
+++ b/docs_extensions/promptscript_lexer.py
@@ -71,12 +71,14 @@ IMPORT_PATH_PATTERN = (
 FENCED_CODE_PATTERN = r"(```)([\w+#.-]*)([^\n]*\n)([\s\S]*?)(```)"
 
 # Info strings that Pygments does not know under the name Markdown authors
-# and the TextMate grammar use.
+# and the TextMate grammar use. Names that only some Pygments releases
+# recognise are mapped too, so the docs render the same on every version.
 FENCE_LANGUAGE_ALIASES = {
     "cjs": "javascript",
     "jsonc": "json",
     "mjs": "javascript",
     "patch": "diff",
+    "tsx": "typescript",
     "yml": "yaml",
 }
 

--- a/docs_extensions/promptscript_lexer.py
+++ b/docs_extensions/promptscript_lexer.py
@@ -6,6 +6,7 @@ highlighting style used in the PromptScript Playground.
 """
 
 from pygments.lexer import RegexLexer, bygroups
+from pygments.lexers import get_lexer_by_name
 from pygments.token import (
     Comment,
     Keyword,
@@ -17,6 +18,7 @@ from pygments.token import (
     Text,
     Whitespace,
 )
+from pygments.util import ClassNotFound
 
 BLOCK_DIRECTIVES = (
     "identity",
@@ -63,6 +65,55 @@ IMPORT_PATH_PATTERN = (
     # import keyword. Documentation uses it for placeholders such as @path.
     + r"|@[A-Za-z_][A-Za-z0-9_-]*"
 )
+
+# A Markdown fence inside a text block: opening fence with an optional info
+# string, the code, and the closing fence.
+FENCED_CODE_PATTERN = r"(```)([\w+#.-]*)([^\n]*\n)([\s\S]*?)(```)"
+
+# Info strings that Pygments does not know under the name Markdown authors
+# and the TextMate grammar use.
+FENCE_LANGUAGE_ALIASES = {
+    "cjs": "javascript",
+    "jsonc": "json",
+    "mjs": "javascript",
+    "patch": "diff",
+    "yml": "yaml",
+}
+
+_SUBLEXER_CACHE = {}
+
+
+def fence_sublexer(name):
+    """Return a lexer for a fence info string, or None when unknown."""
+    if not name:
+        return None
+    if name not in _SUBLEXER_CACHE:
+        try:
+            _SUBLEXER_CACHE[name] = get_lexer_by_name(
+                FENCE_LANGUAGE_ALIASES.get(name, name), stripnl=False
+            )
+        except ClassNotFound:
+            _SUBLEXER_CACHE[name] = None
+    return _SUBLEXER_CACHE[name]
+
+
+def fenced_code_callback(lexer, match):
+    """Highlight a fenced code block with the lexer named by its info string."""
+    del lexer
+
+    yield match.start(1), String.Delimiter, match.group(1)
+    yield match.start(2), Name.Tag, match.group(2)
+    yield match.start(3), String.Doc, match.group(3)
+
+    code = match.group(4)
+    sublexer = fence_sublexer(match.group(2))
+    if sublexer is None:
+        yield match.start(4), String.Doc, code
+    else:
+        for index, token, value in sublexer.get_tokens_unprocessed(code):
+            yield match.start(4) + index, token, value
+
+    yield match.start(5), String.Delimiter, match.group(5)
 
 
 class PromptScriptLexer(RegexLexer):
@@ -257,17 +308,19 @@ class PromptScriptLexer(RegexLexer):
             (r"[$\{]", String.Single),
         ],
         "docstring": [
+            # Fenced code, highlighted with the lexer its info string names
+            (FENCED_CODE_PATTERN, fenced_code_callback),
             # Template expressions
             (TEMPLATE_VAR_PATTERN, bygroups(Punctuation, Name.Variable, Punctuation)),
             # Environment variables inside docstrings
             (ENV_VAR_PATTERN, Name.Variable),
             # End of docstring
             (r'"""', String.Doc, "#pop"),
-            # Content
-            (r'[^"${]+', String.Doc),
+            # Content, stopping at a backtick so fences get their turn
+            (r'[^"${`]+', String.Doc),
             # Quote not part of closing
             (r'"(?!"")', String.Doc),
-            (r"[$\{]", String.Doc),
+            (r"[$\{`]", String.Doc),
         ],
     }
 

--- a/packages/playground/src/__tests__/prs-language.spec.ts
+++ b/packages/playground/src/__tests__/prs-language.spec.ts
@@ -123,6 +123,27 @@ describe('prs-language', () => {
       expect(() => compile(PRS_LANGUAGE_ID, prsLanguageDefinition)).not.toThrow();
     });
 
+    it('should hand fenced code to the language named by the info string', () => {
+      const rules = prsLanguageDefinition.tokenizer.multilineString as unknown[];
+      const embedded = rules.find((rule) => {
+        if (!Array.isArray(rule)) return false;
+        const [pattern, action] = rule as unknown[];
+        return pattern instanceof RegExp && isRecord(action) && 'nextEmbedded' in action;
+      });
+
+      expect(embedded).toBeDefined();
+      const [pattern, action] = embedded as [RegExp, Record<string, unknown>];
+      expect(pattern.exec('```javascript')?.[2]).toBe('javascript');
+      expect(action['nextEmbedded']).toBe('$2');
+      expect(action['next']).toBe('@embeddedCode.$2');
+    });
+
+    it('should leave an unlabelled fence to the plain fence state', () => {
+      const tokenizer = prsLanguageDefinition.tokenizer;
+      expect(tokenizer.embeddedCode).toBeDefined();
+      expect(tokenizer.plainFence).toBeDefined();
+    });
+
     it('should have single-quoted string tokenizer rules', () => {
       const tokenizer = prsLanguageDefinition.tokenizer;
       expect(tokenizer.stringSingle).toBeDefined();

--- a/packages/playground/src/__tests__/prs-language.spec.ts
+++ b/packages/playground/src/__tests__/prs-language.spec.ts
@@ -116,6 +116,13 @@ describe('prs-language', () => {
       expect(Array.isArray(tokenizer.multilineString)).toBe(true);
     });
 
+    it('should compile as a Monarch grammar', async () => {
+      const { compile } =
+        await import('monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js');
+
+      expect(() => compile(PRS_LANGUAGE_ID, prsLanguageDefinition)).not.toThrow();
+    });
+
     it('should have single-quoted string tokenizer rules', () => {
       const tokenizer = prsLanguageDefinition.tokenizer;
       expect(tokenizer.stringSingle).toBeDefined();

--- a/packages/playground/src/utils/prs-language.ts
+++ b/packages/playground/src/utils/prs-language.ts
@@ -152,14 +152,28 @@ export const prsLanguageDefinition: Monaco.languages.IMonarchLanguage = {
     ],
 
     multilineString: [
+      // Fenced code hands its body to the language named by the info string.
+      // Monaco colours it only when that language is registered; the plain
+      // fence rule keeps the delimiters styled either way.
+      [/(```)([\w+#.-]+)/, { token: 'string.fence', next: '@embeddedCode.$2', nextEmbedded: '$2' }],
+      [/```/, 'string.fence', '@plainFence'],
       [/\{\{/, 'variable.template', '@templateExpressionInString'],
       // Environment variables inside multiline strings
       [/\$\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\}/, 'variable.env'],
-      [/[^"{$]+/, 'string'],
+      [/[^"{$`]+/, 'string'],
       [/\$(?!\{)/, 'string'],
       [/\{(?!\{)/, 'string'],
+      [/`/, 'string'],
       [/"""/, 'string', '@pop'],
       [/"/, 'string'],
+    ],
+
+    embeddedCode: [[/```/, { token: 'string.fence', next: '@pop', nextEmbedded: '@pop' }]],
+
+    plainFence: [
+      [/```/, 'string.fence', '@pop'],
+      [/[^`]+/, 'string'],
+      [/`/, 'string'],
     ],
 
     templateExpressionInString: [
@@ -224,6 +238,7 @@ export const prsThemeRules: Monaco.editor.ITokenThemeRule[] = [
   { token: 'variable.name', foreground: 'fb923c' },
   { token: 'variable.env', foreground: 'fbbf24' },
   { token: 'string.url', foreground: '67e8f9' },
+  { token: 'string.fence', foreground: '64748b' },
 ];
 
 /**

--- a/packages/playground/src/utils/prs-language.ts
+++ b/packages/playground/src/utils/prs-language.ts
@@ -53,7 +53,9 @@ export const prsLanguageDefinition: Monaco.languages.IMonarchLanguage = {
       ],
 
       // Contextual operations require a target path before the body.
-      [/@override(?=\s+[a-zA-Z_][\w-]*(?:\.[a-zA-Z_][\w-]*)*\s*\{)/, 'keyword.directive'],
+      // Monarch reads a literal @word in a pattern as an attribute reference,
+      // so the directive name is wrapped in a group to keep it literal.
+      [/@(?:override)(?=\s+[a-zA-Z_][\w-]*(?:\.[a-zA-Z_][\w-]*)*\s*\{)/, 'keyword.directive'],
 
       // Directives
       [

--- a/scripts/check-grammar.mts
+++ b/scripts/check-grammar.mts
@@ -8,6 +8,7 @@
  *   1 - Missing token coverage
  */
 
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { BLOCK_TYPES } from '../packages/core/src/types/constants.js';
@@ -383,6 +384,82 @@ for (const stringRule of ['double-string', 'single-string', 'triple-string']) {
       syncErrors.push(`TextMate ${stringRule} is missing ${requiredInclude}`);
     }
   }
+}
+
+// --- Embedded fenced code ---
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+const fenceRules = Object.entries(grammar.repository ?? {}).filter(([name]) =>
+  name.startsWith('fenced-')
+);
+
+if (!grammar.repository?.['triple-string']?.patterns?.some((p) => p.include === '#fenced-code')) {
+  syncErrors.push('TextMate triple-string is missing #fenced-code');
+}
+
+const fenceLanguages = new Set<string>();
+for (const [name, rule] of fenceRules) {
+  if (name === 'fenced-code' || name === 'fenced-plain') continue;
+
+  const infoStringGroup = rule.begin?.match(/\(([\w|]+)\)/);
+  if (!infoStringGroup) {
+    syncErrors.push(`TextMate ${name} does not name the languages it covers`);
+    continue;
+  }
+  for (const language of infoStringGroup[1]!.split('|')) {
+    fenceLanguages.add(language);
+  }
+  if (!rule.contentName?.startsWith('meta.embedded.block.')) {
+    syncErrors.push(`TextMate ${name} is missing a meta.embedded.block scope`);
+  }
+}
+
+if (fenceLanguages.size === 0) {
+  syncErrors.push('TextMate grammar defines no embedded fence languages');
+}
+
+// The Pygments lexer resolves the info string at runtime, so the guard is
+// that every language TextMate claims is one Pygments can actually load.
+const PYGMENTS_FENCE_PROBE = [
+  'import json, sys',
+  "sys.path.insert(0, 'docs_extensions')",
+  'from promptscript_lexer import PromptScriptLexer, fence_sublexer',
+  'names = json.load(sys.stdin)',
+  'unknown = [name for name in names if fence_sublexer(name) is None]',
+  'sample = \'@knowledge {\\n  api: """\\n  ```javascript\\n  const answer = 42;\\n  ```\\n  """\\n}\\n\'',
+  'tokens = list(PromptScriptLexer().get_tokens(sample))',
+  'delegates = any(str(token).startswith("Token.Keyword") and value == "const" for token, value in tokens)',
+  'json.dump({"unknown": unknown, "delegates": delegates}, sys.stdout)',
+].join('\n');
+
+const pygmentsFences = spawnSync('python3', ['-c', PYGMENTS_FENCE_PROBE], {
+  input: JSON.stringify([...fenceLanguages]),
+  encoding: 'utf-8',
+});
+
+if (pygmentsFences.status !== 0) {
+  syncErrors.push(`Could not query the Pygments lexers: ${pygmentsFences.stderr.trim()}`);
+} else {
+  const result = JSON.parse(pygmentsFences.stdout) as { unknown: string[]; delegates: boolean };
+  for (const language of result.unknown) {
+    syncErrors.push(`Pygments cannot highlight fenced ${language} that TextMate claims`);
+  }
+  if (!result.delegates) {
+    syncErrors.push('Pygments lexer does not delegate fenced code to other lexers');
+  }
+}
+
+const monacoMultiline = (prsLanguageDefinition.tokenizer as Record<string, unknown[]>)[
+  'multilineString'
+];
+const monacoEmbeds = monacoMultiline?.some(
+  (rule) => Array.isArray(rule) && isRecord(rule[1]) && 'nextEmbedded' in rule[1]
+);
+if (!monacoEmbeds) {
+  syncErrors.push('Monaco multilineString does not embed fenced code');
 }
 
 if (missing.length > 0 || syncErrors.length > 0) {


### PR DESCRIPTION
## What

Code inside a `"""` text block was painted as one flat string in all three
highlighters, even though `.prs` files in this repository already embed bash,
mermaid, sql and typescript examples.

Fenced code now switches to the language named by the fence info string:

- **VS Code**: `fenced-code` rules include `source.ts`, `source.js`, `source.json`,
  `source.yaml`, `source.shell`, `source.python`, `source.sql`, `source.go`,
  `source.rust`, `text.html.basic`, `source.css`, `text.xml`, `source.diff`,
  `text.html.markdown`, plus a plain rule that styles the delimiters of any
  other language.
- **Playground**: Monarch `nextEmbedded` hands the body to the language Monaco
  has loaded.
- **Documentation site**: the Pygments lexer resolves the info string at render
  time and delegates the body, with an alias map for `yml`, `patch`, `jsonc`,
  `mjs` and `cjs`.

## Bug found on the way

`@override` in the Monarch grammar broke compilation of the whole PromptScript
language: Monarch reads a literal `@word` in a pattern as a reference to a
language attribute, so `compile()` threw `does not contain attribute 'override'`
and the playground editor lost highlighting entirely. Present since the explicit
override feature landed. Fixed by grouping the name, and a test now compiles the
grammar so it cannot regress.

## Guardrails

`pnpm grammar:check` gains an embedded-fence section:

- every fence language the TextMate grammar claims must be loadable by the
  Pygments lexer (this caught `yml`, `patch`, `jsonc`, `mjs`, `cjs`),
- each fence rule must carry a `meta.embedded.block.*` scope,
- Monaco must embed in `multilineString`, and Pygments must actually delegate
  (asserted by lexing a JavaScript fence and requiring a `const` keyword token).

The VS Code workflow installs Pygments so the check can run there.

## Verification

`format`, `lint`, `typecheck`, `test` (11 projects), `prs validate --strict`,
`schema:check`, `skill:check`, `grammar:check`, `docs:validate:check`,
`docs:highlight:check`, `docs:formatters:check` - all green.
