### PR TITLE
fix(cli): keep managed skill integrity deterministic

### DIFF
--- a/docs/guides/markdown-imports.md
+++ b/docs/guides/markdown-imports.md
@@ -86,6 +86,16 @@ prs skills update
 Both `prs skills add` and `prs skills update` resolve the requested tag, branch, commit, or semver range to an exact commit. They clone that resolved ref, recompute the real `sha256` integrity hash, and validate the SKILL.md frontmatter against the [Agent Skills spec](https://agentskills.io/specification) before touching `promptscript.lock`. Use `--strict` to treat warnings as errors (useful in CI) or `--skip-validation` to bypass the check when the upstream is in flux. Plain `http://` sources are rejected to prevent MITM.
 When a skill is added with a `git@` source, its canonical repository entry also stores `gitUrl` so later updates continue using SSH.
 
+For a repository owner entry with `source: md` and a `skills` list, `integrity` is an
+aggregate SRI hash. PromptScript hashes a canonical JSON array containing each
+managed child source key and its concrete child integrity, sorted by source key.
+`prs lock`, `prs skills add`, and `prs skills update` recompute this value whenever
+the owner is emitted or preserved. If a listed child is missing or has a pending
+or otherwise incomplete integrity, the owner remains `sha256-pending`. Ordinary
+registry dependencies and leaf Markdown entries are never aggregated. Existing
+lockfiles remain valid and are refreshed when one of these commands next writes or
+previews the lockfile.
+
 ## Lock file: version pinning
 
 When a `.prs` file contains remote markdown imports, `prs skills add` or `prs lock` generates a `promptscript.lock` file recording the exact resolved commit for each dependency:
@@ -97,7 +107,7 @@ dependencies:
   https://github.com/anthropics/skills:
     version: 1.0.0
     commit: a3f8c2d1b0e94567890abcdef1234567890abcde
-    integrity: sha256-pending
+    integrity: sha256-5fb42506e17f17329465d2ef8c3a91f19ab030538395939b7c09d67d65868eb7
     source: md
     skills:
       - github.com/anthropics/skills/commit@1.0.0

--- a/packages/cli/src/commands/__tests__/lock.spec.ts
+++ b/packages/cli/src/commands/__tests__/lock.spec.ts
@@ -113,7 +113,6 @@ vi.mock('yaml', () => ({
 
 import { lockCommand, resolveRemoteDependency } from '../lock.js';
 import type { LockfileDependency } from '@promptscript/core';
-import { calculateManagedSkillIntegrity } from '../../utils/skill-lock-integrity.js';
 
 describe('lockCommand', () => {
   beforeEach(() => {
@@ -718,9 +717,8 @@ describe('lockCommand', () => {
     };
     expect(lock.dependencies[child]!.integrity).toBe(childIntegrity);
     expect(lock.dependencies[owner]!.integrity).toBe(
-      calculateManagedSkillIntegrity(lock.dependencies, [child])
+      'sha256-73564491308abbaf4a48db5bfb81ae091f18531a137c04e47610e9efc91c1303'
     );
-    expect(lock.dependencies[owner]!.integrity).not.toBe('sha256-pending');
   });
 
   it('should merge metadata for an md-sourced dependency that is still requested', async () => {

--- a/packages/cli/src/commands/__tests__/lock.spec.ts
+++ b/packages/cli/src/commands/__tests__/lock.spec.ts
@@ -112,6 +112,8 @@ vi.mock('yaml', () => ({
 }));
 
 import { lockCommand, resolveRemoteDependency } from '../lock.js';
+import type { LockfileDependency } from '@promptscript/core';
+import { calculateManagedSkillIntegrity } from '../../utils/skill-lock-integrity.js';
 
 describe('lockCommand', () => {
   beforeEach(() => {
@@ -675,6 +677,50 @@ describe('lockCommand', () => {
     expect(parsed.dependencies['github.com/org/skills/SKILL.md']).toBeDefined();
     expect(parsed.dependencies['github.com/org/skills/SKILL.md']!.source).toBe('md');
     expect(parsed.dependencies['https://github.com/org/skills']!.source).toBe('md');
+  });
+
+  it('should aggregate managed child integrity during dry-run', async () => {
+    const child = 'github.com/org/skills/SKILL.md';
+    const owner = 'https://github.com/org/skills';
+    const childIntegrity = `sha256-${'a'.repeat(64)}`;
+    const existingDependencies = {
+      [child]: {
+        version: 'latest',
+        commit: 'b'.repeat(40),
+        integrity: childIntegrity,
+        source: 'md' as const,
+      },
+      [owner]: {
+        version: 'latest',
+        commit: 'b'.repeat(40),
+        integrity: 'sha256-pending',
+        source: 'md' as const,
+        skills: [child],
+      },
+    };
+    mockFindConfigFile.mockReturnValue('promptscript.yaml');
+    mockLoadConfig.mockResolvedValue({
+      targets: [],
+      registries: { '@company': 'github.com/company/base' },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({ version: 1, dependencies: existingDependencies })
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await lockCommand({ dryRun: true });
+    const printed = logSpy.mock.calls[0]?.[0];
+    logSpy.mockRestore();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    const lock = JSON.parse(String(printed)) as {
+      dependencies: Record<string, LockfileDependency>;
+    };
+    expect(lock.dependencies[child]!.integrity).toBe(childIntegrity);
+    expect(lock.dependencies[owner]!.integrity).toBe(
+      calculateManagedSkillIntegrity(lock.dependencies, [child])
+    );
+    expect(lock.dependencies[owner]!.integrity).not.toBe('sha256-pending');
   });
 
   it('should merge metadata for an md-sourced dependency that is still requested', async () => {

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -173,7 +173,6 @@ import {
   skillsUpdateCommand,
   normalizeSkillSource,
 } from '../skills.js';
-import { calculateManagedSkillIntegrity } from '../../utils/skill-lock-integrity.js';
 
 beforeEach(() => {
   mockFindConfigFile.mockReturnValue(null);
@@ -1194,7 +1193,7 @@ describe('skillsRemoveCommand', () => {
     expect(writtenLock.dependencies).not.toHaveProperty('https://github.com/org/repo');
   });
 
-  it('should preserve a repo pin used by another remote import', async () => {
+  it('should reset managed integrity when preserving a repo pin for another import', async () => {
     mockFindConfigFile.mockReturnValue('promptscript.yaml');
     mockLoadConfig.mockResolvedValue({
       targets: [],
@@ -1213,7 +1212,7 @@ describe('skillsRemoveCommand', () => {
         'https://github.com/org/repo': {
           version: 'v1.0.0',
           commit: 'a'.repeat(40),
-          integrity: 'sha256-pending',
+          integrity: `sha256-${'a'.repeat(64)}`,
           gitUrl: 'git@github.com:org/repo.git',
           skills: [source],
         },
@@ -1242,11 +1241,17 @@ describe('skillsRemoveCommand', () => {
 
     const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
     const writtenLock = JSON.parse(lockWriteCall[1] as string) as {
-      dependencies: Record<string, { gitUrl?: string; skills?: string[]; source?: string }>;
+      dependencies: Record<
+        string,
+        { gitUrl?: string; integrity?: string; skills?: string[]; source?: string }
+      >;
     };
     expect(writtenLock.dependencies['https://github.com/org/repo']).toBeDefined();
     expect(writtenLock.dependencies['https://github.com/org/repo']?.skills).toBeUndefined();
     expect(writtenLock.dependencies['https://github.com/org/repo']?.source).toBeUndefined();
+    expect(writtenLock.dependencies['https://github.com/org/repo']?.integrity).toBe(
+      'sha256-pending'
+    );
     expect(writtenLock.dependencies['https://github.com/org/repo']?.gitUrl).toBe(
       'git@github.com:org/repo.git'
     );
@@ -2483,10 +2488,7 @@ describe('skillsAddCommand frontmatter validation', () => {
       'github.com/org/repo/skills/bar@v1.0.0',
     ]);
     expect(lock.dependencies['https://github.com/org/repo']?.integrity).toBe(
-      calculateManagedSkillIntegrity(lock.dependencies, [
-        sibling,
-        'github.com/org/repo/skills/bar@v1.0.0',
-      ])
+      'sha256-6413a8be8bfdcaff0655c050259633d4c5ad2de4dd12fb70122095d8814b527d'
     );
   });
 
@@ -2773,9 +2775,8 @@ describe('skillsUpdateCommand frontmatter re-validation', () => {
       dependencies: Record<string, LockfileDependency>;
     };
     expect(lock.dependencies[owner]!.integrity).toBe(
-      calculateManagedSkillIntegrity(lock.dependencies, [firstChild, secondChild])
+      'sha256-f81292a6746918d3050119e8fc4bfc14cf5ceea0c834a6e735eb09d70e9d56ae'
     );
-    expect(lock.dependencies[owner]!.integrity).not.toBe('sha256-pending');
   });
 
   it('skips an entry when re-validation reports errors', async () => {

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -102,6 +102,8 @@ const {
   };
 });
 
+import type { LockfileDependency } from '@promptscript/core';
+
 vi.mock('../../output/console.js', () => ({
   createSpinner: vi.fn(() => mockSpinner),
   ConsoleOutput: {
@@ -171,6 +173,7 @@ import {
   skillsUpdateCommand,
   normalizeSkillSource,
 } from '../skills.js';
+import { calculateManagedSkillIntegrity } from '../../utils/skill-lock-integrity.js';
 
 beforeEach(() => {
   mockFindConfigFile.mockReturnValue(null);
@@ -2441,6 +2444,8 @@ describe('skillsAddCommand frontmatter validation', () => {
 
   it('updates sibling skill pins when adding to a shared repository', async () => {
     const sibling = 'github.com/org/repo/skills/foo';
+    const childIntegrity = `sha256-${'c'.repeat(64)}`;
+    mockHashContent.mockReturnValue(childIntegrity);
     arrangeValidation({
       skillContent: '---\nname: skill\n---\nbody',
       lockExists: true,
@@ -2470,13 +2475,19 @@ describe('skillsAddCommand frontmatter validation', () => {
 
     const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
     const lock = JSON.parse(lockWriteCall[1] as string) as {
-      dependencies: Record<string, { integrity?: string; skills?: string[] }>;
+      dependencies: Record<string, LockfileDependency>;
     };
-    expect(lock.dependencies[sibling]?.integrity).toBe('sha256-deadbeef');
+    expect(lock.dependencies[sibling]?.integrity).toBe(childIntegrity);
     expect(lock.dependencies['https://github.com/org/repo']?.skills).toEqual([
       sibling,
       'github.com/org/repo/skills/bar@v1.0.0',
     ]);
+    expect(lock.dependencies['https://github.com/org/repo']?.integrity).toBe(
+      calculateManagedSkillIntegrity(lock.dependencies, [
+        sibling,
+        'github.com/org/repo/skills/bar@v1.0.0',
+      ])
+    );
   });
 
   it('clones the default branch before checking out a commit selector', async () => {
@@ -2723,6 +2734,48 @@ describe('skillsUpdateCommand frontmatter re-validation', () => {
     expect(lock.dependencies['github.com/org/repo/skills/foo/SKILL.md']!.integrity).toBe(
       'sha256-newhash'
     );
+  });
+
+  it('refreshes shared-repository aggregate integrity during update', async () => {
+    const firstChild = 'github.com/org/repo/skills/foo/SKILL.md';
+    const secondChild = 'github.com/org/repo/skills/bar/SKILL.md';
+    const owner = 'https://github.com/org/repo';
+    const childIntegrity = `sha256-${'d'.repeat(64)}`;
+    const lockContent = JSON.stringify({
+      version: 1,
+      dependencies: {
+        [firstChild]: { ...lockEntry, integrity: childIntegrity },
+        [secondChild]: { ...lockEntry, integrity: childIntegrity },
+        [owner]: {
+          version: 'v1.0.0',
+          commit: 'old',
+          integrity: 'sha256-pending',
+          source: 'md',
+          skills: [firstChild, secondChild],
+        },
+      },
+    });
+    mockHashContent.mockReturnValue(childIntegrity);
+    mockMkdtemp.mockResolvedValue('/tmp/prs-skill-validate-xyz');
+    mockExistsSync.mockImplementation(
+      (p: string) => p === 'promptscript.lock' || p.includes('prs-skill-validate-xyz')
+    );
+    mockReadFile.mockImplementation((p: string) =>
+      p === 'promptscript.lock'
+        ? Promise.resolve(lockContent)
+        : Promise.resolve('---\nname: skill\n---')
+    );
+
+    await skillsUpdateCommand(undefined, {});
+
+    const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
+    const lock = JSON.parse(lockWriteCall[1] as string) as {
+      dependencies: Record<string, LockfileDependency>;
+    };
+    expect(lock.dependencies[owner]!.integrity).toBe(
+      calculateManagedSkillIntegrity(lock.dependencies, [firstChild, secondChild])
+    );
+    expect(lock.dependencies[owner]!.integrity).not.toBe('sha256-pending');
   });
 
   it('skips an entry when re-validation reports errors', async () => {

--- a/packages/cli/src/commands/lock.ts
+++ b/packages/cli/src/commands/lock.ts
@@ -18,11 +18,14 @@ import {
 } from '@promptscript/resolver';
 import { generateLockfileReferences } from './lock-references.js';
 import { resolveRegistryPath } from '../utils/registry-resolver.js';
+import {
+  PENDING_INTEGRITY,
+  refreshManagedSkillOwnerIntegrity,
+} from '../utils/skill-lock-integrity.js';
 
 /** Path to the lockfile relative to cwd. */
 export const LOCKFILE_PATH = 'promptscript.lock';
 const UNRESOLVED_COMMIT = '0000000000000000000000000000000000000000';
-const UNRESOLVED_INTEGRITY = 'sha256-pending';
 
 interface RequestedDependency {
   versions: Set<string>;
@@ -176,6 +179,7 @@ export async function lockCommand(options: LockOptions): Promise<void> {
         }
       }
     }
+    refreshManagedSkillOwnerIntegrity(dependencies);
 
     const references = await generateLockfileReferences(
       config,
@@ -290,7 +294,7 @@ export async function resolveRemoteDependency(
         version: resolvedVersion,
         commit: validation.headCommit,
         integrity:
-          existing?.commit === validation.headCommit ? existing.integrity : UNRESOLVED_INTEGRITY,
+          existing?.commit === validation.headCommit ? existing.integrity : PENDING_INTEGRITY,
         ...(existing?.source ? { source: existing.source } : {}),
         ...(existing?.skills ? { skills: existing.skills } : {}),
         ...(fallbackUrl ? { gitUrl: fallbackUrl } : {}),

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -11,7 +11,10 @@ import type { Lockfile, LockfileDependency } from '@promptscript/core';
 import { LOCKFILE_VERSION, isValidLockfile } from '@promptscript/core';
 import { LOCKFILE_PATH, resolveRemoteDependency } from './lock.js';
 import { collectRemoteImports, type RemoteImport } from './lock-scanner.js';
-import { refreshManagedSkillOwnerIntegrity } from '../utils/skill-lock-integrity.js';
+import {
+  PENDING_INTEGRITY,
+  refreshManagedSkillOwnerIntegrity,
+} from '../utils/skill-lock-integrity.js';
 import {
   validateSkillFrontmatter,
   formatSkillValidationIssues,
@@ -960,6 +963,7 @@ export async function skillsRemoveCommand(
         } else {
           delete repoDependency.skills;
           delete repoDependency.source;
+          repoDependency.integrity = PENDING_INTEGRITY;
         }
       }
     }

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -11,6 +11,7 @@ import type { Lockfile, LockfileDependency } from '@promptscript/core';
 import { LOCKFILE_VERSION, isValidLockfile } from '@promptscript/core';
 import { LOCKFILE_PATH, resolveRemoteDependency } from './lock.js';
 import { collectRemoteImports, type RemoteImport } from './lock-scanner.js';
+import { refreshManagedSkillOwnerIntegrity } from '../utils/skill-lock-integrity.js';
 import {
   validateSkillFrontmatter,
   formatSkillValidationIssues,
@@ -800,6 +801,7 @@ export async function skillsAddCommand(
       skills: [...repoSkills, source],
       ...(gitUrl ? { gitUrl } : {}),
     };
+    refreshManagedSkillOwnerIntegrity(lockfile.dependencies);
 
     if (options.dryRun) {
       spinner.succeed('Dry run — no files modified');
@@ -961,6 +963,7 @@ export async function skillsRemoveCommand(
         }
       }
     }
+    refreshManagedSkillOwnerIntegrity(lockfile.dependencies);
     if (lockfileChanged) {
       await saveLockfile(lockfile);
     }
@@ -1140,6 +1143,7 @@ export async function skillsUpdateCommand(
         }
       }
     }
+    refreshManagedSkillOwnerIntegrity(lockfile.dependencies);
 
     if (options.dryRun) {
       spinner.succeed('Dry run — lockfile not written');

--- a/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
+++ b/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
@@ -43,6 +43,25 @@ describe('skill lock integrity', () => {
     expect(secondHash).toBe(EXPECTED_AGGREGATE);
   });
 
+  it('keeps the pending marker when no children are managed', () => {
+    const integrity = calculateManagedSkillIntegrity({}, []);
+
+    expect(integrity).toBe(PENDING_INTEGRITY);
+  });
+
+  it('handles duplicate child sources during canonical sorting', () => {
+    const child = 'github.com/org/repo/skills/child';
+    const dependencies = {
+      [child]: dependency(FIRST_INTEGRITY),
+    };
+
+    const integrity = calculateManagedSkillIntegrity(dependencies, [child, child]);
+
+    expect(integrity).toBe(
+      'sha256-2d94afc4a4b8b9c18f9256bf13c23700c25777ce5b54d9a50ff5199ae79dc142'
+    );
+  });
+
   it('keeps the pending marker when a child is missing or incomplete', () => {
     const child = 'github.com/org/repo/skills/child';
 

--- a/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
+++ b/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
@@ -8,6 +8,8 @@ import {
 
 const FIRST_INTEGRITY = `sha256-${'a'.repeat(64)}`;
 const SECOND_INTEGRITY = `sha256-${'b'.repeat(64)}`;
+const EXPECTED_AGGREGATE =
+  'sha256-9761de7a372bdc7e0acbbba10dd4b2f095eb9a00edb353f3bf620e0139a75e74';
 
 function dependency(integrity: string, source: 'md' | undefined = 'md'): LockfileDependency {
   return {
@@ -37,8 +39,8 @@ describe('skill lock integrity', () => {
       firstChild,
     ]);
 
-    expect(firstHash).toBe(secondHash);
-    expect(firstHash).toMatch(/^sha256-[0-9a-f]{64}$/);
+    expect(firstHash).toBe(EXPECTED_AGGREGATE);
+    expect(secondHash).toBe(EXPECTED_AGGREGATE);
   });
 
   it('keeps the pending marker when a child is missing or incomplete', () => {

--- a/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
+++ b/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
@@ -43,6 +43,19 @@ describe('skill lock integrity', () => {
     expect(secondHash).toBe(EXPECTED_AGGREGATE);
   });
 
+  it('produces the same aggregate for uppercase and lowercase integrity', () => {
+    const child = 'github.com/org/repo/skills/child';
+    const lowercaseHash = calculateManagedSkillIntegrity({ [child]: dependency(FIRST_INTEGRITY) }, [
+      child,
+    ]);
+    const uppercaseHash = calculateManagedSkillIntegrity(
+      { [child]: dependency(FIRST_INTEGRITY.toUpperCase()) },
+      [child]
+    );
+
+    expect(uppercaseHash).toBe(lowercaseHash);
+  });
+
   it('keeps the pending marker when no children are managed', () => {
     const integrity = calculateManagedSkillIntegrity({}, []);
 

--- a/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
+++ b/packages/cli/src/utils/__tests__/skill-lock-integrity.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { LockfileDependency } from '@promptscript/core';
+import {
+  calculateManagedSkillIntegrity,
+  PENDING_INTEGRITY,
+  refreshManagedSkillOwnerIntegrity,
+} from '../skill-lock-integrity.js';
+
+const FIRST_INTEGRITY = `sha256-${'a'.repeat(64)}`;
+const SECOND_INTEGRITY = `sha256-${'b'.repeat(64)}`;
+
+function dependency(integrity: string, source: 'md' | undefined = 'md'): LockfileDependency {
+  return {
+    version: 'v1.0.0',
+    commit: 'a'.repeat(40),
+    integrity,
+    ...(source ? { source } : {}),
+  };
+}
+
+describe('skill lock integrity', () => {
+  it('produces the same aggregate for different child insertion orders', () => {
+    const firstChild = 'github.com/org/repo/skills/first';
+    const secondChild = 'github.com/org/repo/skills/second';
+    const firstDependencies = {
+      [firstChild]: dependency(FIRST_INTEGRITY),
+      [secondChild]: dependency(SECOND_INTEGRITY),
+    };
+    const secondDependencies = {
+      [secondChild]: dependency(SECOND_INTEGRITY),
+      [firstChild]: dependency(FIRST_INTEGRITY),
+    };
+
+    const firstHash = calculateManagedSkillIntegrity(firstDependencies, [firstChild, secondChild]);
+    const secondHash = calculateManagedSkillIntegrity(secondDependencies, [
+      secondChild,
+      firstChild,
+    ]);
+
+    expect(firstHash).toBe(secondHash);
+    expect(firstHash).toMatch(/^sha256-[0-9a-f]{64}$/);
+  });
+
+  it('keeps the pending marker when a child is missing or incomplete', () => {
+    const child = 'github.com/org/repo/skills/child';
+
+    expect(calculateManagedSkillIntegrity({}, [child])).toBe(PENDING_INTEGRITY);
+    expect(calculateManagedSkillIntegrity({ [child]: dependency('sha256-pending') }, [child])).toBe(
+      PENDING_INTEGRITY
+    );
+  });
+
+  it('refreshes only managed Markdown owners', () => {
+    const child = 'github.com/org/repo/skills/child';
+    const managedOwner = 'https://github.com/org/repo';
+    const leaf = 'github.com/org/repo/skills/leaf';
+    const registry = 'github.com/other/repo';
+    const dependencies: Record<string, LockfileDependency> = {
+      [child]: dependency(FIRST_INTEGRITY),
+      [managedOwner]: {
+        ...dependency(PENDING_INTEGRITY),
+        skills: [child],
+      },
+      [leaf]: dependency(SECOND_INTEGRITY),
+      [registry]: {
+        ...dependency(PENDING_INTEGRITY),
+        source: undefined,
+      },
+    };
+
+    refreshManagedSkillOwnerIntegrity(dependencies);
+
+    expect(dependencies[managedOwner]!.integrity).toMatch(/^sha256-[0-9a-f]{64}$/);
+    expect(dependencies[leaf]!.integrity).toBe(SECOND_INTEGRITY);
+    expect(dependencies[registry]!.integrity).toBe(PENDING_INTEGRITY);
+  });
+});

--- a/packages/cli/src/utils/skill-lock-integrity.ts
+++ b/packages/cli/src/utils/skill-lock-integrity.ts
@@ -39,7 +39,7 @@ export function calculateManagedSkillIntegrity(
     if (integrity === undefined || !isConcreteIntegrity(integrity)) {
       return PENDING_INTEGRITY;
     }
-    entries.push({ source, integrity });
+    entries.push({ source, integrity: integrity.toLowerCase() });
   }
 
   entries.sort((left, right) => {

--- a/packages/cli/src/utils/skill-lock-integrity.ts
+++ b/packages/cli/src/utils/skill-lock-integrity.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'crypto';
+import type { LockfileDependency } from '@promptscript/core';
+
+/** Integrity marker used when a dependency cannot claim a complete hash. */
+export const PENDING_INTEGRITY = 'sha256-pending';
+
+const CONCRETE_INTEGRITY_PATTERN = /^sha256-[0-9a-f]{64}$/i;
+
+interface SkillIntegrityEntry {
+  source: string;
+  integrity: string;
+}
+
+/**
+ * Return whether an integrity value is a complete SHA-256 SRI hash.
+ */
+export function isConcreteIntegrity(integrity: string): boolean {
+  return CONCRETE_INTEGRITY_PATTERN.test(integrity);
+}
+
+/**
+ * Hash the canonical representation of managed child entries.
+ *
+ * Entries are represented as JSON objects containing only their source key and
+ * integrity, sorted by source key. Missing or incomplete children keep the
+ * owner in its pending state.
+ */
+export function calculateManagedSkillIntegrity(
+  dependencies: Readonly<Record<string, LockfileDependency>>,
+  childSources: readonly string[]
+): string {
+  if (childSources.length === 0) {
+    return PENDING_INTEGRITY;
+  }
+
+  const entries: SkillIntegrityEntry[] = [];
+  for (const source of childSources) {
+    const integrity = dependencies[source]?.integrity;
+    if (integrity === undefined || !isConcreteIntegrity(integrity)) {
+      return PENDING_INTEGRITY;
+    }
+    entries.push({ source, integrity });
+  }
+
+  entries.sort((left, right) => {
+    if (left.source < right.source) return -1;
+    if (left.source > right.source) return 1;
+    return 0;
+  });
+
+  const canonical = JSON.stringify(entries);
+  const digest = createHash('sha256').update(canonical, 'utf8').digest('hex');
+  return `sha256-${digest}`;
+}
+
+/**
+ * Refresh aggregate integrity for managed Markdown repository owners.
+ */
+export function refreshManagedSkillOwnerIntegrity(
+  dependencies: Record<string, LockfileDependency>
+): void {
+  for (const dependency of Object.values(dependencies)) {
+    if (dependency.source !== 'md' || dependency.skills === undefined) {
+      continue;
+    }
+    dependency.integrity = calculateManagedSkillIntegrity(dependencies, dependency.skills);
+  }
+}

--- a/packages/cli/src/utils/skill-lock-integrity.ts
+++ b/packages/cli/src/utils/skill-lock-integrity.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import type { LockfileDependency } from '@promptscript/core';
 
 /** Integrity marker used when a dependency cannot claim a complete hash. */


### PR DESCRIPTION
## Summary
- Add deterministic aggregate SRI for managed Markdown skill-owner entries.
- Canonicalize sorted child source and integrity pairs, including case normalization for equivalent SHA-256 values.
- Use `sha256-pending` while child integrity is incomplete and reset it when the owner is no longer managed.
- Refresh owner integrity across lock, add, update, and remove flows.

## Verification
- Full eight-step repository verification passed.
- All GitHub CI checks are green.

Closes #401