### PR TITLE
fix(validator): check defaults on typed block fields

### DIFF
--- a/docs/__snapshots__/docs/examples/agent-platform.md/field-replacement_L145/claude.md
+++ b/docs/__snapshots__/docs/examples/agent-platform.md/field-replacement_L145/claude.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+## Project
+
+You are a TypeScript development assistant.
+
+## Code Style
+
+- Use Vitest
+- Follow the AAA pattern
+- Use ESLint
+- Run lint checks before commits
+- platform: Cloud Run
+- regions: us-central1, europe-west1

--- a/docs/__snapshots__/docs/examples/agent-platform.md/field-replacement_L145/cursor.mdc
+++ b/docs/__snapshots__/docs/examples/agent-platform.md/field-replacement_L145/cursor.mdc
@@ -1,0 +1,14 @@
+---
+description: "Project-specific rules"
+alwaysApply: true
+---
+
+You are a TypeScript development assistant.
+
+Code style:
+- Use Vitest
+- Follow the AAA pattern
+- Use ESLint
+- Run lint checks before commits
+- platform: Cloud Run
+- regions: us-central1, europe-west1

--- a/docs/__snapshots__/docs/examples/agent-platform.md/field-replacement_L145/github.md
+++ b/docs/__snapshots__/docs/examples/agent-platform.md/field-replacement_L145/github.md
@@ -1,0 +1,22 @@
+# GitHub Copilot Instructions
+
+## project
+
+You are a TypeScript development assistant.
+
+## code-standards
+
+### testing
+
+- Use Vitest
+- Follow the AAA pattern
+
+### linting
+
+- Use ESLint
+- Run lint checks before commits
+
+### deployment
+
+- platform: Cloud Run
+- regions: us-central1, europe-west1

--- a/docs/__snapshots__/docs/examples/merge-vs-replace.md/merge-vs-replace_L10/claude.md
+++ b/docs/__snapshots__/docs/examples/merge-vs-replace.md/merge-vs-replace_L10/claude.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+## Code Style
+
+- Use Jest
+- Require integration tests
+- Use Biome
+- minimum: 95
+- report: text

--- a/docs/__snapshots__/docs/examples/merge-vs-replace.md/merge-vs-replace_L10/cursor.mdc
+++ b/docs/__snapshots__/docs/examples/merge-vs-replace.md/merge-vs-replace_L10/cursor.mdc
@@ -1,0 +1,13 @@
+---
+description: "Project-specific rules"
+alwaysApply: true
+---
+
+You are working on the project.
+
+Code style:
+- Use Jest
+- Require integration tests
+- Use Biome
+- minimum: 95
+- report: text

--- a/docs/__snapshots__/docs/examples/merge-vs-replace.md/merge-vs-replace_L10/github.md
+++ b/docs/__snapshots__/docs/examples/merge-vs-replace.md/merge-vs-replace_L10/github.md
@@ -1,0 +1,17 @@
+# GitHub Copilot Instructions
+
+## code-standards
+
+### testing
+
+- Use Jest
+- Require integration tests
+
+### linting
+
+- Use Biome
+
+### coverage
+
+- minimum: 95
+- report: text

--- a/docs/__snapshots__/docs/reference/language/execution-order.md/ordered-operations_L29/claude.md
+++ b/docs/__snapshots__/docs/reference/language/execution-order.md/ordered-operations_L29/claude.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+## Code Style
+
+- Use Vitest
+- Require integration tests

--- a/docs/__snapshots__/docs/reference/language/execution-order.md/ordered-operations_L29/cursor.mdc
+++ b/docs/__snapshots__/docs/reference/language/execution-order.md/ordered-operations_L29/cursor.mdc
@@ -1,0 +1,10 @@
+---
+description: "Project-specific rules"
+alwaysApply: true
+---
+
+You are working on the project.
+
+Code style:
+- Use Vitest
+- Require integration tests

--- a/docs/__snapshots__/docs/reference/language/execution-order.md/ordered-operations_L29/github.md
+++ b/docs/__snapshots__/docs/reference/language/execution-order.md/ordered-operations_L29/github.md
@@ -1,0 +1,8 @@
+# GitHub Copilot Instructions
+
+## code-standards
+
+### testing
+
+- Use Vitest
+- Require integration tests

--- a/docs/guides/skill-overlays.md
+++ b/docs/guides/skill-overlays.md
@@ -250,8 +250,8 @@ Layer 2 replaces `description` (allowed), appends to `references`, but **cannot*
 
 @extend base.skills.code-review {
   references: [
-    "!references/product-patterns.md"
-    "references/bu-architecture.md"
+    "!references/product-patterns.md",
+    "references/bu-architecture.md",
     "references/bu-modules.md"
   ]
   requires: ["security-scan"]

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -795,11 +795,11 @@ Configurable parameters:
 </a>
 <!-- playground-link-end -->
 
-| Syntax        | Description        |
-| ------------- | ------------------ |
-| `name: type`  | Required parameter |
-| `name?: type` | Optional parameter |
-| `= value`     | Default value      |
+| Syntax        | Description                                           |
+| ------------- | ----------------------------------------------------- |
+| `name: type`  | Required parameter                                    |
+| `name?: type` | Optional parameter                                    |
+| `= value`     | Default value, rejected when it does not match `type` |
 
 Available types:
 

--- a/packages/validator/src/__tests__/rules-coverage.spec.ts
+++ b/packages/validator/src/__tests__/rules-coverage.spec.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import type { Program, SourceLocation, Block, Value } from '@promptscript/core';
+import type {
+  Program,
+  SourceLocation,
+  Block,
+  PrimitiveValue,
+  TypeExpression,
+  Value,
+} from '@promptscript/core';
+import { createBlockBody } from '@promptscript/core';
 import { allRules, getRuleById, getRuleByName } from '../rules/index.js';
 import { deprecated } from '../rules/deprecated.js';
 import { validPath, isValidPath } from '../rules/valid-path.js';
@@ -1023,6 +1031,146 @@ describe('valid-params rule (PS009) coverage', () => {
   it('should handle AST without meta', () => {
     const ast = createTestProgram({
       meta: undefined,
+    });
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  function createTypedFieldProgram(
+    expression: TypeExpression,
+    defaultValue: PrimitiveValue
+  ): Program {
+    return createTestProgram({
+      blocks: [
+        {
+          type: 'Block',
+          name: 'params',
+          loc,
+          content: { type: 'ObjectContent', properties: {}, loc },
+          canonicalBody: createBlockBody(
+            [
+              {
+                type: 'FieldEntry',
+                name: 'field',
+                loc,
+                value: { type: 'TypeExpressionValueNode', expression, loc },
+                defaultValue: { type: 'ScalarValueNode', value: defaultValue, loc },
+              },
+            ],
+            loc
+          ),
+        },
+      ],
+    });
+  }
+
+  it('should report a block field default that is not the declared type', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'boolean', loc }, 'yes');
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('expected boolean, got string');
+  });
+
+  it('should pass a block field default of the declared type', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'boolean', loc }, false);
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should report a block field default outside the declared enum', () => {
+    const ast = createTypedFieldProgram(
+      { type: 'TypeExpression', kind: 'enum', constraints: { options: ['dev', 'prod'] }, loc },
+      'staging'
+    );
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('expected one of "dev", "prod"');
+  });
+
+  it('should report a block field default outside the declared range', () => {
+    const ast = createTypedFieldProgram(
+      { type: 'TypeExpression', kind: 'range', constraints: { min: 1, max: 10 }, loc },
+      42
+    );
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('at most 10');
+  });
+
+  it('should report a block field default below the declared range', () => {
+    const ast = createTypedFieldProgram(
+      { type: 'TypeExpression', kind: 'range', constraints: { min: 5, max: 10 }, loc },
+      1
+    );
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('at least 5');
+  });
+
+  it('should point at the default value, not the field', () => {
+    const defaultLoc: SourceLocation = { file: 'test.prs', line: 7, column: 22 };
+    const ast = createTestProgram({
+      blocks: [
+        {
+          type: 'Block',
+          name: 'params',
+          loc,
+          content: { type: 'ObjectContent', properties: {}, loc },
+          canonicalBody: createBlockBody(
+            [
+              {
+                type: 'FieldEntry',
+                name: 'verbose',
+                loc,
+                value: {
+                  type: 'TypeExpressionValueNode',
+                  expression: { type: 'TypeExpression', kind: 'boolean', loc },
+                  loc,
+                },
+                defaultValue: { type: 'ScalarValueNode', value: 'yes', loc: defaultLoc },
+              },
+            ],
+            loc
+          ),
+        },
+      ],
+    });
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages[0]!.location).toEqual(defaultLoc);
+  });
+
+  it('should ignore typed block fields without a default', () => {
+    const ast = createTestProgram({
+      blocks: [
+        {
+          type: 'Block',
+          name: 'params',
+          loc,
+          content: { type: 'ObjectContent', properties: {}, loc },
+          canonicalBody: createBlockBody(
+            [
+              {
+                type: 'FieldEntry',
+                name: 'field',
+                loc,
+                value: {
+                  type: 'TypeExpressionValueNode',
+                  expression: { type: 'TypeExpression', kind: 'number', loc },
+                  loc,
+                },
+              },
+            ],
+            loc
+          ),
+        },
+      ],
     });
     const { ctx, messages } = createRuleContext(ast);
     validParams.validate(ctx);

--- a/packages/validator/src/__tests__/rules-coverage.spec.ts
+++ b/packages/validator/src/__tests__/rules-coverage.spec.ts
@@ -6,6 +6,7 @@ import type {
   PrimitiveValue,
   TypeExpression,
   Value,
+  ValueNode,
 } from '@promptscript/core';
 import { createBlockBody } from '@promptscript/core';
 import { allRules, getRuleById, getRuleByName } from '../rules/index.js';
@@ -1039,8 +1040,20 @@ describe('valid-params rule (PS009) coverage', () => {
 
   function createTypedFieldProgram(
     expression: TypeExpression,
-    defaultValue: PrimitiveValue
+    defaultValue: PrimitiveValue | readonly PrimitiveValue[]
   ): Program {
+    const defaultNode: ValueNode = Array.isArray(defaultValue)
+      ? {
+          type: 'ArrayValueNode',
+          loc,
+          elements: defaultValue.map((element) => ({
+            type: 'ArrayElementNode',
+            loc,
+            value: { type: 'ScalarValueNode', value: element, loc },
+          })),
+        }
+      : { type: 'ScalarValueNode', value: defaultValue as PrimitiveValue, loc };
+
     return createTestProgram({
       blocks: [
         {
@@ -1055,7 +1068,7 @@ describe('valid-params rule (PS009) coverage', () => {
                 name: 'field',
                 loc,
                 value: { type: 'TypeExpressionValueNode', expression, loc },
-                defaultValue: { type: 'ScalarValueNode', value: defaultValue, loc },
+                defaultValue: defaultNode,
               },
             ],
             loc
@@ -1102,6 +1115,107 @@ describe('valid-params rule (PS009) coverage', () => {
     expect(messages[0]!.message).toContain('at most 10');
   });
 
+  it('should report a non-string default for a string field', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'string', loc }, 7);
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('expected string, got number');
+  });
+
+  it('should report a non-numeric default for a number field', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'number', loc }, 'seven');
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('expected number, got string');
+  });
+
+  it('should pass a string default for a string field', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'string', loc }, 'seven');
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should pass a default listed in the declared enum', () => {
+    const ast = createTypedFieldProgram(
+      { type: 'TypeExpression', kind: 'enum', constraints: { options: ['dev', 'prod'] }, loc },
+      'prod'
+    );
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should report a non-numeric default for a range field', () => {
+    const ast = createTypedFieldProgram(
+      { type: 'TypeExpression', kind: 'range', constraints: { min: 1, max: 10 }, loc },
+      'five'
+    );
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('expected number, got string');
+  });
+
+  it('should accept any number for a range field without bounds', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'range', loc }, 4200);
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should suggest a plain range when the field declares no bounds', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'range', loc }, 'five');
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages[0]!.suggestion).toContain('match range');
+  });
+
+  it('should accept any string for an enum field without options', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'enum', loc }, 'anything');
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should report a scalar default for a list field', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'list', loc }, 'nope');
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.message).toContain('expected a list, got string');
+    expect(messages[0]!.suggestion).toContain('list');
+  });
+
+  it('should pass an array default for a list field', () => {
+    const ast = createTypedFieldProgram({ type: 'TypeExpression', kind: 'list', loc }, ['a', 'b']);
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should name the enum options in the suggestion', () => {
+    const ast = createTypedFieldProgram(
+      { type: 'TypeExpression', kind: 'enum', constraints: { options: ['dev'] }, loc },
+      'prod'
+    );
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages[0]!.suggestion).toContain('enum("dev")');
+  });
+
+  it('should name the range bounds in the suggestion', () => {
+    const ast = createTypedFieldProgram(
+      { type: 'TypeExpression', kind: 'range', constraints: { min: 1, max: 3 }, loc },
+      9
+    );
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages[0]!.suggestion).toContain('range(1, 3)');
+  });
+
   it('should report a block field default below the declared range', () => {
     const ast = createTypedFieldProgram(
       { type: 'TypeExpression', kind: 'range', constraints: { min: 5, max: 10 }, loc },
@@ -1144,6 +1258,50 @@ describe('valid-params rule (PS009) coverage', () => {
     const { ctx, messages } = createRuleContext(ast);
     validParams.validate(ctx);
     expect(messages[0]!.location).toEqual(defaultLoc);
+  });
+
+  it('should ignore block fields that declare no type', () => {
+    const ast = createTestProgram({
+      blocks: [
+        {
+          type: 'Block',
+          name: 'context',
+          loc,
+          content: { type: 'ObjectContent', properties: {}, loc },
+          canonicalBody: createBlockBody(
+            [
+              {
+                type: 'FieldEntry',
+                name: 'project',
+                loc,
+                value: { type: 'ScalarValueNode', value: 'demo', loc },
+                defaultValue: { type: 'ScalarValueNode', value: 42, loc },
+              },
+            ],
+            loc
+          ),
+        },
+      ],
+    });
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should ignore blocks without a canonical body', () => {
+    const ast = createTestProgram({
+      blocks: [
+        {
+          type: 'Block',
+          name: 'identity',
+          loc,
+          content: { type: 'TextContent', value: 'You are a bot.', loc },
+        },
+      ],
+    });
+    const { ctx, messages } = createRuleContext(ast);
+    validParams.validate(ctx);
+    expect(messages).toHaveLength(0);
   });
 
   it('should ignore typed block fields without a default', () => {

--- a/packages/validator/src/rules/valid-params.ts
+++ b/packages/validator/src/rules/valid-params.ts
@@ -1,5 +1,6 @@
-import type { ValidationRule } from '../types.js';
-import type { ParamType, Value } from '@promptscript/core';
+import type { RuleContext, ValidationRule } from '../types.js';
+import type { ParamType, TypeExpression, Value, ValueNode } from '@promptscript/core';
+import { valueNodeToValue } from '@promptscript/core';
 
 /**
  * Get the string representation of a ParamType.
@@ -54,62 +55,160 @@ function valueMatchesType(value: Value, paramType: ParamType): boolean {
 }
 
 /**
+ * Render a type expression the way it is written in source.
+ */
+function typeExpressionToString(expression: TypeExpression): string {
+  switch (expression.kind) {
+    case 'enum': {
+      const options = expression.constraints?.options ?? [];
+      return `enum(${options.map((option) => JSON.stringify(option)).join(', ')})`;
+    }
+    case 'range': {
+      const { min, max } = expression.constraints ?? {};
+      if (min === undefined || max === undefined) return 'range';
+      return `range(${min}, ${max})`;
+    }
+    default:
+      return expression.kind;
+  }
+}
+
+/**
+ * Describe why a default value does not satisfy a type expression.
+ * @returns Problem description, or undefined when the value is valid
+ */
+function describeTypeExpressionMismatch(
+  value: Value,
+  expression: TypeExpression
+): string | undefined {
+  const actualType = getValueType(value);
+
+  switch (expression.kind) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return actualType === expression.kind
+        ? undefined
+        : `expected ${expression.kind}, got ${actualType}`;
+    case 'list':
+      return actualType === 'array' ? undefined : `expected a list, got ${actualType}`;
+    case 'enum': {
+      const options = expression.constraints?.options ?? [];
+      if (options.length === 0) return undefined;
+      return options.includes(value)
+        ? undefined
+        : `expected one of ${options.map((option) => JSON.stringify(option)).join(', ')}`;
+    }
+    case 'range': {
+      if (actualType !== 'number') return `expected number, got ${actualType}`;
+      const { min, max } = expression.constraints ?? {};
+      const numeric = value as number;
+      if (min !== undefined && numeric < min) return `expected a value of at least ${min}`;
+      if (max !== undefined && numeric > max) return `expected a value of at most ${max}`;
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Read the type expression a canonical field declares, when it declares one.
+ */
+function typeExpressionOf(node: ValueNode): TypeExpression | undefined {
+  return node.type === 'TypeExpressionValueNode' ? (node.expression as TypeExpression) : undefined;
+}
+
+/**
  * PS009: Valid parameter definitions
  *
  * Validates:
  * - No duplicate parameter names
  * - Default values match declared types
  * - Optional parameters with defaults are consistent
+ * - Default values of typed block fields match their declared types
  */
 export const validParams: ValidationRule = {
   id: 'PS009',
   name: 'valid-params',
-  description: 'Validate parameter definitions in @meta',
+  description: 'Validate parameter definitions in @meta and typed block fields',
   defaultSeverity: 'error',
   validate: (ctx) => {
-    const params = ctx.ast.meta?.params;
-    if (!params || params.length === 0) {
-      return;
-    }
-
-    // Check for duplicate parameter names
-    const seen = new Set<string>();
-    for (const param of params) {
-      if (seen.has(param.name)) {
-        ctx.report({
-          message: `Duplicate parameter definition: '${param.name}'`,
-          location: param.loc,
-          suggestion: 'Remove the duplicate parameter definition',
-        });
-      }
-      seen.add(param.name);
-    }
-
-    // Validate default values match their types
-    for (const param of params) {
-      if (param.defaultValue !== undefined) {
-        if (!valueMatchesType(param.defaultValue, param.paramType)) {
-          const expectedType = paramTypeToString(param.paramType);
-          const actualType = getValueType(param.defaultValue);
-          ctx.report({
-            message: `Default value for '${param.name}' has wrong type: expected ${expectedType}, got ${actualType}`,
-            location: param.loc,
-            suggestion: `Change the default value to a ${expectedType}`,
-          });
-        }
-      }
-    }
-
-    // Warn about optional params without defaults (they'll be undefined at runtime)
-    for (const param of params) {
-      if (param.optional && param.defaultValue === undefined) {
-        // This is just a warning since it might be intentional
-        ctx.report({
-          message: `Optional parameter '${param.name}' has no default value`,
-          location: param.loc,
-          suggestion: 'Consider adding a default value or marking as required',
-        });
-      }
-    }
+    validateMetaParams(ctx);
+    validateTypedFieldDefaults(ctx);
   },
 };
+
+/**
+ * Validate the parameter list declared in @meta.
+ */
+function validateMetaParams(ctx: RuleContext): void {
+  const params = ctx.ast.meta?.params;
+  if (!params || params.length === 0) {
+    return;
+  }
+
+  // Check for duplicate parameter names
+  const seen = new Set<string>();
+  for (const param of params) {
+    if (seen.has(param.name)) {
+      ctx.report({
+        message: `Duplicate parameter definition: '${param.name}'`,
+        location: param.loc,
+        suggestion: 'Remove the duplicate parameter definition',
+      });
+    }
+    seen.add(param.name);
+  }
+
+  // Validate default values match their types
+  for (const param of params) {
+    if (param.defaultValue !== undefined) {
+      if (!valueMatchesType(param.defaultValue, param.paramType)) {
+        const expectedType = paramTypeToString(param.paramType);
+        const actualType = getValueType(param.defaultValue);
+        ctx.report({
+          message: `Default value for '${param.name}' has wrong type: expected ${expectedType}, got ${actualType}`,
+          location: param.loc,
+          suggestion: `Change the default value to a ${expectedType}`,
+        });
+      }
+    }
+  }
+
+  // Warn about optional params without defaults (they'll be undefined at runtime)
+  for (const param of params) {
+    if (param.optional && param.defaultValue === undefined) {
+      // This is just a warning since it might be intentional
+      ctx.report({
+        message: `Optional parameter '${param.name}' has no default value`,
+        location: param.loc,
+        suggestion: 'Consider adding a default value or marking as required',
+      });
+    }
+  }
+}
+
+/**
+ * Validate defaults written on typed block fields, such as @params entries.
+ */
+function validateTypedFieldDefaults(ctx: RuleContext): void {
+  for (const block of ctx.ast.blocks) {
+    for (const entry of block.canonicalBody?.entries ?? []) {
+      if (entry.type !== 'FieldEntry' || entry.defaultValue === undefined) continue;
+
+      const expression = typeExpressionOf(entry.value);
+      if (!expression) continue;
+
+      const problem = describeTypeExpressionMismatch(
+        valueNodeToValue(entry.defaultValue),
+        expression
+      );
+      if (!problem) continue;
+
+      ctx.report({
+        message: `Default value for '${entry.name}' does not match its type: ${problem}`,
+        location: entry.defaultValue.loc,
+        suggestion: `Change the default value to match ${typeExpressionToString(expression)}`,
+      });
+    }
+  }
+}

--- a/scripts/validate-docs-examples.mts
+++ b/scripts/validate-docs-examples.mts
@@ -273,11 +273,6 @@ function shouldSkipBlock(content: string, markdownContext: string): boolean {
     return true;
   }
 
-  // Skip blocks containing @extend (proposed syntax not yet supported by parser)
-  if (content.includes('@extend ')) {
-    return true;
-  }
-
   // Skip blocks with unquoted file paths in arrays (e.g., ./references/foo.md)
   if (/^\s+\.\/[\w/.-]+\.md\s*$/m.test(content)) {
     return true;


### PR DESCRIPTION
## What

Two gaps found while re-auditing earlier findings.

### `@params` defaults were never type-checked

PS009 read only the parameter list declared in `@meta`, so a `@params` block
could declare `verbose: boolean = "yes"` and validation reported nothing. The
rule now also walks typed block fields and checks the default against the
declared type, including `enum` options and `range` bounds. Errors point at the
default value rather than the field.

```
✗ Default value for 'verbose' does not match its type: expected boolean, got string
  at params.prs:4:22
```

### The documentation gate skipped every example containing `@extend`

The skip carried the comment "proposed syntax not yet supported by parser",
which stopped being true once `@extend ident { ... }` and `@extend alias.block
{ ... }` landed. It hid 42 lines of documentation from `docs:validate`.

Removing it surfaced one real documentation bug: the layer 3 example in
`skill-overlays.md` listed array elements without commas, so it never parsed.
Three examples that produce compiled output gained snapshots
(`merge-vs-replace`, `execution-order`, `agent-platform` field replacement),
each reviewed to confirm the merge, replace and override semantics are the ones
the surrounding prose describes.

## Verification

`format`, `lint`, `typecheck`, `test` (11 projects), `prs validate --strict`,
`schema:check`, `skill:check`, `grammar:check`, `docs:validate:check`,
`docs:highlight:check`, `docs:formatters:check` - all green. The gate was
confirmed to fail on a deliberately broken `@extend` example before the fix.
