### PR TITLE
fix(ci): configure TypeDoc for NodeNext

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://typedoc.org/schema.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
   "entryPoints": ["packages/*/src/index.ts"],
   "out": "docs/api-reference",
   "plugin": ["typedoc-plugin-markdown"],


### PR DESCRIPTION
## Summary
- configure TypeDoc with NodeNext module resolution
- allow Chalk 6 package exports to resolve during documentation builds

## Validation
- pnpm docs:generate
- full repository verification pipeline