### PR TITLE
fix(ci): isolate schema generator config

### DIFF
--- a/scripts/generate-schema.mts
+++ b/scripts/generate-schema.mts
@@ -15,7 +15,7 @@ const __dirname = path.dirname(__filename);
 
 const config: Config = {
   path: path.resolve(__dirname, '../packages/core/src/types/config.ts'),
-  tsconfig: path.resolve(__dirname, '../tsconfig.base.json'),
+  tsconfig: path.resolve(__dirname, '../tsconfig.schema.json'),
   type: 'PromptScriptConfig',
   schemaId: 'https://getpromptscript.dev/latest/schema/config.json',
   expose: 'export',
@@ -23,7 +23,7 @@ const config: Config = {
   jsDoc: 'extended',
   sortProps: true,
   strictTuples: false,
-  skipTypeCheck: true,
+  skipTypeCheck: false,
   encodeRefs: true,
   extraTags: ['example', 'default'],
 };

--- a/tsconfig.schema.json
+++ b/tsconfig.schema.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@promptscript/*": ["packages/*/src/index.ts"],
+      "@promptscript/core": ["packages/core/src/index.ts"],
+      "@promptscript/parser": ["packages/parser/src/index.ts"],
+      "@promptscript/resolver": ["packages/resolver/src/index.ts"],
+      "@promptscript/validator": ["packages/validator/src/index.ts"],
+      "@promptscript/compiler": ["packages/compiler/src/index.ts"],
+      "@promptscript/formatters": ["packages/formatters/src/index.ts"],
+      "@promptscript/cli": ["packages/cli/src/index.ts"],
+      "@promptscript/importer": ["packages/importer/src/index.ts"],
+      "@promptscript/server": ["packages/server/src/index.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone TypeScript config for schema generation
- restore schema generator type checking
- avoid TypeScript 6 options unsupported by its bundled TypeScript 5.9

## Validation
- full 8-step repository verification pipeline
- pnpm schema:check