### PR TITLE
fix(core): remove regex ReDoS and patch dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,14 @@
 # Build the CLI from source with all development dependencies
 FROM node:25-alpine AS builder
 
-# Install build dependencies for native modules
-RUN apk add --no-cache python3 make g++
+# Update Alpine packages, including OpenSSL, before installing build tools.
+RUN apk upgrade --no-cache && apk add --no-cache python3 make g++
 
 WORKDIR /build
 
-# Install pnpm (corepack may not be available in all Node.js alpine images)
-RUN npm install -g pnpm@10
+# Update npm before installing pnpm so the image does not retain vulnerable
+# packages bundled with the base image's npm.
+RUN npm install --global npm@12.0.2 pnpm@10.34.5
 
 # Copy package files first for better layer caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -67,8 +68,8 @@ LABEL org.opencontainers.image.title="PromptScript CLI" \
       org.opencontainers.image.vendor="PromptScript" \
       org.opencontainers.image.licenses="MIT"
 
-# Install git (required for prs pull and simple-git)
-RUN apk add --no-cache git
+# Update Alpine packages, including OpenSSL, before installing git.
+RUN apk upgrade --no-cache && apk add --no-cache git
 
 # Set up application directory
 WORKDIR /app
@@ -77,8 +78,10 @@ WORKDIR /app
 COPY --from=builder /build/dist/packages/cli/ ./
 COPY --from=builder /build/dist/packages/server/ ./node_modules/@promptscript/server/
 
-# Install production dependencies only
-RUN npm install --omit=dev && \
+# Update npm before installing production dependencies so the runtime image
+# does not retain vulnerable packages bundled with the base image's npm.
+RUN npm install --global npm@12.0.2 && \
+    npm install --omit=dev && \
     npm cache clean --force
 
 # Create workspace directory and set permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Stage 1: Builder
 # -----------------------------------------------------------------------------
 # Build the CLI from source with all development dependencies
-FROM node:25-alpine AS builder
+FROM node:24-alpine AS builder
 
 # Update Alpine packages, including OpenSSL, before installing build tools.
 RUN apk upgrade --no-cache && apk add --no-cache python3 make g++
@@ -58,7 +58,7 @@ RUN pnpm build
 # Stage 2: Runtime
 # -----------------------------------------------------------------------------
 # Minimal runtime image with only production dependencies
-FROM node:25-alpine AS runtime
+FROM node:24-alpine AS runtime
 
 # Image metadata
 LABEL org.opencontainers.image.title="PromptScript CLI" \

--- a/packages/cli/src/__tests__/config-loader.spec.ts
+++ b/packages/cli/src/__tests__/config-loader.spec.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { loadConfig, findConfigFile, CONFIG_FILES, loadEffectiveConfig } from '../config/loader.js';
+import {
+  loadConfig,
+  findConfigFile,
+  CONFIG_FILES,
+  loadEffectiveConfig,
+  interpolateEnvVars,
+} from '../config/loader.js';
 
 // Mock fs modules
 vi.mock('fs', () => ({
@@ -202,6 +208,32 @@ syntax: "1.0.0"
         expect.stringContaining("Environment variable 'MISSING_VAR' is not set")
       );
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('interpolateEnvVars', () => {
+    it('should leave incomplete expressions unchanged', () => {
+      const text = 'prefix ${MISSING:-unterminated';
+
+      expect(interpolateEnvVars(text)).toBe(text);
+    });
+
+    it('should interpolate multiple variables without regex backtracking', () => {
+      process.env['FIRST_VAR'] = 'first';
+      delete process.env['SECOND_VAR'];
+
+      expect(interpolateEnvVars('${FIRST_VAR}:${SECOND_VAR:-second}')).toBe('first:second');
+    });
+
+    it.each(['${MISSING_VAR', '${1MISSING_VAR}', '${MISSING_VAR:invalid}'])(
+      'should leave invalid expressions unchanged: %s',
+      (text) => {
+        expect(interpolateEnvVars(text)).toBe(text);
+      }
+    );
+
+    it('should preserve nested-looking default text', () => {
+      expect(interpolateEnvVars('${MISSING_VAR:-a${OTHER_VAR}}')).toBe('a${OTHER_VAR}');
     });
   });
 

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { parse as parseYaml } from 'yaml';
+import { interpolateEnvVars as interpolateEnvironmentVariables } from '@promptscript/core';
 import type { PromptScriptConfig } from '@promptscript/core';
 import { loadUserConfig } from './user-config.js';
 import { loadEnvOverrides } from './env-config.js';
@@ -22,25 +23,7 @@ export const CONFIG_FILES = [
  * For missing variables without default: warns and returns empty string.
  */
 export function interpolateEnvVars(text: string): string {
-  // Match ${VAR} or ${VAR:-default}
-  // VAR must start with letter or underscore, followed by word characters
-  const envVarPattern = /\$\{([A-Za-z_]\w*)(?::-([^}]*))?\}/g;
-
-  return text.replace(envVarPattern, (_match, varName: string, defaultValue?: string) => {
-    const envValue = process.env[varName];
-
-    if (envValue !== undefined) {
-      return envValue;
-    }
-
-    if (defaultValue !== undefined) {
-      return defaultValue;
-    }
-
-    // Warn and return empty string (like Linux behavior)
-    console.warn(`Warning: Environment variable '${varName}' is not set, using empty string`);
-    return '';
-  });
+  return interpolateEnvironmentVariables(text, (name) => process.env[name]);
 }
 
 /**

--- a/packages/core/src/__tests__/interpolate-env.spec.ts
+++ b/packages/core/src/__tests__/interpolate-env.spec.ts
@@ -1,0 +1,46 @@
+import { interpolateEnvVars } from '../utils/interpolate-env.js';
+
+describe('interpolateEnvVars', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should leave text without expressions unchanged', () => {
+    expect(interpolateEnvVars('plain text', () => undefined)).toBe('plain text');
+  });
+
+  it('should replace values from the environment provider', () => {
+    const provider = (name: string): string | undefined =>
+      name === 'PROJECT_ID' ? 'promptscript' : undefined;
+
+    expect(interpolateEnvVars('id=${PROJECT_ID}', provider)).toBe('id=promptscript');
+  });
+
+  it('should use defaults for missing variables', () => {
+    expect(interpolateEnvVars('${MISSING_VAR:-fallback}', () => undefined)).toBe('fallback');
+  });
+
+  it('should warn and use an empty string without a default', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(interpolateEnvVars('${MISSING_VAR}', () => undefined)).toBe('');
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Warning: Environment variable 'MISSING_VAR' is not set, using empty string"
+    );
+  });
+
+  it.each(['${1INVALID}', '${VAR:invalid}', '${VAR', '${VAR:-unterminated'])(
+    'should preserve malformed expression %s',
+    (text) => {
+      expect(interpolateEnvVars(`prefix ${text} suffix`, () => undefined)).toBe(
+        `prefix ${text} suffix`
+      );
+    }
+  );
+
+  it('should preserve nested-looking default text', () => {
+    expect(interpolateEnvVars('${MISSING_VAR:-a${OTHER_VAR}}', () => undefined)).toBe(
+      'a${OTHER_VAR}'
+    );
+  });
+});

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './path.js';
 export * from './version.js';
 export * from './levenshtein.js';
 export * from './markers.js';
+export * from './interpolate-env.js';

--- a/packages/core/src/utils/interpolate-env.ts
+++ b/packages/core/src/utils/interpolate-env.ts
@@ -1,0 +1,86 @@
+type EnvironmentVariableProvider = (name: string) => string | undefined;
+
+/**
+ * Interpolate environment variables without regex backtracking.
+ * Supports ${VAR} and ${VAR:-default} syntax.
+ */
+export function interpolateEnvVars(
+  text: string,
+  environmentProvider: EnvironmentVariableProvider
+): string {
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const start = text.indexOf('${', cursor);
+    if (start === -1) {
+      result += text.slice(cursor);
+      break;
+    }
+
+    result += text.slice(cursor, start);
+    const nameStart = start + 2;
+    const firstCode = text.charCodeAt(nameStart);
+    if (
+      !(
+        (firstCode >= 65 && firstCode <= 90) ||
+        (firstCode >= 97 && firstCode <= 122) ||
+        firstCode === 95
+      )
+    ) {
+      result += '${';
+      cursor = nameStart;
+      continue;
+    }
+
+    let nameEnd = nameStart + 1;
+    while (nameEnd < text.length) {
+      const code = text.charCodeAt(nameEnd);
+      if (
+        !(
+          (code >= 65 && code <= 90) ||
+          (code >= 97 && code <= 122) ||
+          (code >= 48 && code <= 57) ||
+          code === 95
+        )
+      ) {
+        break;
+      }
+      nameEnd += 1;
+    }
+
+    let expressionEnd = nameEnd;
+    let defaultValue: string | undefined;
+    if (text[nameEnd] === '}') {
+      expressionEnd += 1;
+    } else if (text.startsWith(':-', nameEnd)) {
+      const defaultStart = nameEnd + 2;
+      const closingBrace = text.indexOf('}', defaultStart);
+      if (closingBrace === -1) {
+        result += text.slice(start);
+        break;
+      }
+      defaultValue = text.slice(defaultStart, closingBrace);
+      expressionEnd = closingBrace + 1;
+    } else {
+      result += text.slice(start, nameEnd);
+      cursor = nameEnd;
+      continue;
+    }
+
+    const varName = text.slice(nameStart, nameEnd);
+    const envValue = environmentProvider(varName);
+
+    if (envValue !== undefined) {
+      result += envValue;
+    } else if (defaultValue !== undefined) {
+      result += defaultValue;
+    } else {
+      console.warn(`Warning: Environment variable '${varName}' is not set, using empty string`);
+    }
+
+    cursor = expressionEnd;
+  }
+
+  return result;
+}

--- a/packages/parser/src/__tests__/parser-coverage.spec.ts
+++ b/packages/parser/src/__tests__/parser-coverage.spec.ts
@@ -667,6 +667,24 @@ describe('visitor coverage - edge cases', () => {
       }
     });
 
+    it('should leave incomplete env expressions unchanged', () => {
+      const source = `
+        @meta { id: "test" }
+        @config {
+          value: "\${MISSING_ENV_VAR_TEST:-unterminated"
+        }
+      `;
+      const result = parse(source, { interpolateEnv: true });
+
+      expect(result.errors).toHaveLength(0);
+      const configBlock = result.ast?.blocks.find((b) => b.name === 'config');
+      if (configBlock?.content?.type === 'ObjectContent') {
+        expect(configBlock.content.properties['value']).toBe(
+          '${MISSING_ENV_VAR_TEST:-unterminated'
+        );
+      }
+    });
+
     it('should warn and use empty string for missing env var without default', () => {
       delete process.env['MISSING_NO_DEFAULT_VAR'];
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/parser/src/grammar/visitor.ts
+++ b/packages/parser/src/grammar/visitor.ts
@@ -37,6 +37,7 @@ import {
   createCanonicalOverrideBlock,
   createCanonicalProgram,
   createValueNode,
+  interpolateEnvVars,
   normalizeLegacyHeadingEntries,
   SYNTAX_FEATURES,
 } from '@promptscript/core';
@@ -1253,25 +1254,7 @@ class PromptScriptVisitor extends BaseVisitor {
    * For missing variables without default: warns and returns empty string.
    */
   private interpolateEnvVars(text: string): string {
-    // Match ${VAR} or ${VAR:-default}
-    // VAR must start with letter or underscore, followed by word characters
-    const envVarPattern = /\$\{([A-Za-z_]\w*)(?::-([^}]*))?\}/g;
-
-    return text.replace(envVarPattern, (_match, varName: string, defaultValue?: string) => {
-      const envValue = this.envProvider(varName);
-
-      if (envValue !== undefined) {
-        return envValue;
-      }
-
-      if (defaultValue !== undefined) {
-        return defaultValue;
-      }
-
-      // Warn and return empty string (like Linux behavior)
-      console.warn(`Warning: Environment variable '${varName}' is not set, using empty string`);
-      return '';
-    });
+    return interpolateEnvVars(text, this.envProvider);
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,22 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@xhmikosr/decompress@11.1.1': 11.1.3
+  axios@1.16.0: 1.18.0
+  brace-expansion@2.1.1: 2.1.4
+  brace-expansion@5.0.6: 5.0.9
+  dompurify: ^3.4.13
+  fast-uri@3.1.0: 3.1.5
+  fast-uri@3.1.2: 3.1.5
+  find-my-way@9.5.0: 9.7.0
+  form-data@4.0.5: 4.0.6
+  piscina@4.9.2: 4.9.3
+  qs@6.14.2: 6.15.3
+  tmp@0.2.6: 0.2.7
+  undici@6.26.0: 6.28.0
+  undici@7.27.2: 7.29.0
+
 importers:
 
   .:
@@ -3047,12 +3063,12 @@ packages:
     resolution: {integrity: sha512-1JXu2b6yrpm5EuBoOzMU57B4qrHXJKWQQ7LlMynNEiz85mEjDciO3ayf//GXaTLLCEKiHjWlU3q3THjgf7uODA==}
     engines: {node: '>=20'}
 
-  '@xhmikosr/decompress-unzip@8.1.0':
-    resolution: {integrity: sha512-hVcpEZIS8avXU1ioR0Pb2LcBYHfah1lzzTQPDItkBi3W+kSE/DxSeEgOoHJB8rn+Izm0ArWZxxlpsvEK4ySjaw==}
+  '@xhmikosr/decompress-unzip@8.2.1':
+    resolution: {integrity: sha512-2MS94QnmXQwjkKN8WyFiu1sU7J3rcWJcMze4kRYsX7tN+CXpUGECgkh4YSOhujpkWPuVlFudIziJHO/TxOqkQQ==}
     engines: {node: '>=20'}
 
-  '@xhmikosr/decompress@11.1.1':
-    resolution: {integrity: sha512-KdjwFbTzcpGaTIPncNaPLOHocBSF1hHo4s7gr+ZzzoB2bzVzFumzawqKTij0Vpw0idM4C2FZFPktIfyznkeJTQ==}
+  '@xhmikosr/decompress@11.1.3':
+    resolution: {integrity: sha512-NiyhJq6z7ERsYghcnXZUI6ooDXgZtoB+G9eUsYhfSM4VLp2rKx9UxhKI1NEf1PqosrNPxG3bnSsr2UBVbNurlg==}
     engines: {node: '>=20'}
 
   '@xhmikosr/downloader@16.1.2':
@@ -3233,8 +3249,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
@@ -3352,12 +3368,8 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -3743,8 +3755,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4030,12 +4042,6 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
-
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
@@ -4095,8 +4101,8 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
-  find-my-way@9.5.0:
-    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@5.0.0:
@@ -4133,10 +4139,6 @@ packages:
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
@@ -4884,10 +4886,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.5.1:
-    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
-    engines: {node: 20 || >=22}
-
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -5366,8 +5364,8 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  piscina@4.9.2:
-    resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
+  piscina@4.9.3:
+    resolution: {integrity: sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==}
 
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
@@ -5449,14 +5447,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
-    engines: {node: '>=0.6'}
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -6008,10 +5998,6 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
-  tmp@0.2.6:
-    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
-    engines: {node: '>=14.14'}
-
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
@@ -6167,12 +6153,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -6543,17 +6529,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.9
       '@octokit/request-error': 7.1.0
-      undici: 6.26.0
+      undici: 6.28.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.28.0
 
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.28.0
 
   '@actions/io@3.0.2': {}
 
@@ -6690,7 +6676,7 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6699,8 +6685,8 @@ snapshots:
 
   '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -6742,7 +6728,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -7376,18 +7362,18 @@ snapshots:
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      debug: 4.4.3
+      '@babel/types': 7.29.8
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7638,7 +7624,7 @@ snapshots:
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
@@ -7654,7 +7640,7 @@ snapshots:
   '@eslint/eslintrc@3.3.6':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -7682,7 +7668,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.5
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -8023,7 +8009,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8607,7 +8593,7 @@ snapshots:
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
       ajv: 8.20.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       rc-config-loader: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -8616,7 +8602,7 @@ snapshots:
     dependencies:
       '@secretlint/profiler': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       structured-source: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8629,7 +8615,7 @@ snapshots:
       '@textlint/module-interop': 15.7.1
       '@textlint/types': 15.7.1
       chalk: 5.6.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       pluralize: 8.0.0
       strip-ansi: 7.2.0
       table: 6.9.0
@@ -8645,7 +8631,7 @@ snapshots:
       '@secretlint/profiler': 10.2.2
       '@secretlint/source-creator': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       p-map: 7.0.4
     transitivePeerDependencies:
       - supports-color
@@ -8719,7 +8705,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.6.1
       '@swc/core': 1.15.47(@swc/helpers@0.5.23)
       colorette: 2.0.20
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       fast-json-stable-stringify: 2.1.0
       oxc-resolver: 11.24.2
       pirates: 4.0.7
@@ -8741,7 +8727,7 @@ snapshots:
       '@xhmikosr/bin-wrapper': 14.2.3
       commander: 8.3.0
       minimatch: 9.0.9
-      piscina: 4.9.2
+      piscina: 4.9.3
       semver: 7.7.4
       slash: 3.0.0
       source-map: 0.7.6
@@ -8927,7 +8913,7 @@ snapshots:
       '@textlint/resolver': 15.7.1
       '@textlint/types': 15.7.1
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
@@ -8948,7 +8934,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9050,7 +9036,7 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       eslint: 10.8.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9060,7 +9046,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.60.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9069,7 +9055,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9097,7 +9083,7 @@ snapshots:
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.60.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       eslint: 10.8.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -9109,7 +9095,7 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       eslint: 10.8.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -9126,7 +9112,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/visitor-keys': 8.60.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.6
       semver: 7.8.1
       tinyglobby: 0.2.17
@@ -9141,7 +9127,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -9196,7 +9182,7 @@ snapshots:
       '@verdaccio/core': 8.2.0
       '@verdaccio/loaders': 8.1.0
       '@verdaccio/signature': 8.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       lodash: 4.18.1
       verdaccio-htpasswd: 13.1.0
     transitivePeerDependencies:
@@ -9205,7 +9191,7 @@ snapshots:
   '@verdaccio/config@8.2.0':
     dependencies:
       '@verdaccio/core': 8.2.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       js-yaml: 5.2.2
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -9228,7 +9214,7 @@ snapshots:
     dependencies:
       '@verdaccio/core': 8.2.0
       '@verdaccio/logger': 8.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       got: 15.1.0
       handlebars: 4.7.9
     transitivePeerDependencies:
@@ -9237,7 +9223,7 @@ snapshots:
   '@verdaccio/loaders@8.1.0':
     dependencies:
       '@verdaccio/core': 8.2.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
@@ -9247,7 +9233,7 @@ snapshots:
       '@verdaccio/core': 8.2.0
       '@verdaccio/file-locking': 13.1.0
       '@verdaccio/streams': 10.3.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       globby: 11.1.0
       lodash: 4.18.1
       lowdb: 1.0.0
@@ -9261,7 +9247,7 @@ snapshots:
       '@verdaccio/core': 8.2.0
       '@verdaccio/logger-prettify': 8.1.0
       colorette: 2.0.20
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9286,7 +9272,7 @@ snapshots:
       '@verdaccio/config': 8.2.0
       '@verdaccio/core': 8.2.0
       '@verdaccio/url': 13.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       express: 4.22.1
       express-rate-limit: 5.5.1
       lodash: 4.18.1
@@ -9297,14 +9283,14 @@ snapshots:
   '@verdaccio/package-filter@13.1.0':
     dependencies:
       '@verdaccio/core': 8.2.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
   '@verdaccio/search-indexer@8.1.0':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       fuse.js: 7.3.0
     transitivePeerDependencies:
       - supports-color
@@ -9313,7 +9299,7 @@ snapshots:
     dependencies:
       '@verdaccio/config': 8.2.0
       '@verdaccio/core': 8.2.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - supports-color
@@ -9324,7 +9310,7 @@ snapshots:
     dependencies:
       '@verdaccio/core': 8.2.0
       '@verdaccio/url': 13.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gunzip-maybe: 1.4.2
       tar-stream: 3.1.7
     transitivePeerDependencies:
@@ -9334,14 +9320,14 @@ snapshots:
 
   '@verdaccio/ui-theme@9.0.0-next-9.21':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@verdaccio/url@13.1.0':
     dependencies:
       '@verdaccio/core': 8.2.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       validator: 13.15.26
     transitivePeerDependencies:
       - supports-color
@@ -9464,7 +9450,7 @@ snapshots:
       cheerio: 1.2.0
       cockatiel: 3.2.1
       commander: 12.1.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       glob: 13.0.6
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
@@ -9541,7 +9527,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@xhmikosr/decompress-unzip@8.1.0':
+  '@xhmikosr/decompress-unzip@8.2.1':
     dependencies:
       file-type: 21.3.4
       get-stream: 9.0.1
@@ -9549,12 +9535,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@xhmikosr/decompress@11.1.1':
+  '@xhmikosr/decompress@11.1.3':
     dependencies:
       '@xhmikosr/decompress-tar': 9.0.1
       '@xhmikosr/decompress-tarbz2': 9.0.1
       '@xhmikosr/decompress-targz': 9.0.1
-      '@xhmikosr/decompress-unzip': 8.1.0
+      '@xhmikosr/decompress-unzip': 8.2.1
       graceful-fs: 4.2.11
       strip-dirs: 3.0.0
     transitivePeerDependencies:
@@ -9565,7 +9551,7 @@ snapshots:
   '@xhmikosr/downloader@16.1.2':
     dependencies:
       '@xhmikosr/archive-type': 8.0.1
-      '@xhmikosr/decompress': 11.1.1
+      '@xhmikosr/decompress': 11.1.3
       content-disposition: 1.1.0
       ext-name: 5.0.0
       file-type: 21.3.4
@@ -9623,9 +9609,9 @@ snapshots:
 
   address@2.0.3: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9652,7 +9638,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9730,13 +9716,15 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.16.0:
+  axios@1.18.0(supports-color@7.2.0):
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   azure-devops-node-api@12.5.0:
     dependencies:
@@ -9870,13 +9858,9 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.3
 
   brace-expansion@5.0.9:
     dependencies:
@@ -9981,7 +9965,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.27.2
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chevrotain@12.0.0:
@@ -10161,9 +10145,11 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decimal.js@10.6.0: {}
 
@@ -10232,7 +10218,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.2.7:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10410,7 +10396,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -10536,7 +10522,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -10621,7 +10607,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -10636,10 +10622,6 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
-
-  fast-uri@3.1.0: {}
-
-  fast-uri@3.1.2: {}
 
   fast-uri@3.1.5: {}
 
@@ -10660,7 +10642,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.2.0
       fast-json-stringify: 6.3.0
-      find-my-way: 9.5.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -10720,7 +10702,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.5.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
@@ -10750,14 +10732,6 @@ snapshots:
   forever-agent@0.6.1: {}
 
   form-data-encoder@4.1.0: {}
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
 
   form-data@4.0.6:
     dependencies:
@@ -10972,7 +10946,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10989,17 +10963,17 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11170,12 +11144,12 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -11451,8 +11425,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.5.1: {}
-
   lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
@@ -11576,7 +11548,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
@@ -11588,7 +11560,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -11601,7 +11573,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.13
       marked: 14.0.0
 
   ms@2.0.0: {}
@@ -11686,11 +11658,11 @@ snapshots:
       ansi-styles: 4.3.0
       argparse: 2.0.1
       asynckit: 0.4.0
-      axios: 1.16.0
+      axios: 1.18.0(supports-color@7.2.0)
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
       buffer: 5.7.1
       call-bind-apply-helpers: 1.0.2
       chalk: 4.1.2
@@ -11720,7 +11692,7 @@ snapshots:
       figures: 3.2.0
       flat: 5.0.2
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-constants: 1.0.0
       function-bind: 1.1.2
       get-caller-file: 2.0.5
@@ -11771,7 +11743,7 @@ snapshots:
       strip-bom: 3.0.0
       supports-color: 7.2.0
       tar-stream: 2.2.0
-      tmp: 0.2.6
+      tmp: 0.2.7
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
@@ -12045,7 +12017,7 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  piscina@4.9.2:
+  piscina@4.9.3:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
 
@@ -12131,14 +12103,6 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.1
-
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.1
-
   qs@6.15.3:
     dependencies:
       es-define-property: 1.0.1
@@ -12161,7 +12125,7 @@ snapshots:
 
   rc-config-loader@4.1.4:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -12345,7 +12309,7 @@ snapshots:
       '@secretlint/formatter': 10.2.2
       '@secretlint/node': 10.2.2
       '@secretlint/profiler': 10.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       globby: 14.1.0
       read-pkg: 9.0.1
     transitivePeerDependencies:
@@ -12462,7 +12426,7 @@ snapshots:
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12744,8 +12708,6 @@ snapshots:
     dependencies:
       tldts-core: 7.0.28
 
-  tmp@0.2.6: {}
-
   tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
@@ -12858,7 +12820,7 @@ snapshots:
 
   typed-rest-client@1.8.11:
     dependencies:
-      qs: 6.15.2
+      qs: 6.15.3
       tunnel: 0.0.6
       underscore: 1.13.8
 
@@ -12893,9 +12855,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.26.0: {}
+  undici@6.28.0: {}
 
-  undici@7.27.2: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -12959,7 +12921,7 @@ snapshots:
       '@verdaccio/config': 8.2.0
       '@verdaccio/core': 8.2.0
       express: 4.22.1
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding
@@ -12971,7 +12933,7 @@ snapshots:
       '@verdaccio/file-locking': 13.1.0
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
       unix-crypt-td-js: 1.1.4
     transitivePeerDependencies:
@@ -13001,7 +12963,7 @@ snapshots:
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       compression: 1.8.1
       cors: 2.8.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       envinfo: 7.21.0
       express: 4.22.2
       lodash: 4.18.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,23 @@ allowBuilds:
 
 autoInstallPeers: true
 
+# Keep transitive dependencies on patched releases until their parents update.
+overrides:
+  '@xhmikosr/decompress@11.1.1': 11.1.3
+  axios@1.16.0: 1.18.0
+  brace-expansion@2.1.1: 2.1.4
+  brace-expansion@5.0.6: 5.0.9
+  dompurify: ^3.4.13
+  fast-uri@3.1.0: 3.1.5
+  fast-uri@3.1.2: 3.1.5
+  find-my-way@9.5.0: 9.7.0
+  form-data@4.0.5: 4.0.6
+  piscina@4.9.2: 4.9.3
+  qs@6.14.2: 6.15.3
+  tmp@0.2.6: 0.2.7
+  undici@6.26.0: 6.28.0
+  undici@7.27.2: 7.29.0
+
 ignoredBuiltDependencies:
   - nx
 


### PR DESCRIPTION
## Summary

- Replace polynomial-backtracking environment interpolation regex with a shared linear scanner.
- Preserve valid and malformed interpolation behavior with regression coverage.
- Pin patched transitive npm dependencies in pnpm overrides.
- Update npm, pnpm, and Alpine packages in Docker stages for Trivy findings.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` - 1570 passed
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`
- `pnpm audit` - 0 vulnerabilities
- Commit hooks passed documentation validation, format check, lint, and schema check.

Docker build not run locally because Docker daemon is unavailable.
