### PR TITLE
fix(cli): filter Factory skill frontmatter on init

### DIFF
--- a/packages/cli/src/__tests__/init-command.spec.ts
+++ b/packages/cli/src/__tests__/init-command.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parse as parseYaml } from 'yaml';
-import { initCommand } from '../commands/init.js';
+import { getSkillWrites, initCommand } from '../commands/init.js';
 import { type CliServices } from '../services.js';
 
 // Mock prettier/loader
@@ -805,6 +805,32 @@ describe('commands/init', () => {
       expect(writtenContent).not.toContain('<!-- PromptScript');
       // Frontmatter should still be valid
       expect(writtenContent).toMatch(/^---\n/);
+    });
+
+    it('should filter Factory skill frontmatter during initialization', () => {
+      const writes = getSkillWrites(['factory']);
+      const sourceSkill = writes.find(
+        (write) => write.path === '.promptscript/skills/promptscript/SKILL.md'
+      );
+      const factorySkill = writes.find(
+        (write) => write.path === '.factory/skills/promptscript/SKILL.md'
+      );
+
+      expect(sourceSkill).toBeDefined();
+      expect(factorySkill).toBeDefined();
+      expect(sourceSkill?.content).toContain('license: MIT');
+      expect(sourceSkill?.content).toContain('allowed-tools:');
+      expect(factorySkill?.content).toContain('# promptscript-generated: true');
+      expect(factorySkill?.content).toContain('name: promptscript');
+      expect(factorySkill?.content).toContain('description:');
+      expect(factorySkill?.content).toContain('user-invocable: true');
+      const factoryFrontmatter = factorySkill?.content.match(/^---\n([\s\S]*?)\n---/)?.[1];
+      expect(factoryFrontmatter).toBeDefined();
+      expect(factoryFrontmatter).not.toContain('license: MIT');
+      expect(factoryFrontmatter).not.toContain('metadata:');
+      expect(factoryFrontmatter).not.toContain('compatibility:');
+      expect(factoryFrontmatter).not.toContain('allowed-tools:');
+      expect(factorySkill?.content).toContain('# PromptScript Language Guide');
     });
   });
 

--- a/packages/cli/src/__tests__/init-command.spec.ts
+++ b/packages/cli/src/__tests__/init-command.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parse as parseYaml } from 'yaml';
-import { getSkillWrites, initCommand } from '../commands/init.js';
+import { addPromptScriptMarker, getSkillWrites, initCommand } from '../commands/init.js';
 import { type CliServices } from '../services.js';
 
 // Mock prettier/loader
@@ -831,6 +831,13 @@ describe('commands/init', () => {
       expect(factoryFrontmatter).not.toContain('compatibility:');
       expect(factoryFrontmatter).not.toContain('allowed-tools:');
       expect(factorySkill?.content).toContain('# PromptScript Language Guide');
+    });
+
+    it('should preserve existing PromptScript markers', () => {
+      const content = '---\n# promptscript-generated: true\nname: promptscript\n---\n';
+
+      expect(addPromptScriptMarker(content)).toBe(content);
+      expect(addPromptScriptMarker('# Plain skill')).toBe('# Plain skill');
     });
   });
 

--- a/packages/cli/src/__tests__/init-command.spec.ts
+++ b/packages/cli/src/__tests__/init-command.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import { addPromptScriptMarker, getSkillWrites, initCommand } from '../commands/init.js';
 import { type CliServices } from '../services.js';
+import { FormatterRegistry } from '@promptscript/formatters';
 
 // Mock prettier/loader
 const mockFindPrettierConfig = vi.fn();
@@ -808,36 +809,103 @@ describe('commands/init', () => {
     });
 
     it('should filter Factory skill frontmatter during initialization', () => {
-      const writes = getSkillWrites(['factory']);
+      const writes = getSkillWrites(['factory', 'claude']);
       const sourceSkill = writes.find(
         (write) => write.path === '.promptscript/skills/promptscript/SKILL.md'
       );
       const factorySkill = writes.find(
         (write) => write.path === '.factory/skills/promptscript/SKILL.md'
       );
+      const claudeSkill = writes.find(
+        (write) => write.path === '.claude/skills/promptscript/SKILL.md'
+      );
 
       expect(sourceSkill).toBeDefined();
       expect(factorySkill).toBeDefined();
+      expect(claudeSkill).toBeDefined();
       expect(sourceSkill?.content).toContain('license: MIT');
       expect(sourceSkill?.content).toContain('allowed-tools:');
       expect(factorySkill?.content).toContain('# promptscript-generated: true');
-      expect(factorySkill?.content).toContain('name: promptscript');
-      expect(factorySkill?.content).toContain('description:');
-      expect(factorySkill?.content).toContain('user-invocable: true');
-      const factoryFrontmatter = factorySkill?.content.match(/^---\n([\s\S]*?)\n---/)?.[1];
-      expect(factoryFrontmatter).toBeDefined();
-      expect(factoryFrontmatter).not.toContain('license: MIT');
-      expect(factoryFrontmatter).not.toContain('metadata:');
-      expect(factoryFrontmatter).not.toContain('compatibility:');
-      expect(factoryFrontmatter).not.toContain('allowed-tools:');
-      expect(factorySkill?.content).toContain('# PromptScript Language Guide');
+      expect(claudeSkill?.content).toContain('license: MIT');
+      expect(claudeSkill?.content).toContain('allowed-tools:');
+
+      const sourceFrontmatterMatch = sourceSkill?.content.match(/^---\n([\s\S]*?)\n---/);
+      const factoryFrontmatterMatch = factorySkill?.content.match(/^---\n([\s\S]*?)\n---/);
+      const claudeFrontmatterMatch = claudeSkill?.content.match(/^---\n([\s\S]*?)\n---/);
+      expect(sourceFrontmatterMatch).toBeDefined();
+      expect(factoryFrontmatterMatch).toBeDefined();
+      expect(claudeFrontmatterMatch).toBeDefined();
+
+      const sourceFrontmatter = parseYaml(sourceFrontmatterMatch![1]!) as Record<string, unknown>;
+      const factoryFrontmatter = parseYaml(factoryFrontmatterMatch![1]!) as Record<string, unknown>;
+      const claudeFrontmatter = parseYaml(claudeFrontmatterMatch![1]!) as Record<string, unknown>;
+
+      expect(Object.keys(factoryFrontmatter)).toEqual(['name', 'description', 'user-invocable']);
+      expect(factoryFrontmatter).toEqual({
+        name: 'promptscript',
+        description: sourceFrontmatter['description'],
+        'user-invocable': true,
+      });
+      expect(sourceFrontmatter['license']).toBe('MIT');
+      expect(sourceFrontmatter['allowed-tools']).toBeDefined();
+      expect(claudeFrontmatter['license']).toBe(sourceFrontmatter['license']);
+      expect(claudeFrontmatter['allowed-tools']).toEqual(sourceFrontmatter['allowed-tools']);
+      expect(factorySkill?.content.slice(factoryFrontmatterMatch![0].length)).toBe(
+        sourceSkill?.content.slice(sourceFrontmatterMatch![0].length)
+      );
+    });
+
+    it('should mark untransformed skill content when formatter has no transform hook', () => {
+      const claudeFormatter = FormatterRegistry.get('claude');
+      if (!claudeFormatter) {
+        throw new Error('Claude formatter is not registered');
+      }
+
+      const formatterWithoutTransform = Object.create(claudeFormatter) as typeof claudeFormatter;
+      Object.defineProperty(formatterWithoutTransform, 'transformInjectedSkillContent', {
+        configurable: true,
+        value: undefined,
+      });
+      const originalGet = FormatterRegistry.get;
+      const getSpy = vi.spyOn(FormatterRegistry, 'get');
+
+      try {
+        getSpy.mockImplementation((target) => {
+          if (target === 'claude') return formatterWithoutTransform;
+          return originalGet.call(FormatterRegistry, target);
+        });
+
+        const writes = getSkillWrites(['claude']);
+        const sourceSkill = writes.find(
+          (write) => write.path === '.promptscript/skills/promptscript/SKILL.md'
+        );
+        const claudeSkill = writes.find(
+          (write) => write.path === '.claude/skills/promptscript/SKILL.md'
+        );
+
+        expect(claudeSkill?.content).toBe(sourceSkill?.content);
+        expect(claudeSkill?.content).toContain('# promptscript-generated: true');
+      } finally {
+        getSpy.mockRestore();
+      }
     });
 
     it('should preserve existing PromptScript markers', () => {
-      const content = '---\n# promptscript-generated: true\nname: promptscript\n---\n';
+      const yamlContent = '---\n# promptscript-generated: true\nname: promptscript\n---\n';
+      const legacyHtmlContent =
+        '<!-- PromptScript 2026-07-27T16:59:01.673Z | source: project.prs | target: claude - do not edit -->\n\n---\nname: promptscript\n---\n';
 
-      expect(addPromptScriptMarker(content)).toBe(content);
+      expect(addPromptScriptMarker(yamlContent)).toBe(yamlContent);
+      expect(addPromptScriptMarker(legacyHtmlContent)).toBe(legacyHtmlContent);
       expect(addPromptScriptMarker('# Plain skill')).toBe('# Plain skill');
+    });
+
+    it('should insert YAML marker into existing frontmatter', () => {
+      const content = '---\nname: promptscript\n---\n# Plain skill';
+
+      expect(addPromptScriptMarker(content)).toBe(
+        '---\n# promptscript-generated: true\nname: promptscript\n---\n# Plain skill'
+      );
     });
   });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -565,17 +565,7 @@ export function getSkillWrites(targets: AIToolTarget[]): PlannedWrite[] {
   const skillSource = resolve(BUNDLED_SKILLS_DIR, skillName, 'SKILL.md');
   try {
     const rawSkillContent = readFileSync(skillSource, 'utf-8');
-    // Add PromptScript marker so `prs compile` can safely overwrite these files.
-    // Use YAML comment inside frontmatter to avoid breaking tools like Factory AI
-    // that cannot parse HTML comments between frontmatter and content body.
-    let skillContent = rawSkillContent;
-    const hasMarker =
-      rawSkillContent.includes('<!-- PromptScript') ||
-      rawSkillContent.includes('# promptscript-generated:');
-    if (!hasMarker && rawSkillContent.startsWith('---')) {
-      const yamlMarker = '# promptscript-generated: true';
-      skillContent = `---\n${yamlMarker}${rawSkillContent.slice(3)}`;
-    }
+    const skillContent = addPromptScriptMarker(rawSkillContent);
 
     writes.push({
       path: `.promptscript/skills/${skillName}/SKILL.md`,
@@ -585,7 +575,11 @@ export function getSkillWrites(targets: AIToolTarget[]): PlannedWrite[] {
     for (const target of targets) {
       const targetSkillDir = getTargetSkillDir(target, skillName);
       if (targetSkillDir && !writes.some((write) => write.path === targetSkillDir.path)) {
-        writes.push({ path: targetSkillDir.path, content: skillContent });
+        const formatter = FormatterRegistry.get(target);
+        const targetContent = formatter?.transformInjectedSkillContent
+          ? addPromptScriptMarker(formatter.transformInjectedSkillContent(rawSkillContent))
+          : skillContent;
+        writes.push({ path: targetSkillDir.path, content: targetContent });
       }
     }
   } catch {
@@ -593,6 +587,18 @@ export function getSkillWrites(targets: AIToolTarget[]): PlannedWrite[] {
   }
 
   return writes;
+}
+
+/**
+ * Add a PromptScript marker without putting HTML comments after YAML frontmatter.
+ */
+function addPromptScriptMarker(content: string): string {
+  const hasMarker =
+    content.includes('<!-- PromptScript') || content.includes('# promptscript-generated:');
+  if (!hasMarker && content.startsWith('---')) {
+    return `---\n# promptscript-generated: true${content.slice(3)}`;
+  }
+  return content;
 }
 
 /**

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -576,9 +576,12 @@ export function getSkillWrites(targets: AIToolTarget[]): PlannedWrite[] {
       const targetSkillDir = getTargetSkillDir(target, skillName);
       if (targetSkillDir && !writes.some((write) => write.path === targetSkillDir.path)) {
         const formatter = FormatterRegistry.get(target);
-        const targetContent = formatter?.transformInjectedSkillContent
-          ? addPromptScriptMarker(formatter.transformInjectedSkillContent(rawSkillContent))
-          : skillContent;
+        let targetContent = skillContent;
+        if (formatter?.transformInjectedSkillContent) {
+          targetContent = addPromptScriptMarker(
+            formatter.transformInjectedSkillContent(rawSkillContent)
+          );
+        }
         writes.push({ path: targetSkillDir.path, content: targetContent });
       }
     }
@@ -592,13 +595,12 @@ export function getSkillWrites(targets: AIToolTarget[]): PlannedWrite[] {
 /**
  * Add a PromptScript marker without putting HTML comments after YAML frontmatter.
  */
-function addPromptScriptMarker(content: string): string {
+export function addPromptScriptMarker(content: string): string {
   const hasMarker =
     content.includes('<!-- PromptScript') || content.includes('# promptscript-generated:');
-  if (!hasMarker && content.startsWith('---')) {
-    return `---\n# promptscript-generated: true${content.slice(3)}`;
-  }
-  return content;
+  return !hasMarker && content.startsWith('---')
+    ? `---\n# promptscript-generated: true${content.slice(3)}`
+    : content;
 }
 
 /**


### PR DESCRIPTION
## Summary

- apply target formatter transforms when `prs init` installs the bundled PromptScript skill
- filter unsupported Factory frontmatter fields before writing `.factory/skills/promptscript/SKILL.md`
- preserve the PromptScript generation marker
- add CLI regression coverage

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`