### PR TITLE
fix(resolver): stream Git tree verification

### DIFF
--- a/packages/resolver/src/__tests__/vendor-manifest.spec.ts
+++ b/packages/resolver/src/__tests__/vendor-manifest.spec.ts
@@ -20,6 +20,10 @@ import {
 const tempDirectories: string[] = [];
 const execFileAsync = promisify(execFile);
 
+interface FakeGitOptions {
+  isolatedPath?: boolean;
+}
+
 async function createTempDirectory(): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'prs-vendor-manifest-'));
   tempDirectories.push(directory);
@@ -47,6 +51,40 @@ async function initializeVendoredGitRepository(directory: string): Promise<strin
   const result = await execFileAsync('git', ['-C', directory, 'rev-parse', 'HEAD']);
   await rename(join(directory, '.git'), join(directory, VENDOR_GIT_DIR));
   return result.stdout.trim();
+}
+
+async function withFakeGit(
+  script: string,
+  callback: () => Promise<void>,
+  options: FakeGitOptions = {}
+): Promise<void> {
+  const fakeGitDirectory = await createTempDirectory();
+  const fakeGitPath = join(fakeGitDirectory, 'git');
+  const realGitPath = (await execFileAsync('which', ['git'])).stdout.trim();
+  await writeFile(
+    fakeGitPath,
+    `#!/bin/sh
+${script}
+exec "${realGitPath}" "$@"
+`
+  );
+  await chmod(fakeGitPath, 0o755);
+
+  const originalPath = process.env['PATH'];
+  process.env['PATH'] = options.isolatedPath
+    ? fakeGitDirectory
+    : originalPath
+      ? `${fakeGitDirectory}${delimiter}${originalPath}`
+      : fakeGitDirectory;
+  try {
+    await callback();
+  } finally {
+    if (originalPath === undefined) {
+      delete process.env['PATH'];
+    } else {
+      process.env['PATH'] = originalPath;
+    }
+  }
 }
 
 afterEach(async () => {
@@ -228,11 +266,8 @@ describe('vendor manifest', () => {
       const objectId = (
         await execFileAsync('git', ['-C', repositoryDir, 'hash-object', '--no-filters', 'base.prs'])
       ).stdout.trim();
-      const fakeGitDirectory = await createTempDirectory();
-      const realGitPath = (await execFileAsync('which', ['git'])).stdout.trim();
-      await writeFile(
-        join(fakeGitDirectory, 'git'),
-        `#!/bin/sh
+      await withFakeGit(
+        `
 if [ "$3" = "ls-tree" ]; then
   index=0
   while [ "$index" -lt 20000 ]; do
@@ -241,23 +276,82 @@ if [ "$3" = "ls-tree" ]; then
   done
   exit 0
 fi
-exec "${realGitPath}" "$@"
-`
-      );
-      await chmod(join(fakeGitDirectory, 'git'), 0o755);
-
-      const originalPath = process.env['PATH'];
-      process.env['PATH'] = originalPath
-        ? `${fakeGitDirectory}${delimiter}${originalPath}`
-        : fakeGitDirectory;
-      try {
-        await expect(verifyVendoredGitRepository(repositoryDir, commit)).resolves.toBeUndefined();
-      } finally {
-        if (originalPath === undefined) {
-          delete process.env['PATH'];
-        } else {
-          process.env['PATH'] = originalPath;
+`,
+        async () => {
+          await expect(verifyVendoredGitRepository(repositoryDir, commit)).resolves.toBeUndefined();
         }
+      );
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'reports streamed Git tree process failures',
+    async () => {
+      const repositoryDir = await createTempDirectory();
+      await writeFile(join(repositoryDir, 'base.prs'), '@meta { id: "base" }');
+      const commit = await initializeVendoredGitRepository(repositoryDir);
+
+      await withFakeGit(
+        `
+if [ "$3" = "rev-parse" ]; then
+  /bin/rm "$0"
+fi
+`,
+        async () => {
+          await expect(verifyVendoredGitRepository(repositoryDir, commit)).rejects.toThrow(
+            'Failed to run git ls-tree'
+          );
+        },
+        { isolatedPath: true }
+      );
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects failed and malformed streamed Git tree output',
+    async () => {
+      const repositoryDir = await createTempDirectory();
+      await writeFile(join(repositoryDir, 'base.prs'), '@meta { id: "base" }');
+      const commit = await initializeVendoredGitRepository(repositoryDir);
+      const objectId = (
+        await execFileAsync('git', ['-C', repositoryDir, 'hash-object', '--no-filters', 'base.prs'])
+      ).stdout.trim();
+      const cases = [
+        {
+          script: `
+if [ "$3" = "ls-tree" ]; then
+  "${process.execPath}" -e 'process.stderr.write("x".repeat(70000), () => process.exit(7))'
+  exit $?
+fi
+`,
+          expected: '[stderr truncated]',
+        },
+        {
+          script: `
+if [ "$3" = "ls-tree" ]; then
+  "${process.execPath}" -e 'process.stdout.write("x".repeat(1048577))'
+  exit $?
+fi
+`,
+          expected: 'record exceeds',
+        },
+        {
+          script: `
+if [ "$3" = "ls-tree" ]; then
+  printf '100644 blob %s\tbase.prs' '${objectId}'
+  exit 0
+fi
+`,
+          expected: 'unterminated record',
+        },
+      ];
+
+      for (const testCase of cases) {
+        await withFakeGit(testCase.script, async () => {
+          await expect(verifyVendoredGitRepository(repositoryDir, commit)).rejects.toThrow(
+            testCase.expected
+          );
+        });
       }
     }
   );

--- a/packages/resolver/src/__tests__/vendor-manifest.spec.ts
+++ b/packages/resolver/src/__tests__/vendor-manifest.spec.ts
@@ -64,6 +64,13 @@ async function withFakeGit(
   await writeFile(
     fakeGitPath,
     `#!/bin/sh
+# Resolve the subcommand by name so scripts do not depend on git flag positions.
+subcommand=''
+for arg in "$@"; do
+  case "$arg" in
+    ls-tree|rev-parse|hash-object) subcommand="$arg"; break ;;
+  esac
+done
 ${script}
 exec "${realGitPath}" "$@"
 `
@@ -268,7 +275,7 @@ describe('vendor manifest', () => {
       ).stdout.trim();
       await withFakeGit(
         `
-if [ "$3" = "ls-tree" ]; then
+if [ "$subcommand" = "ls-tree" ]; then
   index=0
   while [ "$index" -lt 20000 ]; do
     printf '100644 blob %s\tbase.prs\\000' '${objectId}'
@@ -293,7 +300,7 @@ fi
 
       await withFakeGit(
         `
-if [ "$3" = "rev-parse" ]; then
+if [ "$subcommand" = "rev-parse" ]; then
   /bin/rm "$0"
 fi
 `,
@@ -319,7 +326,7 @@ fi
       const cases = [
         {
           script: `
-if [ "$3" = "ls-tree" ]; then
+if [ "$subcommand" = "ls-tree" ]; then
   "${process.execPath}" -e 'process.stderr.write("x".repeat(70000), () => process.exit(7))'
   exit $?
 fi
@@ -328,7 +335,7 @@ fi
         },
         {
           script: `
-if [ "$3" = "ls-tree" ]; then
+if [ "$subcommand" = "ls-tree" ]; then
   "${process.execPath}" -e 'process.stdout.write("x".repeat(1048577))'
   exit $?
 fi
@@ -337,7 +344,7 @@ fi
         },
         {
           script: `
-if [ "$3" = "ls-tree" ]; then
+if [ "$subcommand" = "ls-tree" ]; then
   printf '100644 blob %s\tbase.prs' '${objectId}'
   exit 0
 fi

--- a/packages/resolver/src/__tests__/vendor-manifest.spec.ts
+++ b/packages/resolver/src/__tests__/vendor-manifest.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { execFile } from 'child_process';
 import { chmod, mkdtemp, mkdir, rename, rm, symlink, unlink, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { delimiter, join } from 'path';
 import { tmpdir } from 'os';
 import { promisify } from 'util';
 import {
@@ -218,6 +218,49 @@ describe('vendor manifest', () => {
       repositoryDir
     );
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'streams large Git tree output while validating a checkout',
+    async () => {
+      const repositoryDir = await createTempDirectory();
+      await writeFile(join(repositoryDir, 'base.prs'), '@meta { id: "base" }');
+      const commit = await initializeVendoredGitRepository(repositoryDir);
+      const objectId = (
+        await execFileAsync('git', ['-C', repositoryDir, 'hash-object', '--no-filters', 'base.prs'])
+      ).stdout.trim();
+      const fakeGitDirectory = await createTempDirectory();
+      const realGitPath = (await execFileAsync('which', ['git'])).stdout.trim();
+      await writeFile(
+        join(fakeGitDirectory, 'git'),
+        `#!/bin/sh
+if [ "$3" = "ls-tree" ]; then
+  index=0
+  while [ "$index" -lt 20000 ]; do
+    printf '100644 blob %s\tbase.prs\\000' '${objectId}'
+    index=$((index + 1))
+  done
+  exit 0
+fi
+exec "${realGitPath}" "$@"
+`
+      );
+      await chmod(join(fakeGitDirectory, 'git'), 0o755);
+
+      const originalPath = process.env['PATH'];
+      process.env['PATH'] = originalPath
+        ? `${fakeGitDirectory}${delimiter}${originalPath}`
+        : fakeGitDirectory;
+      try {
+        await expect(verifyVendoredGitRepository(repositoryDir, commit)).resolves.toBeUndefined();
+      } finally {
+        if (originalPath === undefined) {
+          delete process.env['PATH'];
+        } else {
+          process.env['PATH'] = originalPath;
+        }
+      }
+    }
+  );
 
   it('rejects worktree changes even when the editable manifest hash is updated', async () => {
     const vendorDir = await createTempDirectory();

--- a/packages/resolver/src/vendor-manifest.ts
+++ b/packages/resolver/src/vendor-manifest.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { lstat, readFile, readdir, realpath } from 'fs/promises';
 import { basename, dirname, isAbsolute, join, posix, relative, sep } from 'path';
 import { promisify } from 'util';
@@ -8,6 +8,8 @@ export const VENDOR_MANIFEST_FILE = '.vendor-manifest.json';
 export const VENDOR_GIT_DIR = '.promptscript-git';
 const execFileAsync = promisify(execFile);
 const NULL_DEVICE = process.platform === 'win32' ? 'NUL' : '/dev/null';
+const MAX_GIT_STDERR_BYTES = 64 * 1024;
+const MAX_GIT_TREE_RECORD_BYTES = 1024 * 1024;
 
 export interface VendorManifestEntry {
   commit: string;
@@ -151,9 +153,12 @@ export async function verifyGitRepositoryCheckout(
     await lstat(join(gitDir, 'objects', 'info', 'alternates'));
     throw new Error(`Git object alternates are not allowed in vendor metadata: ${gitDir}`);
   } catch (error) {
-    if (
-      !(typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT')
-    ) {
+    if (!(
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    )) {
       throw error;
     }
   }
@@ -175,26 +180,158 @@ export async function verifyGitRepositoryCheckout(
     throw new Error(`Vendored repository commit does not match the lockfile: ${directory}`);
   }
 
-  const tree = await execFileAsync('git', [...commonArgs, 'ls-tree', '-r', '-z', expectedCommit], {
+  const trackedFiles = new Map<string, { objectId: string; executable: boolean }>();
+  const treeProcess = spawn('git', [...commonArgs, 'ls-tree', '-r', '-z', expectedCommit], {
     env: environment,
   });
-  const trackedFiles = new Map<string, { objectId: string; executable: boolean }>();
-  for (const row of tree.stdout.split('\0').filter(Boolean)) {
-    const separator = row.indexOf('\t');
-    const metadata = row.slice(0, separator).split(' ');
-    const path = row.slice(separator + 1);
-    if (separator < 0 || metadata.length !== 3 || metadata[1] !== 'blob') {
-      throw new Error(`Unsupported Git tree entry in vendored repository: ${path}`);
-    }
-    const mode = metadata[0];
-    if (mode !== '100644' && mode !== '100755') {
-      throw new Error(`Unsupported Git tree mode in vendored repository: ${path}`);
-    }
-    trackedFiles.set(path, {
-      objectId: metadata[2]!,
-      executable: mode === '100755',
-    });
+  const treeStdout = treeProcess.stdout;
+  const treeStderr = treeProcess.stderr;
+  if (!treeStdout || !treeStderr) {
+    treeProcess.kill();
+    throw new Error('Git ls-tree did not provide output streams');
   }
+  await new Promise<void>((resolve, reject) => {
+    let pendingRecord = Buffer.alloc(0);
+    const stderrChunks: Buffer[] = [];
+    let stderrBytes = 0;
+    let stderrTruncated = false;
+    let parseError: Error | null = null;
+    let streamError: Error | null = null;
+    let spawnError: Error | null = null;
+
+    const killTreeProcess = (): void => {
+      if (!treeProcess.killed) {
+        treeProcess.kill();
+      }
+    };
+
+    const recordParseError = (error: unknown): void => {
+      if (parseError || streamError) {
+        return;
+      }
+      parseError = error instanceof Error ? error : new Error(String(error));
+      killTreeProcess();
+    };
+
+    const recordStreamError = (streamName: string, error: unknown): void => {
+      if (parseError || streamError) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      streamError = new Error(`Failed to read git ls-tree ${streamName}: ${message}`, {
+        cause: error,
+      });
+      killTreeProcess();
+    };
+
+    const captureStderr = (chunk: Buffer): void => {
+      const remaining = MAX_GIT_STDERR_BYTES - stderrBytes;
+      if (remaining <= 0) {
+        stderrTruncated = true;
+        return;
+      }
+      const capturedLength = Math.min(chunk.length, remaining);
+      if (capturedLength > 0) {
+        stderrChunks.push(Buffer.from(chunk.subarray(0, capturedLength)));
+        stderrBytes += capturedLength;
+      }
+      if (capturedLength < chunk.length) {
+        stderrTruncated = true;
+      }
+    };
+
+    const processRow = (row: string): void => {
+      const separator = row.indexOf('\t');
+      const metadata = row.slice(0, separator).split(' ');
+      const path = row.slice(separator + 1);
+      if (separator < 0 || metadata.length !== 3 || metadata[1] !== 'blob') {
+        throw new Error(`Unsupported Git tree entry in vendored repository: ${path}`);
+      }
+      const mode = metadata[0];
+      if (mode !== '100644' && mode !== '100755') {
+        throw new Error(`Unsupported Git tree mode in vendored repository: ${path}`);
+      }
+      trackedFiles.set(path, {
+        objectId: metadata[2]!,
+        executable: mode === '100755',
+      });
+    };
+
+    const consumeStdout = (chunk: Buffer): void => {
+      const output = pendingRecord.length > 0 ? Buffer.concat([pendingRecord, chunk]) : chunk;
+      let recordStart = 0;
+      let separator = output.indexOf(0, recordStart);
+      while (separator >= 0) {
+        if (separator > recordStart) {
+          processRow(output.toString('utf8', recordStart, separator));
+        }
+        recordStart = separator + 1;
+        separator = output.indexOf(0, recordStart);
+      }
+      pendingRecord =
+        recordStart < output.length ? Buffer.from(output.subarray(recordStart)) : Buffer.alloc(0);
+      if (pendingRecord.length > MAX_GIT_TREE_RECORD_BYTES) {
+        throw new Error(`Git ls-tree record exceeds ${MAX_GIT_TREE_RECORD_BYTES} bytes`);
+      }
+    };
+
+    treeStdout.on('data', (chunk: Buffer) => {
+      if (parseError || streamError) {
+        return;
+      }
+      try {
+        consumeStdout(chunk);
+      } catch (error) {
+        recordParseError(error);
+      }
+    });
+    treeStderr.on('data', (chunk: Buffer) => {
+      captureStderr(chunk);
+    });
+    treeStdout.once('error', (error: unknown) => {
+      recordStreamError('stdout', error);
+    });
+    treeStderr.once('error', (error: unknown) => {
+      recordStreamError('stderr', error);
+    });
+    treeProcess.once('error', (error: Error) => {
+      if (!parseError && !streamError && !spawnError) {
+        spawnError = error;
+        killTreeProcess();
+      }
+    });
+    treeProcess.once('close', (code, signal) => {
+      if (!parseError && !streamError && !spawnError) {
+        try {
+          if (code === 0 && pendingRecord.length > 0) {
+            throw new Error('Git ls-tree output ended with an unterminated record');
+          }
+        } catch (error) {
+          recordParseError(error);
+        }
+      }
+      const stderrOutput = Buffer.concat(stderrChunks, stderrBytes).toString('utf8');
+      const stderrDetails = stderrTruncated ? `${stderrOutput}\n[stderr truncated]` : stderrOutput;
+      const details = stderrDetails.trim();
+
+      if (parseError) {
+        reject(parseError);
+      } else if (streamError) {
+        reject(streamError);
+      } else if (spawnError) {
+        reject(
+          new Error(`Failed to run git ls-tree: ${spawnError.message}`, {
+            cause: spawnError,
+          })
+        );
+      } else if (code !== 0) {
+        const status = signal ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
+        reject(new Error(`Git ls-tree failed with ${status}${details ? `: ${details}` : ''}`));
+      } else {
+        resolve();
+      }
+    });
+  });
 
   const worktreeFiles: string[] = [];
   async function collectFiles(currentDirectory: string, prefix: string): Promise<void> {
@@ -291,14 +428,12 @@ export async function loadVendorManifest(vendorDir: string): Promise<VendorManif
           });
         }
       } catch (backupError) {
-        if (
-          !(
-            typeof backupError === 'object' &&
-            backupError !== null &&
-            'code' in backupError &&
-            backupError.code === 'ENOENT'
-          )
-        ) {
+        if (!(
+          typeof backupError === 'object' &&
+          backupError !== null &&
+          'code' in backupError &&
+          backupError.code === 'ENOENT'
+        )) {
           throw backupError;
         }
       }

--- a/packages/resolver/src/vendor-manifest.ts
+++ b/packages/resolver/src/vendor-manifest.ts
@@ -231,15 +231,21 @@ export async function verifyGitRepositoryCheckout(
           const metadataSeparator = row.indexOf('\t');
           const metadata = row.slice(0, metadataSeparator).split(' ');
           const path = row.slice(metadataSeparator + 1);
-          if (metadataSeparator < 0 || metadata.length !== 3 || metadata[1] !== 'blob') {
+          const [mode, entryType, objectId, ...extraFields] = metadata;
+          if (
+            metadataSeparator < 0 ||
+            entryType !== 'blob' ||
+            extraFields.length > 0 ||
+            mode === undefined ||
+            objectId === undefined
+          ) {
             throw new Error(`Unsupported Git tree entry in vendored repository: ${path}`);
           }
-          const mode = metadata[0];
           if (mode !== '100644' && mode !== '100755') {
             throw new Error(`Unsupported Git tree mode in vendored repository: ${path}`);
           }
           trackedFiles.set(path, {
-            objectId: metadata[2]!,
+            objectId,
             executable: mode === '100755',
           });
         }
@@ -253,7 +259,7 @@ export async function verifyGitRepositoryCheckout(
       }
     }
   } catch (error) {
-    stdoutError = error instanceof Error ? error : new Error(String(error));
+    stdoutError = error instanceof Error ? error : new Error(String(error), { cause: error });
     treeProcess.kill();
   }
 

--- a/packages/resolver/src/vendor-manifest.ts
+++ b/packages/resolver/src/vendor-manifest.ts
@@ -23,6 +23,11 @@ export interface VendorManifest {
   dependencies: Record<string, VendorManifestEntry>;
 }
 
+interface GitProcessResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
 export function getVendorRepositoryRelativePath(repoUrl: string): string {
   const sshMatch = /^git@([^:]+):(.+)$/.exec(repoUrl);
   const candidate = sshMatch
@@ -183,87 +188,60 @@ export async function verifyGitRepositoryCheckout(
   const trackedFiles = new Map<string, { objectId: string; executable: boolean }>();
   const treeProcess = spawn('git', [...commonArgs, 'ls-tree', '-r', '-z', expectedCommit], {
     env: environment,
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
-  const treeStdout = treeProcess.stdout;
-  const treeStderr = treeProcess.stderr;
-  if (!treeStdout || !treeStderr) {
-    treeProcess.kill();
-    throw new Error('Git ls-tree did not provide output streams');
-  }
-  await new Promise<void>((resolve, reject) => {
-    let pendingRecord = Buffer.alloc(0);
-    const stderrChunks: Buffer[] = [];
-    let stderrBytes = 0;
-    let stderrTruncated = false;
-    let parseError: Error | null = null;
-    let streamError: Error | null = null;
-    let spawnError: Error | null = null;
+  let processError: Error | null = null;
+  const processCompletion = new Promise<GitProcessResult>((resolveProcess) => {
+    treeProcess.once('error', (error: Error) => {
+      processError = new Error(`Failed to run git ls-tree: ${error.message}`, { cause: error });
+      resolveProcess({ code: null, signal: null });
+    });
+    treeProcess.once('close', (code, signal) => {
+      resolveProcess({ code, signal });
+    });
+  });
 
-    const killTreeProcess = (): void => {
-      if (!treeProcess.killed) {
-        treeProcess.kill();
-      }
-    };
-
-    const recordParseError = (error: unknown): void => {
-      if (parseError || streamError) {
-        return;
-      }
-      parseError = error instanceof Error ? error : new Error(String(error));
-      killTreeProcess();
-    };
-
-    const recordStreamError = (streamName: string, error: unknown): void => {
-      if (parseError || streamError) {
-        return;
-      }
-      const message = error instanceof Error ? error.message : String(error);
-      streamError = new Error(`Failed to read git ls-tree ${streamName}: ${message}`, {
-        cause: error,
-      });
-      killTreeProcess();
-    };
-
-    const captureStderr = (chunk: Buffer): void => {
+  const stderrChunks: Buffer[] = [];
+  let stderrBytes = 0;
+  let stderrTruncated = false;
+  const stderrCompletion = (async (): Promise<void> => {
+    for await (const chunk of treeProcess.stderr as AsyncIterable<Buffer>) {
       const remaining = MAX_GIT_STDERR_BYTES - stderrBytes;
-      if (remaining <= 0) {
-        stderrTruncated = true;
-        return;
+      if (remaining > 0) {
+        const captured = chunk.subarray(0, remaining);
+        stderrChunks.push(Buffer.from(captured));
+        stderrBytes += captured.length;
       }
-      const capturedLength = Math.min(chunk.length, remaining);
-      if (capturedLength > 0) {
-        stderrChunks.push(Buffer.from(chunk.subarray(0, capturedLength)));
-        stderrBytes += capturedLength;
-      }
-      if (capturedLength < chunk.length) {
+      if (chunk.length > remaining) {
         stderrTruncated = true;
       }
-    };
+    }
+  })();
 
-    const processRow = (row: string): void => {
-      const separator = row.indexOf('\t');
-      const metadata = row.slice(0, separator).split(' ');
-      const path = row.slice(separator + 1);
-      if (separator < 0 || metadata.length !== 3 || metadata[1] !== 'blob') {
-        throw new Error(`Unsupported Git tree entry in vendored repository: ${path}`);
-      }
-      const mode = metadata[0];
-      if (mode !== '100644' && mode !== '100755') {
-        throw new Error(`Unsupported Git tree mode in vendored repository: ${path}`);
-      }
-      trackedFiles.set(path, {
-        objectId: metadata[2]!,
-        executable: mode === '100755',
-      });
-    };
-
-    const consumeStdout = (chunk: Buffer): void => {
+  let pendingRecord = Buffer.alloc(0);
+  let stdoutError: Error | null = null;
+  try {
+    for await (const chunk of treeProcess.stdout as AsyncIterable<Buffer>) {
       const output = pendingRecord.length > 0 ? Buffer.concat([pendingRecord, chunk]) : chunk;
       let recordStart = 0;
       let separator = output.indexOf(0, recordStart);
       while (separator >= 0) {
         if (separator > recordStart) {
-          processRow(output.toString('utf8', recordStart, separator));
+          const row = output.toString('utf8', recordStart, separator);
+          const metadataSeparator = row.indexOf('\t');
+          const metadata = row.slice(0, metadataSeparator).split(' ');
+          const path = row.slice(metadataSeparator + 1);
+          if (metadataSeparator < 0 || metadata.length !== 3 || metadata[1] !== 'blob') {
+            throw new Error(`Unsupported Git tree entry in vendored repository: ${path}`);
+          }
+          const mode = metadata[0];
+          if (mode !== '100644' && mode !== '100755') {
+            throw new Error(`Unsupported Git tree mode in vendored repository: ${path}`);
+          }
+          trackedFiles.set(path, {
+            objectId: metadata[2]!,
+            executable: mode === '100755',
+          });
         }
         recordStart = separator + 1;
         separator = output.indexOf(0, recordStart);
@@ -273,65 +251,29 @@ export async function verifyGitRepositoryCheckout(
       if (pendingRecord.length > MAX_GIT_TREE_RECORD_BYTES) {
         throw new Error(`Git ls-tree record exceeds ${MAX_GIT_TREE_RECORD_BYTES} bytes`);
       }
-    };
+    }
+  } catch (error) {
+    stdoutError = error instanceof Error ? error : new Error(String(error));
+    treeProcess.kill();
+  }
 
-    treeStdout.on('data', (chunk: Buffer) => {
-      if (parseError || streamError) {
-        return;
-      }
-      try {
-        consumeStdout(chunk);
-      } catch (error) {
-        recordParseError(error);
-      }
-    });
-    treeStderr.on('data', (chunk: Buffer) => {
-      captureStderr(chunk);
-    });
-    treeStdout.once('error', (error: unknown) => {
-      recordStreamError('stdout', error);
-    });
-    treeStderr.once('error', (error: unknown) => {
-      recordStreamError('stderr', error);
-    });
-    treeProcess.once('error', (error: Error) => {
-      if (!parseError && !streamError && !spawnError) {
-        spawnError = error;
-        killTreeProcess();
-      }
-    });
-    treeProcess.once('close', (code, signal) => {
-      if (!parseError && !streamError && !spawnError) {
-        try {
-          if (code === 0 && pendingRecord.length > 0) {
-            throw new Error('Git ls-tree output ended with an unterminated record');
-          }
-        } catch (error) {
-          recordParseError(error);
-        }
-      }
-      const stderrOutput = Buffer.concat(stderrChunks, stderrBytes).toString('utf8');
-      const stderrDetails = stderrTruncated ? `${stderrOutput}\n[stderr truncated]` : stderrOutput;
-      const details = stderrDetails.trim();
-
-      if (parseError) {
-        reject(parseError);
-      } else if (streamError) {
-        reject(streamError);
-      } else if (spawnError) {
-        reject(
-          new Error(`Failed to run git ls-tree: ${spawnError.message}`, {
-            cause: spawnError,
-          })
-        );
-      } else if (code !== 0) {
-        const status = signal ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
-        reject(new Error(`Git ls-tree failed with ${status}${details ? `: ${details}` : ''}`));
-      } else {
-        resolve();
-      }
-    });
-  });
+  const [{ code, signal }] = await Promise.all([processCompletion, stderrCompletion]);
+  if (processError) {
+    throw processError;
+  }
+  if (stdoutError) {
+    throw stdoutError;
+  }
+  if (code !== 0) {
+    const stderrOutput = Buffer.concat(stderrChunks, stderrBytes).toString('utf8');
+    const stderrDetails = stderrTruncated ? `${stderrOutput}\n[stderr truncated]` : stderrOutput;
+    const details = stderrDetails.trim();
+    const status = signal ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
+    throw new Error(`Git ls-tree failed with ${status}${details ? `: ${details}` : ''}`);
+  }
+  if (pendingRecord.length > 0) {
+    throw new Error('Git ls-tree output ended with an unterminated record');
+  }
 
   const worktreeFiles: string[] = [];
   async function collectFiles(currentDirectory: string, prefix: string): Promise<void> {


### PR DESCRIPTION
## Summary

- stream `git ls-tree -r -z` output instead of buffering it through `execFile`
- parse NUL-delimited records across arbitrary chunks while preserving tree validation
- bound stderr and malformed-record memory, terminate Git after stream or parse failures
- add regression coverage with more than 1 MiB of tree output

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` - 1613 tests passed
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`

Closes #393
