### PR TITLE
fix(cli): bound remote skill operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ testem.log
 # Temporary
 temp/
 
+# prs skills add transaction lock
+/.promptscript-skills-add.lock
+/.promptscript-skills-add.lock.stale-*
+
 # Misc
 /.sass-cache
 /connect.lock

--- a/docs/guides/markdown-imports.md
+++ b/docs/guides/markdown-imports.md
@@ -83,8 +83,9 @@ prs skills update
 # and updates promptscript.lock
 ```
 
-Both `prs skills add` and `prs skills update` resolve the requested tag, branch, commit, or semver range to an exact commit. They clone that resolved ref, recompute the real `sha256` integrity hash, and validate the SKILL.md frontmatter against the [Agent Skills spec](https://agentskills.io/specification) before touching `promptscript.lock`. Use `--strict` to treat warnings as errors (useful in CI) or `--skip-validation` to bypass the check when the upstream is in flux. Plain `http://` sources are rejected to prevent MITM.
+Both `prs skills add` and `prs skills update` resolve the requested tag, branch, commit, or semver range to an exact commit. They clone that resolved ref, recompute the real `sha256` integrity hash, and validate the SKILL.md frontmatter against the [Agent Skills spec](https://agentskills.io/specification) before touching `promptscript.lock`. Remote Git operations, including `ls-remote` and commit probes, have a 60-second hard timeout with actionable failure output. Use `--strict` to treat warnings as errors (useful in CI) or `--skip-validation` to skip only frontmatter checks. Remote access, cloning, commit pinning, file checks, and integrity hashing still run. Plain `http://` sources are rejected to prevent MITM.
 When a skill is added with a `git@` source, its canonical repository entry also stores `gitUrl` so later updates continue using SSH.
+`prs skills add` writes the `.prs` file and lockfile as one user-visible transaction. If the second write fails, both files are restored to their original contents. Rollback failures are reported explicitly.
 
 ## Lock file: version pinning
 

--- a/docs/guides/markdown-imports.md
+++ b/docs/guides/markdown-imports.md
@@ -83,9 +83,9 @@ prs skills update
 # and updates promptscript.lock
 ```
 
-Both `prs skills add` and `prs skills update` resolve the requested tag, branch, commit, or semver range to an exact commit. They clone that resolved ref, recompute the real `sha256` integrity hash, and validate the SKILL.md frontmatter against the [Agent Skills spec](https://agentskills.io/specification) before touching `promptscript.lock`. Remote Git operations, including `ls-remote` and commit probes, have a 60-second hard timeout with actionable failure output. Use `--strict` to treat warnings as errors (useful in CI) or `--skip-validation` to skip only frontmatter checks. Remote access, cloning, commit pinning, file checks, and integrity hashing still run. Plain `http://` sources are rejected to prevent MITM.
+Both `prs skills add` and `prs skills update` resolve the requested tag, branch, commit, or semver range to an exact commit. They clone that resolved ref, recompute the real `sha256` integrity hash, and validate the SKILL.md frontmatter against the [Agent Skills spec](https://agentskills.io/specification) before touching `promptscript.lock`. Every Git operation, including semver lookup, `ls-remote`, commit probes, cloning, and checkout, has a 60-second hard timeout with actionable failure output. Use `--strict` to treat warnings as errors (useful in CI) or `--skip-validation` to skip only frontmatter checks. Remote access, cloning, commit pinning, file checks, and integrity hashing still run. Plain `http://` sources are rejected to prevent MITM.
 When a skill is added with a `git@` source, its canonical repository entry also stores `gitUrl` so later updates continue using SSH.
-`prs skills add` writes the `.prs` file and lockfile as one user-visible transaction. If the second write fails, both files are restored to their original contents. Rollback failures are reported explicitly.
+`prs skills add` writes the `.prs` file and lockfile as one user-visible transaction. If the second write fails, both files are restored when the lockfile still contains the command's update. A lockfile changed concurrently is left untouched, and the rollback conflict is reported explicitly.
 
 ## Lock file: version pinning
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -945,7 +945,7 @@ prs skills add <source> [options]
 
 **Validation:**
 
-Before writing to the lockfile, `prs skills add` clones the target ref into a temporary directory, recomputes a real `sha256` integrity hash, and runs the [Agent Skills spec](https://agentskills.io/specification) validator against the SKILL.md frontmatter. Checks include:
+Before writing project files, `prs skills add` clones the target ref into a temporary directory, recomputes a real `sha256` integrity hash, and runs the [Agent Skills spec](https://agentskills.io/specification) validator against the SKILL.md frontmatter. Remote Git operations, including `ls-remote` and commit probes, have a 60-second hard timeout. A timeout fails with the repository URL and network troubleshooting guidance.
 
 - `name` present, ≤64 chars, matches `^[a-z0-9]+(-[a-z0-9]+)*$`, and equals the parent directory basename
 - `name` does not collide with another already-installed skill
@@ -958,6 +958,8 @@ Before writing to the lockfile, `prs skills add` clones the target ref into a te
 
 Plain `http://` sources are rejected to prevent MITM. Use `https://`, `git@`, or `github.com/...` form. The fetched commit's integrity hash is written to `promptscript.lock`.
 For SSH input, the lockfile retains the SSH clone URL so later skill updates do not require HTTPS access.
+`--skip-validation` skips only SKILL.md frontmatter checks. Remote access, cloning, commit pinning, file existence checks, and integrity hashing still run.
+The `.prs` file and lockfile are written transactionally from the command user's perspective. If the lockfile write fails after the `.prs` file changes, the original contents are restored. If restoration also fails, the error reports the rollback failure.
 
 **Examples:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -960,6 +960,7 @@ Plain `http://` sources are rejected to prevent MITM. Use `https://`, `git@`, or
 For SSH input, the lockfile retains the SSH clone URL so later skill updates do not require HTTPS access.
 `--skip-validation` skips only SKILL.md frontmatter checks. Remote access, cloning, commit pinning, file existence checks, and integrity hashing still run.
 The `.prs` file and lockfile are written transactionally from the command user's perspective. If the lockfile write fails after the `.prs` file changes, the original contents are restored when the lockfile still contains the command's update. Concurrent lockfile changes are left untouched and reported as rollback conflicts. If restoration also fails, the error reports the rollback failure.
+Concurrent runs are serialized through a `.promptscript-skills-add.lock` file in the project root. A second run fails fast instead of interleaving writes. A lock is reclaimed when its owning process is gone or when it is older than 30 minutes, so a recycled process ID cannot block the command permanently. Add `.promptscript-skills-add.lock` to `.gitignore`.
 
 **Examples:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -945,7 +945,7 @@ prs skills add <source> [options]
 
 **Validation:**
 
-Before writing project files, `prs skills add` clones the target ref into a temporary directory, recomputes a real `sha256` integrity hash, and runs the [Agent Skills spec](https://agentskills.io/specification) validator against the SKILL.md frontmatter. Remote Git operations, including `ls-remote` and commit probes, have a 60-second hard timeout. A timeout fails with the repository URL and network troubleshooting guidance.
+Before writing project files, `prs skills add` clones the target ref into a temporary directory, recomputes a real `sha256` integrity hash, and runs the [Agent Skills spec](https://agentskills.io/specification) validator against the SKILL.md frontmatter. Every Git operation, including semver lookup, `ls-remote`, commit probes, cloning, and checkout, has a 60-second hard timeout. A timeout fails with the repository URL and network troubleshooting guidance.
 
 - `name` present, ≤64 chars, matches `^[a-z0-9]+(-[a-z0-9]+)*$`, and equals the parent directory basename
 - `name` does not collide with another already-installed skill
@@ -959,7 +959,7 @@ Before writing project files, `prs skills add` clones the target ref into a temp
 Plain `http://` sources are rejected to prevent MITM. Use `https://`, `git@`, or `github.com/...` form. The fetched commit's integrity hash is written to `promptscript.lock`.
 For SSH input, the lockfile retains the SSH clone URL so later skill updates do not require HTTPS access.
 `--skip-validation` skips only SKILL.md frontmatter checks. Remote access, cloning, commit pinning, file existence checks, and integrity hashing still run.
-The `.prs` file and lockfile are written transactionally from the command user's perspective. If the lockfile write fails after the `.prs` file changes, the original contents are restored. If restoration also fails, the error reports the rollback failure.
+The `.prs` file and lockfile are written transactionally from the command user's perspective. If the lockfile write fails after the `.prs` file changes, the original contents are restored when the lockfile still contains the command's update. Concurrent lockfile changes are left untouched and reported as rollback conflicts. If restoration also fails, the error reports the rollback failure.
 
 **Examples:**
 

--- a/packages/cli/src/commands/__tests__/lock.spec.ts
+++ b/packages/cli/src/commands/__tests__/lock.spec.ts
@@ -344,6 +344,32 @@ describe('lockCommand', () => {
     expect(mockValidateRemoteAccess).not.toHaveBeenCalled();
   });
 
+  it('should apply the configured timeout to version lookup and validation', async () => {
+    const timeout = 25;
+
+    const result = await resolveRemoteDependency(
+      'github.com/company/base',
+      ['v1.2.0'],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      { timeout }
+    );
+
+    expect(result.version).toBe('v1.2.0');
+    expect(mockCreateRegistryOptions).toHaveBeenCalledWith({
+      url: 'https://github.com/company/base.git',
+      auth: undefined,
+      timeout,
+    });
+    expect(mockValidateRemoteAccess).toHaveBeenCalledWith(
+      'https://github.com/company/base.git',
+      'v1.2.0',
+      { timeout }
+    );
+  });
+
   it('should refresh existing pins with --update', async () => {
     mockFindConfigFile.mockReturnValue('promptscript.yaml');
     mockLoadConfig.mockResolvedValue({

--- a/packages/cli/src/commands/__tests__/lock.spec.ts
+++ b/packages/cli/src/commands/__tests__/lock.spec.ts
@@ -344,6 +344,27 @@ describe('lockCommand', () => {
     expect(mockValidateRemoteAccess).not.toHaveBeenCalled();
   });
 
+  it('should preserve timeout errors instead of treating them as authentication failures', async () => {
+    mockValidateRemoteAccess.mockResolvedValueOnce({
+      accessible: false,
+      error: 'Timed out after 25ms while contacting https://github.com/company/base.git',
+    });
+
+    await expect(
+      resolveRemoteDependency(
+        'github.com/company/base',
+        ['latest'],
+        undefined,
+        false,
+        'git@github.com:company/base.git',
+        undefined,
+        { timeout: 25 }
+      )
+    ).rejects.toThrow('Timed out after 25ms');
+
+    expect(mockValidateRemoteAccess).toHaveBeenCalledTimes(1);
+  });
+
   it('should apply the configured timeout to version lookup and validation', async () => {
     const timeout = 25;
 

--- a/packages/cli/src/commands/__tests__/lock.spec.ts
+++ b/packages/cli/src/commands/__tests__/lock.spec.ts
@@ -441,6 +441,52 @@ describe('lockCommand', () => {
     expect(mockValidateRemoteAccess).toHaveBeenCalledTimes(1);
   });
 
+  it('should continue fallback when a repository URL contains timeout', async () => {
+    mockValidateRemoteAccess
+      .mockResolvedValueOnce({
+        accessible: false,
+        error: 'Authentication failed for https://example.com/timeout-repo',
+      })
+      .mockResolvedValueOnce({
+        accessible: true,
+        headCommit: '1234567890abcdef1234567890abcdef12345678',
+      });
+
+    const result = await resolveRemoteDependency(
+      'https://example.com/timeout-repo',
+      ['latest'],
+      undefined,
+      false,
+      'https://github.com/company/base',
+      undefined,
+      { timeout: 25 }
+    );
+
+    expect(result.commit).toBe('1234567890abcdef1234567890abcdef12345678');
+    expect(mockValidateRemoteAccess).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not classify a missing remote ref named timeout as a timeout', async () => {
+    mockValidateRemoteAccess.mockResolvedValueOnce({
+      accessible: false,
+      error: "Could not find remote ref 'timeout'",
+    });
+
+    await expect(
+      resolveRemoteDependency(
+        'github.com/company/timeout-repo',
+        ['latest'],
+        undefined,
+        false,
+        undefined,
+        undefined,
+        { timeout: 25 }
+      )
+    ).rejects.toThrow("Could not find remote ref 'timeout'");
+
+    expect(mockValidateRemoteAccess).toHaveBeenCalledTimes(1);
+  });
+
   it('should ignore non-timeout Git error codes during fallback handling', async () => {
     const failure = Object.assign(new Error('remote probe failed'), { code: 'EOTHER' });
     mockValidateRemoteAccess.mockRejectedValueOnce(failure);

--- a/packages/cli/src/commands/__tests__/lock.spec.ts
+++ b/packages/cli/src/commands/__tests__/lock.spec.ts
@@ -391,6 +391,84 @@ describe('lockCommand', () => {
     );
   });
 
+  it('should apply the configured timeout to authenticated resolution', async () => {
+    const timeout = 25;
+    const auth = { type: 'token' as const, token: 'secret' };
+
+    const result = await resolveRemoteDependency(
+      'github.com/company/base',
+      ['v1.2.0'],
+      undefined,
+      false,
+      undefined,
+      auth,
+      { timeout }
+    );
+
+    expect(result.commit).toBe('1234567890abcdef1234567890abcdef12345678');
+    expect(mockCreateRegistryOptions).toHaveBeenNthCalledWith(1, {
+      url: 'https://github.com/company/base.git',
+      auth,
+      timeout,
+    });
+    expect(mockCreateRegistryOptions).toHaveBeenNthCalledWith(2, {
+      url: 'https://github.com/company/base.git',
+      auth,
+      timeout,
+    });
+    expect(mockGetCommitHash).toHaveBeenCalledWith('v1.2.0');
+    expect(mockValidateRemoteAccess).not.toHaveBeenCalled();
+  });
+
+  it('should stop fallback resolution for timeout errors wrapped in a cause', async () => {
+    const cause = Object.assign(new Error('remote authentication failed'), {
+      code: 'ETIMEDOUT',
+    });
+    mockValidateRemoteAccess.mockRejectedValueOnce(new Error('remote probe failed', { cause }));
+
+    await expect(
+      resolveRemoteDependency(
+        'github.com/company/base',
+        ['latest'],
+        undefined,
+        false,
+        'git@github.com:company/base.git',
+        undefined,
+        { timeout: 25 }
+      )
+    ).rejects.toThrow('remote probe failed');
+
+    expect(mockValidateRemoteAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore non-timeout Git error codes during fallback handling', async () => {
+    const failure = Object.assign(new Error('remote probe failed'), { code: 'EOTHER' });
+    mockValidateRemoteAccess.mockRejectedValueOnce(failure);
+
+    await expect(
+      resolveRemoteDependency('github.com/company/base', ['latest'], undefined, false)
+    ).rejects.toBe(failure);
+  });
+
+  it('should surface timeout failures from lock command', async () => {
+    mockFindConfigFile.mockReturnValue('promptscript.yaml');
+    mockLoadConfig.mockResolvedValue({
+      targets: [],
+      registries: { '@company': 'github.com/company/base' },
+    });
+    mockExistsSync.mockReturnValue(false);
+    mockValidateRemoteAccess.mockResolvedValueOnce({
+      accessible: false,
+      error: 'Timed out after 25ms while contacting https://github.com/company/base.git',
+    });
+
+    await lockCommand({});
+
+    expect(mockFail).toHaveBeenCalledWith('Failed to generate lockfile');
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
   it('should refresh existing pins with --update', async () => {
     mockFindConfigFile.mockReturnValue('promptscript.yaml');
     mockLoadConfig.mockResolvedValue({

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -830,6 +830,56 @@ describe('skillsAddCommand', () => {
     expect(mockSucceed).toHaveBeenCalledWith('Skill added');
   });
 
+  it('should recover from a lock past the stale window with a recycled pid', async () => {
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    mockOpen.mockRejectedValueOnce(lockError).mockResolvedValueOnce(mockLockFile);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve(
+          JSON.stringify({
+            acquiredAt: Date.now() - 60 * 60 * 1000,
+            pid: process.pid,
+            token: 'recycled',
+          })
+        );
+      }
+      return Promise.resolve(SAMPLE_PRS);
+    });
+
+    await skillsAddCommand('github.com/company/skills/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockOpen).toHaveBeenCalledTimes(2);
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+  });
+
+  it('should keep a fresh lock owned by a live pid', async () => {
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    mockOpen.mockRejectedValueOnce(lockError);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve(
+          JSON.stringify({
+            acquiredAt: Date.now() - 60 * 1000,
+            pid: process.pid,
+            token: 'fresh',
+          })
+        );
+      }
+      return Promise.resolve(SAMPLE_PRS);
+    });
+
+    await skillsAddCommand('github.com/company/skills/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Another "prs skills add" is already running')
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
   it('does not remove a replacement lock when stale quarantine loses a race', async () => {
     arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
     const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -14,6 +14,10 @@ const {
   mockMkdtemp,
   mockRm,
   mockRename,
+  mockChmod,
+  mockOpen,
+  mockStat,
+  mockLockFile,
   mockValidateRemoteAccess,
   mockValidateSkillFrontmatter,
   mockFormatSkillValidationIssues,
@@ -48,6 +52,15 @@ const {
   const mockMkdtemp = vi.fn().mockResolvedValue('/tmp/prs-skill-default');
   const mockRm = vi.fn().mockResolvedValue(undefined);
   const mockRename = vi.fn().mockResolvedValue(undefined);
+  const mockChmod = vi.fn().mockResolvedValue(undefined);
+  const mockLockFile = {
+    close: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockOpen = vi.fn().mockResolvedValue(mockLockFile);
+  const mockStat = vi
+    .fn()
+    .mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
   const mockValidateRemoteAccess = vi.fn().mockResolvedValue({
     accessible: true,
     headCommit: 'abc1234567890123456789012345678901234567890'.slice(0, 40),
@@ -105,6 +118,10 @@ const {
     mockMkdtemp,
     mockRm,
     mockRename,
+    mockChmod,
+    mockOpen,
+    mockStat,
+    mockLockFile,
   };
 });
 
@@ -145,6 +162,9 @@ vi.mock('fs/promises', () => ({
   mkdtemp: mockMkdtemp,
   rm: mockRm,
   rename: mockRename,
+  chmod: mockChmod,
+  open: mockOpen,
+  stat: mockStat,
 }));
 
 vi.mock('yaml', () => ({
@@ -183,6 +203,16 @@ import {
 beforeEach(() => {
   mockFindConfigFile.mockReturnValue(null);
   mockCollectRemoteImports.mockResolvedValue([]);
+  mockOpen.mockReset();
+  mockOpen.mockResolvedValue(mockLockFile);
+  mockLockFile.close.mockReset();
+  mockLockFile.close.mockResolvedValue(undefined);
+  mockLockFile.writeFile.mockReset();
+  mockLockFile.writeFile.mockResolvedValue(undefined);
+  mockStat.mockReset();
+  mockStat.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+  mockChmod.mockReset();
+  mockChmod.mockResolvedValue(undefined);
 });
 
 describe('normalizeSkillSource', () => {
@@ -549,6 +579,8 @@ describe('skillsAddCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.exitCode = undefined;
+    mockWriteFile.mockReset();
+    mockWriteFile.mockResolvedValue(undefined);
   });
 
   it('should reject local paths starting with ./', async () => {
@@ -706,6 +738,168 @@ describe('skillsAddCommand', () => {
       dependencies: Record<string, { source?: string }>;
     };
     expect(lockContent.dependencies['github.com/company/skills/SKILL.md']?.source).toBe('md');
+  });
+
+  it('should acquire and release a project-scoped transaction lock', async () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.includes('entry.prs')) return true;
+      return false;
+    });
+    let lockMetadata = '';
+    mockLockFile.writeFile.mockImplementation(async (data: string) => {
+      lockMetadata = data;
+    });
+    mockReadFile.mockImplementation((filePath: string) =>
+      Promise.resolve(
+        filePath.includes('.promptscript-skills-add.lock') ? lockMetadata : SAMPLE_PRS
+      )
+    );
+
+    await skillsAddCommand('github.com/company/skills/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      expect.stringContaining('.promptscript-skills-add.lock'),
+      'wx',
+      0o600
+    );
+    expect(mockLockFile.writeFile).toHaveBeenCalledWith(expect.any(String), 'utf-8');
+    expect(mockLockFile.close).toHaveBeenCalled();
+    expect(mockRm).toHaveBeenCalledWith(expect.stringContaining('.promptscript-skills-add.lock'), {
+      force: true,
+    });
+  });
+
+  it('should fail when another skills add transaction owns the lock', async () => {
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    mockOpen.mockRejectedValueOnce(lockError);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve(
+          JSON.stringify({ acquiredAt: Date.now(), pid: process.pid, token: 'other' })
+        );
+      }
+      return Promise.resolve(SAMPLE_PRS);
+    });
+
+    await skillsAddCommand('github.com/company/skills/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Another "prs skills add" is already running')
+    );
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should recover from a stale transaction lock', async () => {
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    mockOpen.mockRejectedValueOnce(lockError).mockResolvedValueOnce(mockLockFile);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve(
+          JSON.stringify({
+            acquiredAt: Date.now() - 60 * 60 * 1000,
+            pid: 99999999,
+            token: 'stale',
+          })
+        );
+      }
+      return Promise.resolve(SAMPLE_PRS);
+    });
+
+    await skillsAddCommand('github.com/company/skills/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockOpen).toHaveBeenCalledTimes(2);
+    expect(mockRm).toHaveBeenCalledWith(expect.stringContaining('.promptscript-skills-add.lock'), {
+      force: true,
+    });
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+  });
+
+  it('should preserve existing file modes during atomic writes', async () => {
+    const originalLockfile = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'https://github.com/org/repo': {
+          version: 'latest',
+          commit: 'old',
+          integrity: 'sha256-pending',
+        },
+      },
+    });
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      lockExists: true,
+      lockContent: originalLockfile,
+    });
+    mockStat.mockResolvedValue({ mode: 0o100600 });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockChmod).toHaveBeenCalledTimes(2);
+    expect(mockChmod).toHaveBeenNthCalledWith(1, expect.stringContaining('entry.prs'), 0o600);
+    expect(mockChmod).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('promptscript.lock'),
+      0o600
+    );
+  });
+
+  it('should preserve existing mode when rolling back an atomic write', async () => {
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
+    const originalLockfile = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'https://github.com/org/repo': {
+          version: 'latest',
+          commit: 'old',
+          integrity: 'sha256-pending',
+        },
+      },
+    });
+    let currentEntry = originalEntry;
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      lockExists: true,
+      lockContent: originalLockfile,
+      prsContent: originalEntry,
+    });
+    mockStat.mockResolvedValue({ mode: 0o100600 });
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath === 'promptscript.lock') return Promise.resolve(originalLockfile);
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath.endsWith('promptscript.lock')) {
+        throw new Error('lockfile temp write failed');
+      }
+      if (filePath.endsWith('entry.prs')) {
+        currentEntry = fileContent;
+      }
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(currentEntry).toBe(originalEntry);
+    expect(
+      mockChmod.mock.calls.filter(
+        (call) => String(call[0]).includes('entry.prs') && call[1] === 0o600
+      )
+    ).toHaveLength(2);
   });
 
   it('should warn if skill is already imported', async () => {

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -2533,6 +2533,44 @@ describe('skillsAddCommand frontmatter validation', () => {
     expect(process.exitCode).not.toBe(1);
   });
 
+  it('completes after warning on an existing skill in the same repository', async () => {
+    const sibling = 'github.com/org/repo/skills/existing/SKILL.md';
+    arrangeValidation({
+      skillContent: '---\nname: x\n---',
+      lockExists: true,
+      lockContent: JSON.stringify({
+        version: 1,
+        dependencies: {
+          [sibling]: {
+            version: 'latest',
+            commit: 'old',
+            integrity: 'sha256-old',
+            source: 'md',
+          },
+          'https://github.com/org/repo': {
+            version: 'latest',
+            commit: 'old',
+            integrity: 'sha256-pending',
+            source: 'md',
+            skills: [sibling],
+          },
+        },
+      }),
+    });
+    mockValidateSkillFrontmatter
+      .mockReturnValueOnce({
+        valid: true,
+        issues: [{ severity: 'warning', code: 'SK050', message: 'description short' }],
+      })
+      .mockReturnValueOnce({ valid: true, issues: [] });
+
+    await skillsAddCommand('github.com/org/repo/skills/new/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockWarn).toHaveBeenCalledWith(`${sibling}: SKILL.md has validation warnings`);
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+    expect(process.exitCode).not.toBe(1);
+  });
+
   it('treats warnings as errors when --strict is set', async () => {
     arrangeValidation({ skillContent: '---\nname: x\n---' });
     mockValidateSkillFrontmatter.mockReturnValue({
@@ -2547,6 +2585,46 @@ describe('skillsAddCommand frontmatter validation', () => {
     });
 
     expect(mockFail).toHaveBeenCalledWith('SKILL.md failed validation');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('rolls back both files when the lockfile write fails', async () => {
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
+    const originalLockfile = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'https://github.com/org/repo': {
+          version: 'latest',
+          commit: 'old',
+          integrity: 'sha256-pending',
+        },
+      },
+    });
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      lockExists: true,
+      lockContent: originalLockfile,
+      prsContent: originalEntry,
+    });
+    mockWriteFile
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('lock write failed'))
+      .mockResolvedValue(undefined);
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    const entryWrites = mockWriteFile.mock.calls.filter((call) =>
+      String(call[0]).includes('entry.prs')
+    );
+    const lockWrites = mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock');
+    expect(entryWrites).toHaveLength(2);
+    expect(entryWrites[0]?.[1]).not.toBe(originalEntry);
+    expect(entryWrites[1]?.[1]).toBe(originalEntry);
+    expect(lockWrites).toHaveLength(2);
+    expect(lockWrites[1]?.[1]).toBe(originalLockfile);
+    expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -16,6 +16,7 @@ const {
   mockRename,
   mockChmod,
   mockOpen,
+  mockLstat,
   mockStat,
   mockLockFile,
   mockValidateRemoteAccess,
@@ -58,6 +59,9 @@ const {
     writeFile: vi.fn().mockResolvedValue(undefined),
   };
   const mockOpen = vi.fn().mockResolvedValue(mockLockFile);
+  const mockLstat = vi
+    .fn()
+    .mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
   const mockStat = vi
     .fn()
     .mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
@@ -120,6 +124,7 @@ const {
     mockRename,
     mockChmod,
     mockOpen,
+    mockLstat,
     mockStat,
     mockLockFile,
   };
@@ -164,6 +169,7 @@ vi.mock('fs/promises', () => ({
   rename: mockRename,
   chmod: mockChmod,
   open: mockOpen,
+  lstat: mockLstat,
   stat: mockStat,
 }));
 
@@ -209,6 +215,8 @@ beforeEach(() => {
   mockLockFile.close.mockResolvedValue(undefined);
   mockLockFile.writeFile.mockReset();
   mockLockFile.writeFile.mockResolvedValue(undefined);
+  mockLstat.mockReset();
+  mockLstat.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
   mockStat.mockReset();
   mockStat.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
   mockChmod.mockReset();
@@ -822,6 +830,41 @@ describe('skillsAddCommand', () => {
     expect(mockSucceed).toHaveBeenCalledWith('Skill added');
   });
 
+  it('does not remove a replacement lock when stale quarantine loses a race', async () => {
+    arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    const lockDisappeared = Object.assign(new Error('lock disappeared'), { code: 'ENOENT' });
+    mockOpen.mockRejectedValueOnce(lockError).mockResolvedValueOnce(mockLockFile);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve(
+          JSON.stringify({ acquiredAt: Date.now() - 60 * 60 * 1000, pid: 99999999, token: 'stale' })
+        );
+      }
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: foo\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) {
+        return Promise.resolve(SAMPLE_PRS_FOR_VALIDATION);
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+    mockRename.mockRejectedValueOnce(lockDisappeared);
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockOpen).toHaveBeenCalledTimes(2);
+    expect(mockRename).toHaveBeenCalledWith(
+      expect.stringContaining('.promptscript-skills-add.lock'),
+      expect.stringContaining('.promptscript-skills-add.lock.stale-')
+    );
+    expect(mockRm).not.toHaveBeenCalledWith(
+      expect.stringContaining('.promptscript-skills-add.lock'),
+      { force: true }
+    );
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+  });
+
   it('should preserve existing file modes during atomic writes', async () => {
     const originalLockfile = JSON.stringify({
       version: 1,
@@ -838,7 +881,7 @@ describe('skillsAddCommand', () => {
       lockExists: true,
       lockContent: originalLockfile,
     });
-    mockStat.mockResolvedValue({ mode: 0o100600 });
+    mockLstat.mockResolvedValue({ mode: 0o100600, isSymbolicLink: () => false });
 
     await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
       file: 'entry.prs',
@@ -872,7 +915,7 @@ describe('skillsAddCommand', () => {
       lockContent: originalLockfile,
       prsContent: originalEntry,
     });
-    mockStat.mockResolvedValue({ mode: 0o100600 });
+    mockLstat.mockResolvedValue({ mode: 0o100600, isSymbolicLink: () => false });
     mockReadFile.mockImplementation((filePath: string) => {
       if (filePath === 'promptscript.lock') return Promise.resolve(originalLockfile);
       if (filePath.includes('prs-skill-validate-xyz')) {
@@ -2744,14 +2787,47 @@ describe('skillsAddCommand frontmatter validation', () => {
     );
   });
 
-  it('reports a non-ENOENT stat failure before an atomic write', async () => {
+  it('reports a non-ENOENT lstat failure before an atomic write', async () => {
     arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
-    mockStat.mockRejectedValueOnce(new Error('stat failed'));
+    mockLstat.mockRejectedValueOnce(new Error('lstat failed'));
 
     await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
 
-    expect(mockConsoleError).toHaveBeenCalledWith('stat failed');
+    expect(mockConsoleError).toHaveBeenCalledWith('lstat failed');
     expect(mockRename).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('preserves an entry symlink when atomic write rejects it', async () => {
+    arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
+    mockLstat.mockResolvedValue({
+      mode: 0o120777,
+      isSymbolicLink: () => true,
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('symlink'));
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('preserves a lockfile symlink when atomic write rejects it', async () => {
+    arrangeValidation({
+      skillContent: '---\nname: foo\n---\nbody',
+      lockExists: true,
+    });
+    mockLstat.mockImplementation(async (filePath: string) => ({
+      mode: 0o100600,
+      isSymbolicLink: () => filePath.endsWith('promptscript.lock'),
+    }));
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('symlink'));
+    expect(mockRename).toHaveBeenCalledTimes(1);
+    expect(mockRename.mock.calls[0]?.[1]).toEqual(expect.stringContaining('entry.prs'));
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -25,6 +25,7 @@ const {
   mockConsoleWarn,
   mockConsoleError,
   mockParse,
+  mockDefaultGitTimeoutMs,
 } = vi.hoisted(() => {
   const mockStart = vi.fn().mockReturnThis();
   const mockSucceed = vi.fn().mockReturnThis();
@@ -74,6 +75,7 @@ const {
   const mockConsoleWarn = vi.fn();
   const mockConsoleError = vi.fn();
   const mockParse = vi.fn();
+  const mockDefaultGitTimeoutMs = 60_000;
   return {
     mockSucceed,
     mockFail,
@@ -97,6 +99,7 @@ const {
     mockConsoleWarn,
     mockConsoleError,
     mockParse,
+    mockDefaultGitTimeoutMs,
     mockMkdtemp,
     mockRm,
   };
@@ -151,6 +154,7 @@ vi.mock('@promptscript/resolver', () => ({
   formatSkillValidationIssues: mockFormatSkillValidationIssues,
   hashContent: mockHashContent,
   createGitRegistry: mockCreateGitRegistry,
+  DEFAULT_GIT_TIMEOUT_MS: mockDefaultGitTimeoutMs,
   normalizeGitUrl: (url: string) => {
     const sshMatch = url.match(/^git@([^:]+):(.+)$/);
     const normalized = sshMatch ? `https://${sshMatch[1]}/${sshMatch[2]}` : url;
@@ -623,10 +627,13 @@ describe('skillsAddCommand', () => {
       ['latest'],
       undefined,
       false,
-      'git@github.com:org/repo.git'
+      'git@github.com:org/repo.git',
+      undefined,
+      { timeout: 60_000 }
     );
     expect(mockCreateGitRegistry).toHaveBeenCalledWith({
       url: 'git@github.com:org/repo.git',
+      timeout: 60_000,
     });
   });
 
@@ -905,7 +912,10 @@ describe('skillsAddCommand', () => {
       'https://github.com/org/repo',
       ['v1.2.3'],
       undefined,
-      false
+      false,
+      undefined,
+      undefined,
+      { timeout: 60_000 }
     );
   });
 
@@ -928,7 +938,10 @@ describe('skillsAddCommand', () => {
       'https://github.com/org/repo',
       ['v2.0.0', 'v2.0.0'],
       undefined,
-      false
+      false,
+      undefined,
+      undefined,
+      { timeout: 60_000 }
     );
   });
 
@@ -962,7 +975,10 @@ describe('skillsAddCommand', () => {
       'https://github.com/org/repo',
       ['v1.0.0'],
       aliasedOwner,
-      false
+      false,
+      undefined,
+      undefined,
+      { timeout: 60_000 }
     );
     const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
     const writtenLock = JSON.parse(lockWriteCall[1] as string) as {
@@ -1000,7 +1016,10 @@ describe('skillsAddCommand', () => {
       'https://github.com/org/repo',
       ['v1.0.0'],
       regularPin,
-      false
+      false,
+      undefined,
+      undefined,
+      { timeout: 60_000 }
     );
     const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
     const writtenLock = JSON.parse(lockWriteCall[1] as string) as {
@@ -2129,7 +2148,10 @@ describe('skillsUpdateCommand', () => {
       'https://github.com/org/repo',
       ['v1.0.0', 'v1.0.0'],
       undefined,
-      true
+      true,
+      undefined,
+      undefined,
+      { timeout: 60_000 }
     );
   });
 
@@ -2330,7 +2352,10 @@ describe('skillsAddCommand frontmatter validation', () => {
 
     await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
 
-    expect(mockCreateGitRegistry).toHaveBeenCalledWith({ url: 'https://github.com/org/repo' });
+    expect(mockCreateGitRegistry).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo',
+      timeout: 60_000,
+    });
     expect(mockCloneAtTag).toHaveBeenCalled();
     expect(mockSucceed).toHaveBeenCalledWith('Skill added');
     const writeCalls = mockWriteFile.mock.calls as unknown[][];
@@ -2345,6 +2370,33 @@ describe('skillsAddCommand frontmatter validation', () => {
     expect(mockRm).toHaveBeenCalledWith(
       '/tmp/prs-skill-validate-xyz',
       expect.objectContaining({ recursive: true, force: true })
+    );
+  });
+
+  it('preserves a concurrently-created lockfile during rollback', async () => {
+    arrangeValidation({ skillContent: '---\nname: x\n---\nbody' });
+    const concurrentLockfile = '{"version":1,"dependencies":{"other":"process"}}';
+    mockReadFile
+      .mockResolvedValueOnce(SAMPLE_PRS_FOR_VALIDATION)
+      .mockResolvedValueOnce('---\nname: x\n---\nbody')
+      .mockResolvedValueOnce(concurrentLockfile);
+    mockWriteFile
+      .mockImplementationOnce(async () => undefined)
+      .mockImplementationOnce(async () => {
+        throw new Error('lockfile write failed');
+      });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockRm).not.toHaveBeenCalledWith(
+      'promptscript.lock',
+      expect.objectContaining({ force: true })
+    );
+    expect(
+      (mockWriteFile.mock.calls as unknown[][]).filter((call) => call[0] === 'promptscript.lock')
+    ).toHaveLength(1);
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('changed during skills add')
     );
   });
 
@@ -2622,8 +2674,7 @@ describe('skillsAddCommand frontmatter validation', () => {
     expect(entryWrites).toHaveLength(2);
     expect(entryWrites[0]?.[1]).not.toBe(originalEntry);
     expect(entryWrites[1]?.[1]).toBe(originalEntry);
-    expect(lockWrites).toHaveLength(2);
-    expect(lockWrites[1]?.[1]).toBe(originalLockfile);
+    expect(lockWrites).toHaveLength(1);
     expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
     expect(process.exitCode).toBe(1);
   });

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -2319,6 +2319,8 @@ describe('skillsAddCommand frontmatter validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.exitCode = undefined;
+    mockWriteFile.mockReset();
+    mockWriteFile.mockResolvedValue(undefined);
     // Re-prime defaults that vi.clearAllMocks wipes.
     mockValidateRemoteAccess.mockResolvedValue({
       accessible: true,
@@ -2374,32 +2376,238 @@ describe('skillsAddCommand frontmatter validation', () => {
   });
 
   it('preserves a concurrently-created lockfile during rollback', async () => {
-    arrangeValidation({ skillContent: '---\nname: x\n---\nbody' });
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
     const concurrentLockfile = '{"version":1,"dependencies":{"other":"process"}}';
-    mockReadFile
-      .mockResolvedValueOnce(SAMPLE_PRS_FOR_VALIDATION)
-      .mockResolvedValueOnce('---\nname: x\n---\nbody')
-      .mockResolvedValueOnce(concurrentLockfile);
-    mockWriteFile
-      .mockImplementationOnce(async () => undefined)
-      .mockImplementationOnce(async () => {
+    let currentEntry = originalEntry;
+    const currentLockfile = concurrentLockfile;
+    let lockfileExists = false;
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      prsContent: originalEntry,
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === 'promptscript.lock') return lockfileExists;
+      if (p.includes('prs-skill-validate-xyz')) return !p.endsWith('.prs');
+      return p.includes('entry.prs');
+    });
+    mockReadFile.mockImplementation((p: string) => {
+      if (p === 'promptscript.lock') return Promise.resolve(currentLockfile);
+      if (p.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (p.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${p}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath === 'promptscript.lock') {
         throw new Error('lockfile write failed');
-      });
+      }
+      currentEntry = fileContent;
+      lockfileExists = true;
+      return undefined;
+    });
 
     await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
 
+    expect(currentEntry).toBe(originalEntry);
+    expect(currentLockfile).toBe(concurrentLockfile);
     expect(mockRm).not.toHaveBeenCalledWith(
       'promptscript.lock',
       expect.objectContaining({ force: true })
     );
     expect(
       (mockWriteFile.mock.calls as unknown[][]).filter((call) => call[0] === 'promptscript.lock')
-    ).toHaveLength(1);
+    ).toHaveLength(0);
     expect(mockConsoleError).toHaveBeenCalledWith(
       expect.stringContaining('changed during skills add')
     );
   });
 
+  it('aborts without overwriting a concurrent .prs edit', async () => {
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
+    const concurrentEntry = `${originalEntry}// concurrent edit\n`;
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      prsContent: originalEntry,
+    });
+    let entryReadCount = 0;
+    mockReadFile.mockImplementation((p: string) => {
+      if (p.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (p.includes('entry.prs')) {
+        entryReadCount += 1;
+        return Promise.resolve(entryReadCount === 1 ? originalEntry : concurrentEntry);
+      }
+      return Promise.reject(new Error(`unexpected read: ${p}`));
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(entryReadCount).toBe(2);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Cannot update'));
+    expect(concurrentEntry).toContain('// concurrent edit');
+  });
+
+  it('preserves a concurrent .prs edit during rollback', async () => {
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
+    let currentEntry = originalEntry;
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      lockExists: true,
+      lockContent: JSON.stringify({
+        version: 1,
+        dependencies: {
+          'https://github.com/org/repo': {
+            version: 'latest',
+            commit: 'old',
+            integrity: 'sha256-pending',
+          },
+        },
+      }),
+      prsContent: originalEntry,
+    });
+    mockReadFile.mockImplementation((p: string) => {
+      if (p === 'promptscript.lock') {
+        return Promise.resolve(
+          JSON.stringify({
+            version: 1,
+            dependencies: {
+              'https://github.com/org/repo': {
+                version: 'latest',
+                commit: 'old',
+                integrity: 'sha256-pending',
+              },
+            },
+          })
+        );
+      }
+      if (p.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (p.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${p}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath === 'promptscript.lock') {
+        throw new Error('lockfile write failed');
+      }
+      currentEntry = `${fileContent}// concurrent edit\n`;
+      return undefined;
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(currentEntry).toContain('// concurrent edit');
+    expect(mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock')).toHaveLength(
+      1
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Cannot roll back'));
+  });
+
+  it('rolls back an existing lockfile when its write fails', async () => {
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
+    const originalLockfile = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'https://github.com/org/repo': {
+          version: 'latest',
+          commit: 'old',
+          integrity: 'sha256-pending',
+        },
+      },
+    });
+    let currentEntry = originalEntry;
+    const currentLockfile = originalLockfile;
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      lockExists: true,
+      lockContent: originalLockfile,
+      prsContent: originalEntry,
+    });
+    mockReadFile.mockImplementation((p: string) => {
+      if (p === 'promptscript.lock') return Promise.resolve(currentLockfile);
+      if (p.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (p.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${p}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath === 'promptscript.lock') {
+        throw new Error('lock write failed');
+      }
+      currentEntry = fileContent;
+      return undefined;
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(currentEntry).toBe(originalEntry);
+    expect(currentLockfile).toBe(originalLockfile);
+    expect(mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock')).toHaveLength(
+      1
+    );
+    expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('does not overwrite an existing lockfile changed before its write', async () => {
+    const originalLockfile = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'https://github.com/org/repo': {
+          version: 'latest',
+          commit: 'old',
+          integrity: 'sha256-pending',
+        },
+      },
+    });
+    const concurrentLockfile = '{"version":1,"dependencies":{"other":"process"}}';
+    let lockReadCount = 0;
+    let currentEntry = SAMPLE_PRS_FOR_VALIDATION;
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      lockExists: true,
+      lockContent: originalLockfile,
+    });
+    mockReadFile.mockImplementation((p: string) => {
+      if (p === 'promptscript.lock') {
+        lockReadCount += 1;
+        return Promise.resolve(lockReadCount === 1 ? originalLockfile : concurrentLockfile);
+      }
+      if (p.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (p.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${p}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath.includes('entry.prs')) {
+        currentEntry = fileContent;
+      }
+      return undefined;
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(lockReadCount).toBe(2);
+    const entryWrites = mockWriteFile.mock.calls.filter((call) =>
+      String(call[0]).includes('entry.prs')
+    );
+    expect(entryWrites).toHaveLength(2);
+    expect(entryWrites[1]?.[1]).toBe(SAMPLE_PRS_FOR_VALIDATION);
+    expect(currentEntry).toBe(SAMPLE_PRS_FOR_VALIDATION);
+    expect(mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock')).toHaveLength(
+      0
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot update promptscript.lock')
+    );
+  });
   it('validates root markdown files under the repository folder name', async () => {
     arrangeValidation({ skillContent: '---\nname: repo\n---\nbody' });
 
@@ -2658,10 +2866,22 @@ describe('skillsAddCommand frontmatter validation', () => {
       lockContent: originalLockfile,
       prsContent: originalEntry,
     });
-    mockWriteFile
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('lock write failed'))
-      .mockResolvedValue(undefined);
+    let currentEntry = originalEntry;
+    mockReadFile.mockImplementation((p: string) => {
+      if (p === 'promptscript.lock') return Promise.resolve(originalLockfile);
+      if (p.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (p.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${p}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath === 'promptscript.lock') {
+        throw new Error('lock write failed');
+      }
+      currentEntry = fileContent;
+      return undefined;
+    });
 
     await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
       file: 'entry.prs',
@@ -2674,6 +2894,7 @@ describe('skillsAddCommand frontmatter validation', () => {
     expect(entryWrites).toHaveLength(2);
     expect(entryWrites[0]?.[1]).not.toBe(originalEntry);
     expect(entryWrites[1]?.[1]).toBe(originalEntry);
+    expect(currentEntry).toBe(originalEntry);
     expect(lockWrites).toHaveLength(1);
     expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
     expect(process.exitCode).toBe(1);

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -13,6 +13,7 @@ const {
   mockReaddir,
   mockMkdtemp,
   mockRm,
+  mockRename,
   mockValidateRemoteAccess,
   mockValidateSkillFrontmatter,
   mockFormatSkillValidationIssues,
@@ -46,6 +47,7 @@ const {
   const mockReaddir = vi.fn();
   const mockMkdtemp = vi.fn().mockResolvedValue('/tmp/prs-skill-default');
   const mockRm = vi.fn().mockResolvedValue(undefined);
+  const mockRename = vi.fn().mockResolvedValue(undefined);
   const mockValidateRemoteAccess = vi.fn().mockResolvedValue({
     accessible: true,
     headCommit: 'abc1234567890123456789012345678901234567890'.slice(0, 40),
@@ -102,6 +104,7 @@ const {
     mockDefaultGitTimeoutMs,
     mockMkdtemp,
     mockRm,
+    mockRename,
   };
 });
 
@@ -141,6 +144,7 @@ vi.mock('fs/promises', () => ({
   readdir: mockReaddir,
   mkdtemp: mockMkdtemp,
   rm: mockRm,
+  rename: mockRename,
 }));
 
 vi.mock('yaml', () => ({
@@ -614,7 +618,7 @@ describe('skillsAddCommand', () => {
     expect(mockSucceed).toHaveBeenCalledWith('Skill added');
 
     const writeCalls = mockWriteFile.mock.calls as unknown[][];
-    const lockWriteCall = writeCalls.find((call) => call[0] === 'promptscript.lock');
+    const lockWriteCall = writeCalls.find((call) => String(call[0]).endsWith('promptscript.lock'));
     const lockContent = JSON.parse(lockWriteCall![1] as string) as {
       dependencies: Record<string, { gitUrl?: string }>;
     };
@@ -696,7 +700,7 @@ describe('skillsAddCommand', () => {
     expect(writtenContent).toContain('@use github.com/company/skills/SKILL.md');
 
     // Check the lockfile was written
-    const lockWriteCall = writeCalls.find((call) => call[0] === 'promptscript.lock');
+    const lockWriteCall = writeCalls.find((call) => String(call[0]).endsWith('promptscript.lock'));
     expect(lockWriteCall).toBeDefined();
     const lockContent = JSON.parse(lockWriteCall![1] as string) as {
       dependencies: Record<string, { source?: string }>;
@@ -980,7 +984,9 @@ describe('skillsAddCommand', () => {
       undefined,
       { timeout: 60_000 }
     );
-    const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
+    const lockWriteCall = mockWriteFile.mock.calls.find((call) =>
+      String(call[0]).endsWith('promptscript.lock')
+    )!;
     const writtenLock = JSON.parse(lockWriteCall[1] as string) as {
       dependencies: Record<string, unknown>;
     };
@@ -1021,7 +1027,9 @@ describe('skillsAddCommand', () => {
       undefined,
       { timeout: 60_000 }
     );
-    const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
+    const lockWriteCall = mockWriteFile.mock.calls.find((call) =>
+      String(call[0]).endsWith('promptscript.lock')
+    )!;
     const writtenLock = JSON.parse(lockWriteCall[1] as string) as {
       dependencies: Record<string, unknown>;
     };
@@ -1103,7 +1111,7 @@ describe('skillsAddCommand', () => {
     // Assert
     expect(mockSucceed).toHaveBeenCalledWith('Skill added');
     const writeCalls = mockWriteFile.mock.calls as unknown[][];
-    const lockWriteCall = writeCalls.find((call) => call[0] === 'promptscript.lock');
+    const lockWriteCall = writeCalls.find((call) => String(call[0]).endsWith('promptscript.lock'));
     expect(lockWriteCall).toBeDefined();
     const lockContent = JSON.parse(lockWriteCall![1] as string) as {
       dependencies: Record<string, { commit: string; skills?: string[]; source?: string }>;
@@ -1203,7 +1211,7 @@ describe('skillsRemoveCommand', () => {
     expect(prsWriteCall).toBeDefined();
     const writtenContent = prsWriteCall![1] as string;
     expect(writtenContent).not.toContain('@use github.com/org/repo/SKILL.md');
-    const lockWriteCall = writeCalls.find((call) => call[0] === 'promptscript.lock');
+    const lockWriteCall = writeCalls.find((call) => String(call[0]).endsWith('promptscript.lock'));
     const writtenLock = JSON.parse(lockWriteCall![1] as string) as {
       dependencies: Record<string, unknown>;
     };
@@ -1256,7 +1264,9 @@ describe('skillsRemoveCommand', () => {
 
     await skillsRemoveCommand('skills/foo', {});
 
-    const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
+    const lockWriteCall = mockWriteFile.mock.calls.find((call) =>
+      String(call[0]).endsWith('promptscript.lock')
+    )!;
     const writtenLock = JSON.parse(lockWriteCall[1] as string) as {
       dependencies: Record<string, { gitUrl?: string; skills?: string[]; source?: string }>;
     };
@@ -2261,7 +2271,9 @@ describe('skillsUpdateCommand', () => {
 
     await skillsUpdateCommand(undefined, {});
 
-    const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
+    const lockWriteCall = mockWriteFile.mock.calls.find((call) =>
+      String(call[0]).endsWith('promptscript.lock')
+    )!;
     const lock = JSON.parse(lockWriteCall[1] as string) as {
       dependencies: Record<string, unknown>;
     };
@@ -2361,7 +2373,7 @@ describe('skillsAddCommand frontmatter validation', () => {
     expect(mockCloneAtTag).toHaveBeenCalled();
     expect(mockSucceed).toHaveBeenCalledWith('Skill added');
     const writeCalls = mockWriteFile.mock.calls as unknown[][];
-    const lockWriteCall = writeCalls.find((c) => c[0] === 'promptscript.lock');
+    const lockWriteCall = writeCalls.find((c) => String(c[0]).endsWith('promptscript.lock'));
     const lock = JSON.parse(lockWriteCall![1] as string) as {
       dependencies: Record<string, { integrity: string }>;
     };
@@ -2399,7 +2411,7 @@ describe('skillsAddCommand frontmatter validation', () => {
       return Promise.reject(new Error(`unexpected read: ${p}`));
     });
     mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
-      if (filePath === 'promptscript.lock') {
+      if (filePath.endsWith('promptscript.lock')) {
         throw new Error('lockfile write failed');
       }
       currentEntry = fileContent;
@@ -2416,7 +2428,9 @@ describe('skillsAddCommand frontmatter validation', () => {
       expect.objectContaining({ force: true })
     );
     expect(
-      (mockWriteFile.mock.calls as unknown[][]).filter((call) => call[0] === 'promptscript.lock')
+      (mockWriteFile.mock.calls as unknown[][]).filter((call) =>
+        String(call[0]).endsWith('promptscript.lock')
+      )
     ).toHaveLength(0);
     expect(mockConsoleError).toHaveBeenCalledWith(
       expect.stringContaining('changed during skills add')
@@ -2490,7 +2504,7 @@ describe('skillsAddCommand frontmatter validation', () => {
       return Promise.reject(new Error(`unexpected read: ${p}`));
     });
     mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
-      if (filePath === 'promptscript.lock') {
+      if (filePath.endsWith('promptscript.lock')) {
         throw new Error('lockfile write failed');
       }
       currentEntry = `${fileContent}// concurrent edit\n`;
@@ -2500,9 +2514,9 @@ describe('skillsAddCommand frontmatter validation', () => {
     await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
 
     expect(currentEntry).toContain('// concurrent edit');
-    expect(mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock')).toHaveLength(
-      1
-    );
+    expect(
+      mockWriteFile.mock.calls.filter((call) => String(call[0]).endsWith('promptscript.lock'))
+    ).toHaveLength(1);
     expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Cannot roll back'));
   });
 
@@ -2535,7 +2549,7 @@ describe('skillsAddCommand frontmatter validation', () => {
       return Promise.reject(new Error(`unexpected read: ${p}`));
     });
     mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
-      if (filePath === 'promptscript.lock') {
+      if (filePath.endsWith('promptscript.lock')) {
         throw new Error('lock write failed');
       }
       currentEntry = fileContent;
@@ -2548,9 +2562,9 @@ describe('skillsAddCommand frontmatter validation', () => {
 
     expect(currentEntry).toBe(originalEntry);
     expect(currentLockfile).toBe(originalLockfile);
-    expect(mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock')).toHaveLength(
-      1
-    );
+    expect(
+      mockWriteFile.mock.calls.filter((call) => String(call[0]).endsWith('promptscript.lock'))
+    ).toHaveLength(1);
     expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
     expect(process.exitCode).toBe(1);
   });
@@ -2601,9 +2615,9 @@ describe('skillsAddCommand frontmatter validation', () => {
     expect(entryWrites).toHaveLength(2);
     expect(entryWrites[1]?.[1]).toBe(SAMPLE_PRS_FOR_VALIDATION);
     expect(currentEntry).toBe(SAMPLE_PRS_FOR_VALIDATION);
-    expect(mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock')).toHaveLength(
-      0
-    );
+    expect(
+      mockWriteFile.mock.calls.filter((call) => String(call[0]).endsWith('promptscript.lock'))
+    ).toHaveLength(0);
     expect(mockConsoleError).toHaveBeenCalledWith(
       expect.stringContaining('Cannot update promptscript.lock')
     );
@@ -2728,7 +2742,9 @@ describe('skillsAddCommand frontmatter validation', () => {
       file: 'entry.prs',
     });
 
-    const lockWriteCall = mockWriteFile.mock.calls.find((call) => call[0] === 'promptscript.lock')!;
+    const lockWriteCall = mockWriteFile.mock.calls.find((call) =>
+      String(call[0]).endsWith('promptscript.lock')
+    )!;
     const lock = JSON.parse(lockWriteCall[1] as string) as {
       dependencies: Record<string, { integrity?: string; skills?: string[] }>;
     };
@@ -2775,7 +2791,7 @@ describe('skillsAddCommand frontmatter validation', () => {
     expect(process.exitCode).toBe(1);
     // No write to entry.prs nor lockfile.
     const writeCalls = mockWriteFile.mock.calls as unknown[][];
-    expect(writeCalls.find((c) => c[0] === 'promptscript.lock')).toBeUndefined();
+    expect(writeCalls.find((c) => String(c[0]).endsWith('promptscript.lock'))).toBeUndefined();
   });
 
   it('surfaces warnings non-strict but still installs', async () => {
@@ -2876,7 +2892,7 @@ describe('skillsAddCommand frontmatter validation', () => {
       return Promise.reject(new Error(`unexpected read: ${p}`));
     });
     mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
-      if (filePath === 'promptscript.lock') {
+      if (filePath.endsWith('promptscript.lock')) {
         throw new Error('lock write failed');
       }
       currentEntry = fileContent;
@@ -2890,13 +2906,104 @@ describe('skillsAddCommand frontmatter validation', () => {
     const entryWrites = mockWriteFile.mock.calls.filter((call) =>
       String(call[0]).includes('entry.prs')
     );
-    const lockWrites = mockWriteFile.mock.calls.filter((call) => call[0] === 'promptscript.lock');
+    const lockWrites = mockWriteFile.mock.calls.filter((call) =>
+      String(call[0]).endsWith('promptscript.lock')
+    );
     expect(entryWrites).toHaveLength(2);
     expect(entryWrites[0]?.[1]).not.toBe(originalEntry);
     expect(entryWrites[1]?.[1]).toBe(originalEntry);
     expect(currentEntry).toBe(originalEntry);
     expect(lockWrites).toHaveLength(1);
     expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('cleans up the temporary entry file when its write fails', async () => {
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      prsContent: SAMPLE_PRS_FOR_VALIDATION,
+    });
+    mockMkdtemp.mockReset();
+    mockMkdtemp
+      .mockResolvedValueOnce('/tmp/prs-skill-validate-xyz')
+      .mockResolvedValueOnce('/tmp/prs-atomic-entry');
+    mockWriteFile.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('entry.prs')) {
+        throw new Error('entry temp write failed');
+      }
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(mockFail).toHaveBeenCalledWith('Failed to add skill');
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(mockRm).toHaveBeenCalledWith(
+      '/tmp/prs-atomic-entry',
+      expect.objectContaining({ recursive: true, force: true })
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith('entry temp write failed');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('cleans up the temporary lockfile when its write fails', async () => {
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
+    const originalLockfile = JSON.stringify({
+      version: 1,
+      dependencies: {
+        'https://github.com/org/repo': {
+          version: 'latest',
+          commit: 'old',
+          integrity: 'sha256-pending',
+        },
+      },
+    });
+    arrangeValidation({
+      skillContent: '---\nname: x\n---\nbody',
+      lockExists: true,
+      lockContent: originalLockfile,
+      prsContent: originalEntry,
+    });
+    mockMkdtemp.mockReset();
+    mockMkdtemp
+      .mockResolvedValueOnce('/tmp/prs-skill-validate-xyz')
+      .mockResolvedValueOnce('/tmp/prs-atomic-entry')
+      .mockResolvedValueOnce('/tmp/prs-atomic-lock')
+      .mockResolvedValueOnce('/tmp/prs-atomic-rollback');
+    let currentEntry = originalEntry;
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath === 'promptscript.lock') return Promise.resolve(originalLockfile);
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath.endsWith('promptscript.lock')) {
+        throw new Error('lockfile temp write failed');
+      }
+      if (filePath.endsWith('entry.prs')) {
+        currentEntry = fileContent;
+      }
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', {
+      file: 'entry.prs',
+    });
+
+    expect(currentEntry).toBe(originalEntry);
+    expect(mockRename).toHaveBeenCalledTimes(2);
+    expect(mockRename).not.toHaveBeenCalledWith(
+      '/tmp/prs-atomic-lock/promptscript.lock',
+      'promptscript.lock'
+    );
+    expect(mockRm).toHaveBeenCalledWith(
+      '/tmp/prs-atomic-lock',
+      expect.objectContaining({ recursive: true, force: true })
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith('lockfile temp write failed');
     expect(process.exitCode).toBe(1);
   });
 
@@ -3066,7 +3173,7 @@ describe('skillsUpdateCommand frontmatter re-validation', () => {
     await skillsUpdateCommand(undefined, {});
 
     const writeCalls = mockWriteFile.mock.calls as unknown[][];
-    const lockWriteCall = writeCalls.find((c) => c[0] === 'promptscript.lock');
+    const lockWriteCall = writeCalls.find((c) => String(c[0]).endsWith('promptscript.lock'));
     const lock = JSON.parse(lockWriteCall![1] as string) as {
       dependencies: Record<string, { integrity: string }>;
     };
@@ -3163,7 +3270,7 @@ describe('skillsUpdateCommand frontmatter re-validation', () => {
       expect.stringContaining('github.com/org/repo/skills/foo/SKILL.md: validation warnings')
     );
     const writeCalls = mockWriteFile.mock.calls as unknown[][];
-    expect(writeCalls.find((c) => c[0] === 'promptscript.lock')).toBeDefined();
+    expect(writeCalls.find((c) => String(c[0]).endsWith('promptscript.lock'))).toBeDefined();
   });
 
   it('skips an update when the validation clone fails', async () => {

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -2581,6 +2581,268 @@ describe('skillsAddCommand frontmatter validation', () => {
     );
   });
 
+  it('fails when the transaction lock cannot be opened', async () => {
+    mockOpen.mockRejectedValueOnce('lock open failed');
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith('lock open failed');
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('treats a lock that disappears during stale checking as active', async () => {
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    const missingLockError = Object.assign(new Error('lock disappeared'), { code: 'ENOENT' });
+    mockOpen.mockRejectedValueOnce(lockError);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.reject(missingLockError);
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Another "prs skills add" is already running')
+    );
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('uses lock mtime when stale metadata is malformed', async () => {
+    arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
+    mockOpen.mockRejectedValueOnce(Object.assign(new Error('lock exists'), { code: 'EEXIST' }));
+    mockOpen.mockResolvedValueOnce(mockLockFile);
+    mockStat.mockResolvedValueOnce({ mtimeMs: Date.now() - 60 * 60 * 1000 });
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve('{malformed');
+      }
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: foo\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) {
+        return Promise.resolve(SAMPLE_PRS_FOR_VALIDATION);
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockStat).toHaveBeenCalledWith(expect.stringContaining('.promptscript-skills-add.lock'));
+    expect(mockOpen).toHaveBeenCalledTimes(2);
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+  });
+
+  it('recovers when stale-lock stat reports that the lock was removed', async () => {
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    mockOpen.mockRejectedValueOnce(lockError).mockResolvedValueOnce(mockLockFile);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve('{malformed');
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+    mockStat.mockRejectedValueOnce(
+      Object.assign(new Error('lock disappeared'), { code: 'ENOENT' })
+    );
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockOpen).toHaveBeenCalledTimes(2);
+    expect(mockSucceed).not.toHaveBeenCalled();
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('unexpected read'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('cleans up a lock when writing lock metadata fails', async () => {
+    const writeError = new Error('lock metadata write failed');
+    mockLockFile.writeFile.mockRejectedValueOnce(writeError);
+    mockLockFile.close.mockRejectedValueOnce(new Error('close failed'));
+    mockRm.mockRejectedValueOnce(new Error('lock cleanup failed'));
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockLockFile.close).toHaveBeenCalled();
+    expect(mockRm).toHaveBeenCalledWith(expect.stringContaining('.promptscript-skills-add.lock'), {
+      force: true,
+    });
+    expect(mockConsoleError).toHaveBeenCalledWith('lock metadata write failed');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('fails after both lock acquisition attempts remain occupied', async () => {
+    const lockError = Object.assign(new Error('lock exists'), { code: 'EEXIST' });
+    mockOpen.mockRejectedValue(lockError);
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve(
+          JSON.stringify({ acquiredAt: Date.now(), pid: 99999999, token: 'stale' })
+        );
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockOpen).toHaveBeenCalledTimes(2);
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot acquire skills add lock')
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('ignores lock close and metadata cleanup failures during release', async () => {
+    arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
+    mockLockFile.close.mockRejectedValueOnce(new Error('close failed'));
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.reject(new Error('metadata read failed'));
+      }
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: foo\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) {
+        return Promise.resolve(SAMPLE_PRS_FOR_VALIDATION);
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+    expect(mockLockFile.close).toHaveBeenCalled();
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('does not remove a lock owned by another transaction during release', async () => {
+    arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('.promptscript-skills-add.lock')) {
+        return Promise.resolve(
+          JSON.stringify({ acquiredAt: Date.now(), pid: process.pid, token: 'other-owner' })
+        );
+      }
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: foo\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) {
+        return Promise.resolve(SAMPLE_PRS_FOR_VALIDATION);
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockSucceed).toHaveBeenCalledWith('Skill added');
+    expect(mockRm).not.toHaveBeenCalledWith(
+      expect.stringContaining('.promptscript-skills-add.lock'),
+      { force: true }
+    );
+  });
+
+  it('reports a non-ENOENT stat failure before an atomic write', async () => {
+    arrangeValidation({ skillContent: '---\nname: foo\n---\nbody' });
+    mockStat.mockRejectedValueOnce(new Error('stat failed'));
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith('stat failed');
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('treats a lockfile removed during the initial read as missing', async () => {
+    arrangeValidation({ skillContent: '---\nname: foo\n---\nbody', lockExists: true });
+    const missingLockfile = Object.assign(new Error('lockfile disappeared'), { code: 'ENOENT' });
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath === 'promptscript.lock') {
+        return Promise.reject(missingLockfile);
+      }
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: foo\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) {
+        return Promise.resolve(SAMPLE_PRS_FOR_VALIDATION);
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot read promptscript.lock')
+    );
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('removes a newly created lockfile when a post-write failure triggers rollback', async () => {
+    const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
+    let currentEntry = originalEntry;
+    let currentLockfile: string | undefined;
+    let pendingEntry = '';
+    let pendingLockfile = '';
+    let rollbackStarted = false;
+    let lockfileExists = false;
+
+    arrangeValidation({
+      skillContent: '---\nname: foo\n---\nbody',
+      prsContent: originalEntry,
+    });
+    mockExistsSync.mockImplementation((filePath: string) => {
+      if (filePath === 'promptscript.lock') return lockfileExists;
+      if (filePath.includes('prs-skill-validate-xyz')) return !filePath.endsWith('.prs');
+      return filePath.includes('entry.prs');
+    });
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath === 'promptscript.lock') return Promise.resolve(currentLockfile);
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: foo\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) {
+        return Promise.resolve(rollbackStarted ? originalEntry : currentEntry);
+      }
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath.endsWith('entry.prs')) {
+        pendingEntry = fileContent;
+      }
+      if (filePath.endsWith('promptscript.lock')) {
+        pendingLockfile = fileContent;
+      }
+    });
+    mockRename.mockImplementation(async (_temporaryFile: string, filePath: string) => {
+      if (filePath === 'entry.prs') currentEntry = pendingEntry;
+      if (filePath === 'promptscript.lock') {
+        currentLockfile = pendingLockfile;
+        lockfileExists = true;
+      }
+    });
+    mockRm.mockImplementation(async (filePath: string) => {
+      if (filePath === 'promptscript.lock') {
+        lockfileExists = false;
+        currentLockfile = undefined;
+      }
+    });
+    mockSucceed.mockImplementationOnce(() => {
+      rollbackStarted = true;
+      throw new Error('post-write failure');
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockRm).toHaveBeenCalledWith('promptscript.lock', { force: true });
+    expect(currentLockfile).toBeUndefined();
+    expect(currentEntry).toBe(originalEntry);
+    expect(mockConsoleError).toHaveBeenCalledWith('post-write failure');
+    expect(process.exitCode).toBe(1);
+  });
+
   it('preserves a concurrently-created lockfile during rollback', async () => {
     const originalEntry = SAMPLE_PRS_FOR_VALIDATION;
     const concurrentLockfile = '{"version":1,"dependencies":{"other":"process"}}';
@@ -2712,6 +2974,49 @@ describe('skillsAddCommand frontmatter validation', () => {
       mockWriteFile.mock.calls.filter((call) => String(call[0]).endsWith('promptscript.lock'))
     ).toHaveLength(1);
     expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Cannot roll back'));
+  });
+
+  it('reports rollback conflicts when both project files change concurrently', async () => {
+    let currentEntry = SAMPLE_PRS_FOR_VALIDATION;
+    let currentLockfile: string | undefined;
+    let pendingEntry = '';
+    let pendingLockfile = '';
+
+    arrangeValidation({ skillContent: '---\nname: x\n---\nbody' });
+    mockExistsSync.mockImplementation((filePath: string) => {
+      if (filePath === 'promptscript.lock') return currentLockfile !== undefined;
+      if (filePath.includes('prs-skill-validate-xyz')) return !filePath.endsWith('.prs');
+      return filePath.includes('entry.prs');
+    });
+    mockReadFile.mockImplementation((filePath: string) => {
+      if (filePath === 'promptscript.lock') return Promise.resolve(currentLockfile);
+      if (filePath.includes('prs-skill-validate-xyz')) {
+        return Promise.resolve('---\nname: x\n---\nbody');
+      }
+      if (filePath.includes('entry.prs')) return Promise.resolve(currentEntry);
+      return Promise.reject(new Error(`unexpected read: ${filePath}`));
+    });
+    mockWriteFile.mockImplementation(async (filePath: string, fileContent: string) => {
+      if (filePath.endsWith('entry.prs')) pendingEntry = fileContent;
+      if (filePath.endsWith('promptscript.lock')) pendingLockfile = fileContent;
+    });
+    mockRename.mockImplementation(async (_temporaryFile: string, filePath: string) => {
+      if (filePath === 'entry.prs') currentEntry = pendingEntry;
+      if (filePath === 'promptscript.lock') currentLockfile = pendingLockfile;
+    });
+    mockSucceed.mockImplementationOnce(() => {
+      currentEntry = `${currentEntry}// concurrent entry\n`;
+      currentLockfile = `${currentLockfile}# concurrent lock\n`;
+      throw new Error('post-write failure');
+    });
+
+    await skillsAddCommand('github.com/org/repo/skills/foo/SKILL.md', { file: 'entry.prs' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('failed to roll back project files')
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Cannot roll back'));
+    expect(process.exitCode).toBe(1);
   });
 
   it('rolls back an existing lockfile when its write fails', async () => {

--- a/packages/cli/src/commands/lock.ts
+++ b/packages/cli/src/commands/lock.ts
@@ -35,6 +35,30 @@ export interface RemoteDependencyOptions {
   timeout?: number;
 }
 
+function isGitTimeoutError(error: Error): boolean {
+  const errorWithCode = error as Error & { code?: unknown; cause?: unknown };
+  const message = error.message.toLowerCase();
+  const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
+  const cause = errorWithCode.cause;
+  const causeMessage = cause instanceof Error ? cause.message.toLowerCase() : '';
+  const causeCode =
+    cause instanceof Error &&
+    'code' in cause &&
+    typeof (cause as { code?: unknown }).code === 'string'
+      ? (cause as { code: string }).code.toLowerCase()
+      : '';
+  return (
+    message.includes('timeout') ||
+    message.includes('timed out') ||
+    message.includes('etimedout') ||
+    code === 'etimedout' ||
+    causeMessage.includes('timeout') ||
+    causeMessage.includes('timed out') ||
+    causeMessage.includes('etimedout') ||
+    causeCode === 'etimedout'
+  );
+}
+
 /**
  * Generate or update promptscript.lock by resolving all remote imports.
  *
@@ -307,6 +331,9 @@ export async function resolveRemoteDependency(
       };
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
+      if (isGitTimeoutError(lastError)) {
+        break;
+      }
     }
   }
 

--- a/packages/cli/src/commands/lock.ts
+++ b/packages/cli/src/commands/lock.ts
@@ -37,24 +37,30 @@ export interface RemoteDependencyOptions {
 
 function isGitTimeoutError(error: Error): boolean {
   const errorWithCode = error as Error & { code?: unknown; cause?: unknown };
-  const message = error.message.toLowerCase();
   const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
   const cause = errorWithCode.cause;
-  const causeMessage = cause instanceof Error ? cause.message.toLowerCase() : '';
   const causeCode =
     cause instanceof Error &&
     'code' in cause &&
     typeof (cause as { code?: unknown }).code === 'string'
       ? (cause as { code: string }).code.toLowerCase()
       : '';
+
+  const containsTimeoutMessage = (message: string): boolean => {
+    const withoutUrlsAndRefs = message
+      .toLowerCase()
+      .replace(/\b[a-z][a-z\d+.-]*:\/\/[^\s'"]+|git@[\w.-]+:[^\s'"]+/g, '')
+      .replace(/\b(?:remote\s+)?ref(?:erence)?\s+["']?[^\s"']+/g, '')
+      .replace(/\bremote\s+branch\s+["']?[^\s"']+/g, '');
+    return /(?:^|[\s:()[\],.!?])(timeout|timed out|etimedout)(?=$|[\s:()[\],.!?])/i.test(
+      withoutUrlsAndRefs
+    );
+  };
+
   return (
-    message.includes('timeout') ||
-    message.includes('timed out') ||
-    message.includes('etimedout') ||
     code === 'etimedout' ||
-    causeMessage.includes('timeout') ||
-    causeMessage.includes('timed out') ||
-    causeMessage.includes('etimedout') ||
+    containsTimeoutMessage(error.message) ||
+    (cause instanceof Error && containsTimeoutMessage(cause.message)) ||
     causeCode === 'etimedout'
   );
 }

--- a/packages/cli/src/commands/lock.ts
+++ b/packages/cli/src/commands/lock.ts
@@ -30,6 +30,11 @@ interface RequestedDependency {
   auth?: GitAuthOptions;
 }
 
+export interface RemoteDependencyOptions {
+  /** Maximum wall-clock time for each Git operation in milliseconds */
+  timeout?: number;
+}
+
 /**
  * Generate or update promptscript.lock by resolving all remote imports.
  *
@@ -240,7 +245,8 @@ export async function resolveRemoteDependency(
   existing: LockfileDependency | undefined,
   forceUpdate: boolean,
   fallbackUrl?: string,
-  auth?: GitAuthOptions
+  auth?: GitAuthOptions,
+  options: RemoteDependencyOptions = {}
 ): Promise<LockfileDependency> {
   const canReuse =
     !forceUpdate &&
@@ -270,7 +276,8 @@ export async function resolveRemoteDependency(
         repoUrl,
         remoteUrl,
         requestedVersions,
-        candidateAuth
+        candidateAuth,
+        options
       );
       const resolvedRef = resolvedVersion === 'latest' ? undefined : resolvedVersion;
       const validation = candidateAuth
@@ -279,9 +286,12 @@ export async function resolveRemoteDependency(
             headCommit: await createGitRegistry({
               url: remoteUrl,
               auth: candidateAuth,
+              ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
             }).getCommitHash(resolvedRef),
           }
-        : await validateRemoteAccess(remoteUrl, resolvedRef);
+        : options.timeout !== undefined
+          ? await validateRemoteAccess(remoteUrl, resolvedRef, { timeout: options.timeout })
+          : await validateRemoteAccess(remoteUrl, resolvedRef);
       if (!validation.accessible || !validation.headCommit) {
         throw new Error(validation.error ?? `Could not resolve a commit for ${repoUrl}`);
       }
@@ -307,7 +317,8 @@ async function resolveRequestedVersion(
   repoUrl: string,
   remoteUrl: string,
   requestedVersions: string[],
-  auth?: GitAuthOptions
+  auth?: GitAuthOptions,
+  options: RemoteDependencyOptions = {}
 ): Promise<string> {
   const explicitVersions = [
     ...new Set(requestedVersions.filter((version) => version !== 'latest')),
@@ -317,7 +328,11 @@ async function resolveRequestedVersion(
   }
 
   if (explicitVersions.every(isSemverRange)) {
-    const registry = createGitRegistry({ url: remoteUrl, auth });
+    const registry = createGitRegistry({
+      url: remoteUrl,
+      auth,
+      ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
+    });
     const matchedVersion = await registry.resolveVersion(remoteUrl, explicitVersions);
     if (!matchedVersion) {
       throw new Error(`No remote version of ${repoUrl} matches ${explicitVersions.join(', ')}`);

--- a/packages/cli/src/commands/lock.ts
+++ b/packages/cli/src/commands/lock.ts
@@ -6,7 +6,7 @@ import type { LockOptions } from '../types.js';
 import { loadConfig, findConfigFile } from '../config/loader.js';
 import { createSpinner, ConsoleOutput } from '../output/console.js';
 import type { Lockfile, LockfileDependency } from '@promptscript/core';
-import { LOCKFILE_VERSION, isValidLockfile } from '@promptscript/core';
+import { LOCKFILE_VERSION, isGitTimeoutError, isValidLockfile } from '@promptscript/core';
 import { collectRemoteImports } from './lock-scanner.js';
 import {
   createGitRegistry,
@@ -33,36 +33,6 @@ interface RequestedDependency {
 export interface RemoteDependencyOptions {
   /** Maximum wall-clock time for each Git operation in milliseconds */
   timeout?: number;
-}
-
-function isGitTimeoutError(error: Error): boolean {
-  const errorWithCode = error as Error & { code?: unknown; cause?: unknown };
-  const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
-  const cause = errorWithCode.cause;
-  const causeCode =
-    cause instanceof Error &&
-    'code' in cause &&
-    typeof (cause as { code?: unknown }).code === 'string'
-      ? (cause as { code: string }).code.toLowerCase()
-      : '';
-
-  const containsTimeoutMessage = (message: string): boolean => {
-    const withoutUrlsAndRefs = message
-      .toLowerCase()
-      .replace(/\b[a-z][a-z\d+.-]*:\/\/[^\s'"]+|git@[\w.-]+:[^\s'"]+/g, '')
-      .replace(/\b(?:remote\s+)?ref(?:erence)?\s+["']?[^\s"']+/g, '')
-      .replace(/\bremote\s+branch\s+["']?[^\s"']+/g, '');
-    return /(?:^|[\s:()[\],.!?])(timeout|timed out|etimedout)(?=$|[\s:()[\],.!?])/i.test(
-      withoutUrlsAndRefs
-    );
-  };
-
-  return (
-    code === 'etimedout' ||
-    containsTimeoutMessage(error.message) ||
-    (cause instanceof Error && containsTimeoutMessage(cause.message)) ||
-    causeCode === 'etimedout'
-  );
 }
 
 /**

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,4 +1,4 @@
-import { writeFile, readFile, readdir, mkdtemp, rm } from 'fs/promises';
+import { writeFile, readFile, readdir, mkdtemp, rm, rename } from 'fs/promises';
 import { resolve, join, basename, dirname } from 'path';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
@@ -655,6 +655,19 @@ async function saveLockfile(lockfile: Lockfile): Promise<void> {
   await writeFile(LOCKFILE_PATH, stringifyYaml(lockfile), 'utf-8');
 }
 
+async function writeFileAtomically(filePath: string, content: string): Promise<void> {
+  const temporaryDirectory = await mkdtemp(join(dirname(filePath), `.${basename(filePath)}-`));
+  const temporaryFile = join(temporaryDirectory, basename(filePath));
+  try {
+    await writeFile(temporaryFile, content, 'utf-8');
+    await rename(temporaryFile, filePath);
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true }).catch(() => {
+      // Best-effort cleanup must not hide the write error.
+    });
+  }
+}
+
 interface SkillsAddRollbackState {
   entryFile: string;
   originalEntryContent: string;
@@ -726,7 +739,7 @@ async function rollbackFile(
     if (originalContent === undefined) {
       await rm(filePath, { force: true });
     } else {
-      await writeFile(filePath, originalContent, 'utf-8');
+      await writeFileAtomically(filePath, originalContent);
     }
     return undefined;
   } catch (error) {
@@ -969,10 +982,10 @@ export async function skillsAddCommand(
 
     // Write both files as one transaction from the user's perspective.
     await assertFileUnchanged(entryFile, content);
-    await writeFile(entryFile, updatedContent, 'utf-8');
+    await writeFileAtomically(entryFile, updatedContent);
     rollbackState.entryWriteCompleted = true;
     await assertFileUnchanged(LOCKFILE_PATH, originalLockfileContent);
-    await writeFile(LOCKFILE_PATH, updatedLockfileContent, 'utf-8');
+    await writeFileAtomically(LOCKFILE_PATH, updatedLockfileContent);
     rollbackState.lockfileWriteCompleted = true;
 
     spinner.succeed('Skill added');

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -660,6 +660,7 @@ interface SkillsAddRollbackState {
   originalEntryContent: string;
   originalLockfileContent: string | undefined;
   updatedLockfileContent: string;
+  lockfileWriteCompleted: boolean;
 }
 
 function isMissingFileError(error: unknown): boolean {
@@ -686,7 +687,10 @@ async function rollbackSkillsAdd(state: SkillsAddRollbackState): Promise<Error |
     const currentLockfileContent = await readLockfileForRollback();
     if (currentLockfileContent === state.originalLockfileContent) {
       // The lockfile write did not change its contents.
-    } else if (currentLockfileContent === state.updatedLockfileContent) {
+    } else if (
+      state.lockfileWriteCompleted &&
+      currentLockfileContent === state.updatedLockfileContent
+    ) {
       if (state.originalLockfileContent === undefined) {
         await rm(LOCKFILE_PATH, { force: true });
       } else {
@@ -914,11 +918,13 @@ export async function skillsAddCommand(
       originalEntryContent: content,
       originalLockfileContent,
       updatedLockfileContent,
+      lockfileWriteCompleted: false,
     };
 
     // Write both files as one transaction from the user's perspective.
     await writeFile(entryFile, updatedContent, 'utf-8');
     await writeFile(LOCKFILE_PATH, updatedLockfileContent, 'utf-8');
+    rollbackState.lockfileWriteCompleted = true;
 
     spinner.succeed('Skill added');
     ConsoleOutput.newline();

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,4 +1,15 @@
-import { writeFile, readFile, readdir, mkdtemp, rm, rename, chmod, open, stat } from 'fs/promises';
+import {
+  writeFile,
+  readFile,
+  readdir,
+  mkdtemp,
+  rm,
+  rename,
+  chmod,
+  open,
+  lstat,
+  stat,
+} from 'fs/promises';
 import { resolve, join, basename, dirname } from 'path';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
@@ -498,7 +509,18 @@ async function acquireSkillsAddLock(): Promise<SkillsAddLockHandle> {
           { cause: error }
         );
       }
-      await rm(lockPath, { force: true });
+      const quarantinePath = `${lockPath}.stale-${process.pid}-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`;
+      try {
+        await rename(lockPath, quarantinePath);
+      } catch (renameError) {
+        if (getErrorCode(renameError) === 'ENOENT') {
+          continue;
+        }
+        throw renameError;
+      }
+      await rm(quarantinePath, { force: true });
     }
   }
   throw new Error(`Cannot acquire skills add lock: ${resolve(SKILLS_ADD_LOCK_PATH)}`);
@@ -786,7 +808,13 @@ async function saveLockfile(lockfile: Lockfile): Promise<void> {
 async function writeFileAtomically(filePath: string, content: string): Promise<void> {
   let originalMode: number | undefined;
   try {
-    originalMode = (await stat(filePath)).mode & 0o7777;
+    const details = await lstat(filePath);
+    if (details.isSymbolicLink()) {
+      throw new Error(
+        `Refusing to replace symlink "${filePath}" during atomic write. Remove the symlink first or update its target directly.`
+      );
+    }
+    originalMode = details.mode & 0o7777;
   } catch (error) {
     if (getErrorCode(error) !== 'ENOENT') {
       throw error;

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,4 +1,4 @@
-import { writeFile, readFile, readdir, mkdtemp, rm, rename } from 'fs/promises';
+import { writeFile, readFile, readdir, mkdtemp, rm, rename, chmod, open, stat } from 'fs/promises';
 import { resolve, join, basename, dirname } from 'path';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
@@ -392,6 +392,134 @@ function printValidationIssues(issues: readonly SkillValidationIssue[]): void {
  * occurrence of any of these directives.
  */
 const HEADER_DIRECTIVES = ['@use ', '@inherit ', '@meta '];
+const SKILLS_ADD_LOCK_PATH = '.promptscript-skills-add.lock';
+const SKILLS_ADD_LOCK_STALE_MS = 30 * 60 * 1000;
+
+interface SkillsAddLockHandle {
+  path: string;
+  token: string;
+  file: {
+    close(): Promise<void>;
+    writeFile(data: string, encoding: BufferEncoding): Promise<void>;
+  };
+}
+
+interface SkillsAddLockMetadata {
+  acquiredAt: number;
+  pid: number;
+  token: string;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return getErrorCode(error) === 'EPERM';
+  }
+}
+
+function isSkillsAddLockMetadata(value: unknown): value is SkillsAddLockMetadata {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'acquiredAt' in value &&
+    typeof value.acquiredAt === 'number' &&
+    'pid' in value &&
+    typeof value.pid === 'number' &&
+    'token' in value &&
+    typeof value.token === 'string'
+  );
+}
+
+async function isStaleSkillsAddLock(lockPath: string): Promise<boolean> {
+  let metadata: SkillsAddLockMetadata | undefined;
+  try {
+    const raw = await readFile(lockPath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (isSkillsAddLockMetadata(parsed)) {
+      metadata = parsed;
+    }
+  } catch (error) {
+    if (getErrorCode(error) === 'ENOENT') {
+      return false;
+    }
+  }
+
+  if (metadata && Number.isInteger(metadata.pid) && metadata.pid > 0) {
+    return !isProcessAlive(metadata.pid);
+  }
+
+  try {
+    const details = await stat(lockPath);
+    return Date.now() - details.mtimeMs > SKILLS_ADD_LOCK_STALE_MS;
+  } catch (error) {
+    return getErrorCode(error) === 'ENOENT';
+  }
+}
+
+async function acquireSkillsAddLock(): Promise<SkillsAddLockHandle> {
+  const lockPath = resolve(SKILLS_ADD_LOCK_PATH);
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const file = await open(lockPath, 'wx', 0o600);
+      const metadata: SkillsAddLockMetadata = {
+        acquiredAt: Date.now(),
+        pid: process.pid,
+        token: `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      };
+      try {
+        await file.writeFile(JSON.stringify(metadata), 'utf-8');
+      } catch (error) {
+        await file.close().catch(() => {
+          // Best-effort close must not hide the write error.
+        });
+        await rm(lockPath, { force: true }).catch(() => {
+          // Best-effort cleanup must not hide the write error.
+        });
+        throw error;
+      }
+      return { path: lockPath, token: metadata.token, file };
+    } catch (error) {
+      if (getErrorCode(error) !== 'EEXIST') {
+        throw error;
+      }
+      if (!(await isStaleSkillsAddLock(lockPath))) {
+        throw new Error(
+          `Another "prs skills add" is already running for this project. Try again after it finishes.`,
+          { cause: error }
+        );
+      }
+      await rm(lockPath, { force: true });
+    }
+  }
+  throw new Error(`Cannot acquire skills add lock: ${resolve(SKILLS_ADD_LOCK_PATH)}`);
+}
+
+async function releaseSkillsAddLock(lock: SkillsAddLockHandle): Promise<void> {
+  try {
+    await lock.file.close();
+  } catch {
+    // Best-effort close must not leave the project lock behind.
+  }
+  try {
+    const raw = await readFile(lock.path, 'utf-8');
+    const metadata: unknown = JSON.parse(raw);
+    if (isSkillsAddLockMetadata(metadata) && metadata.token === lock.token) {
+      await rm(lock.path, { force: true });
+    }
+  } catch {
+    // Best-effort cleanup allows stale-lock recovery on the next invocation.
+  }
+}
 
 /**
  * Extract the base repository URL from a skill source path.
@@ -656,10 +784,22 @@ async function saveLockfile(lockfile: Lockfile): Promise<void> {
 }
 
 async function writeFileAtomically(filePath: string, content: string): Promise<void> {
+  let originalMode: number | undefined;
+  try {
+    originalMode = (await stat(filePath)).mode & 0o7777;
+  } catch (error) {
+    if (getErrorCode(error) !== 'ENOENT') {
+      throw error;
+    }
+  }
+
   const temporaryDirectory = await mkdtemp(join(dirname(filePath), `.${basename(filePath)}-`));
   const temporaryFile = join(temporaryDirectory, basename(filePath));
   try {
     await writeFile(temporaryFile, content, 'utf-8');
+    if (originalMode !== undefined) {
+      await chmod(temporaryFile, originalMode);
+    }
     await rename(temporaryFile, filePath);
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true }).catch(() => {
@@ -791,6 +931,7 @@ export async function skillsAddCommand(
 ): Promise<void> {
   const spinner = createSpinner('Adding skill...').start();
   let rollbackState: SkillsAddRollbackState | undefined;
+  let transactionLock: SkillsAddLockHandle | undefined;
 
   try {
     // Reject plain HTTP early (security): git over plaintext exposes the
@@ -816,6 +957,10 @@ export async function skillsAddCommand(
       spinner.fail(sourceError);
       process.exitCode = 1;
       return;
+    }
+
+    if (!options.dryRun) {
+      transactionLock = await acquireSkillsAddLock();
     }
 
     // Resolve target file
@@ -1006,6 +1151,10 @@ export async function skillsAddCommand(
     spinner.fail('Failed to add skill');
     ConsoleOutput.error(reportedError.message);
     process.exitCode = 1;
+  } finally {
+    if (transactionLock) {
+      await releaseSkillsAddLock(transactionLock);
+    }
   }
 }
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -600,14 +600,18 @@ function findUseEndLine(lines: string[], startLine: number): number {
 /**
  * Load the lockfile from disk.
  */
-async function loadLockfile(): Promise<Lockfile> {
+async function readLockfileContent(): Promise<string> {
+  return readFile(LOCKFILE_PATH, 'utf-8');
+}
+
+async function loadLockfile(rawContent?: string): Promise<Lockfile> {
   const defaultLockfile: Lockfile = { version: LOCKFILE_VERSION, dependencies: {} };
-  if (!existsSync(LOCKFILE_PATH)) {
+  if (rawContent === undefined && !existsSync(LOCKFILE_PATH)) {
     return defaultLockfile;
   }
   let parsed: unknown;
   try {
-    const raw = await readFile(LOCKFILE_PATH, 'utf-8');
+    const raw = rawContent ?? (await readLockfileContent());
     parsed = parseYaml(raw, { maxAliasCount: 100 });
   } catch (error) {
     throw new Error(
@@ -628,6 +632,38 @@ async function saveLockfile(lockfile: Lockfile): Promise<void> {
   await writeFile(LOCKFILE_PATH, stringifyYaml(lockfile), 'utf-8');
 }
 
+interface SkillsAddRollbackState {
+  entryFile: string;
+  originalEntryContent: string;
+  originalLockfileContent: string | undefined;
+}
+
+async function rollbackSkillsAdd(state: SkillsAddRollbackState): Promise<Error | undefined> {
+  const rollbackErrors: Error[] = [];
+
+  try {
+    if (state.originalLockfileContent === undefined) {
+      await rm(LOCKFILE_PATH, { force: true });
+    } else {
+      await writeFile(LOCKFILE_PATH, state.originalLockfileContent, 'utf-8');
+    }
+  } catch (error) {
+    rollbackErrors.push(error instanceof Error ? error : new Error(String(error)));
+  }
+
+  try {
+    await writeFile(state.entryFile, state.originalEntryContent, 'utf-8');
+  } catch (error) {
+    rollbackErrors.push(error instanceof Error ? error : new Error(String(error)));
+  }
+
+  if (rollbackErrors.length === 0) {
+    return undefined;
+  }
+
+  return new Error(rollbackErrors.map((error) => error.message).join('; '));
+}
+
 /**
  * Add a remote skill to the project.
  *
@@ -641,6 +677,7 @@ export async function skillsAddCommand(
   options: SkillsAddOptions
 ): Promise<void> {
   const spinner = createSpinner('Adding skill...').start();
+  let rollbackState: SkillsAddRollbackState | undefined;
 
   try {
     // Reject plain HTTP early (security): git over plaintext exposes the
@@ -689,7 +726,18 @@ export async function skillsAddCommand(
 
     // Load lockfile early — we need it for collision detection AND to write
     // the new entry below.
-    const lockfile = await loadLockfile();
+    let originalLockfileContent: string | undefined;
+    if (existsSync(LOCKFILE_PATH)) {
+      try {
+        originalLockfileContent = await readLockfileContent();
+      } catch (error) {
+        throw new Error(
+          `Cannot read ${LOCKFILE_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error }
+        );
+      }
+    }
+    const lockfile = await loadLockfile(originalLockfileContent);
     const parsedSource = parseSkillSource(source);
     const repoUrl = extractRepoUrl(source);
     const ownerEntry = findSkillOwnerEntry(lockfile, repoUrl);
@@ -810,10 +858,14 @@ export async function skillsAddCommand(
       return;
     }
 
-    // Write the modified .prs file
-    await writeFile(entryFile, updatedContent, 'utf-8');
+    rollbackState = {
+      entryFile,
+      originalEntryContent: content,
+      originalLockfileContent,
+    };
 
-    // Write lockfile
+    // Write both files as one transaction from the user's perspective.
+    await writeFile(entryFile, updatedContent, 'utf-8');
     await saveLockfile(lockfile);
 
     spinner.succeed('Skill added');
@@ -821,8 +873,18 @@ export async function skillsAddCommand(
     ConsoleOutput.success(`${newLine}  →  ${entryFile}`);
     ConsoleOutput.muted(`Lockfile updated: ${LOCKFILE_PATH}`);
   } catch (error) {
+    let reportedError = error instanceof Error ? error : new Error(String(error));
+    if (rollbackState) {
+      const rollbackError = await rollbackSkillsAdd(rollbackState);
+      if (rollbackError) {
+        reportedError = new Error(
+          `${reportedError.message}; failed to roll back project files: ${rollbackError.message}`,
+          { cause: reportedError }
+        );
+      }
+    }
     spinner.fail('Failed to add skill');
-    ConsoleOutput.error(error instanceof Error ? error.message : String(error));
+    ConsoleOutput.error(reportedError.message);
     process.exitCode = 1;
   }
 }

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -658,8 +658,10 @@ async function saveLockfile(lockfile: Lockfile): Promise<void> {
 interface SkillsAddRollbackState {
   entryFile: string;
   originalEntryContent: string;
+  updatedEntryContent: string;
   originalLockfileContent: string | undefined;
   updatedLockfileContent: string;
+  entryWriteCompleted: boolean;
   lockfileWriteCompleted: boolean;
 }
 
@@ -670,6 +672,9 @@ function isMissingFileError(error: unknown): boolean {
 }
 
 async function readLockfileForRollback(): Promise<string | undefined> {
+  if (!existsSync(LOCKFILE_PATH)) {
+    return undefined;
+  }
   try {
     return await readLockfileContent();
   } catch (error) {
@@ -680,35 +685,76 @@ async function readLockfileForRollback(): Promise<string | undefined> {
   }
 }
 
-async function rollbackSkillsAdd(state: SkillsAddRollbackState): Promise<Error | undefined> {
-  const rollbackErrors: Error[] = [];
+async function assertFileUnchanged(
+  filePath: string,
+  originalContent: string | undefined
+): Promise<void> {
+  const currentContent =
+    filePath === LOCKFILE_PATH
+      ? await readLockfileForRollback()
+      : await readFile(filePath, 'utf-8');
+  if (currentContent !== originalContent) {
+    throw new Error(
+      `Cannot update ${filePath}: it changed during skills add; leaving current contents untouched`
+    );
+  }
+}
 
-  try {
-    const currentLockfileContent = await readLockfileForRollback();
-    if (currentLockfileContent === state.originalLockfileContent) {
-      // The lockfile write did not change its contents.
-    } else if (
-      state.lockfileWriteCompleted &&
-      currentLockfileContent === state.updatedLockfileContent
-    ) {
-      if (state.originalLockfileContent === undefined) {
-        await rm(LOCKFILE_PATH, { force: true });
-      } else {
-        await writeFile(LOCKFILE_PATH, state.originalLockfileContent, 'utf-8');
-      }
-    } else {
-      throw new Error(
-        `Cannot roll back ${LOCKFILE_PATH}: it changed during skills add; leaving current contents untouched`
-      );
-    }
-  } catch (error) {
-    rollbackErrors.push(error instanceof Error ? error : new Error(String(error)));
+async function rollbackFile(
+  filePath: string,
+  originalContent: string | undefined,
+  updatedContent: string,
+  writeCompleted: boolean
+): Promise<Error | undefined> {
+  if (!writeCompleted) {
+    return undefined;
   }
 
   try {
-    await writeFile(state.entryFile, state.originalEntryContent, 'utf-8');
+    const currentContent =
+      filePath === LOCKFILE_PATH
+        ? await readLockfileForRollback()
+        : await readFile(filePath, 'utf-8');
+    if (currentContent === originalContent) {
+      return undefined;
+    }
+    if (currentContent !== updatedContent) {
+      throw new Error(
+        `Cannot roll back ${filePath}: it changed during skills add; leaving current contents untouched`
+      );
+    }
+    if (originalContent === undefined) {
+      await rm(filePath, { force: true });
+    } else {
+      await writeFile(filePath, originalContent, 'utf-8');
+    }
+    return undefined;
   } catch (error) {
-    rollbackErrors.push(error instanceof Error ? error : new Error(String(error)));
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+async function rollbackSkillsAdd(state: SkillsAddRollbackState): Promise<Error | undefined> {
+  const rollbackErrors: Error[] = [];
+
+  const entryRollbackError = await rollbackFile(
+    state.entryFile,
+    state.originalEntryContent,
+    state.updatedEntryContent,
+    state.entryWriteCompleted
+  );
+  if (entryRollbackError) {
+    rollbackErrors.push(entryRollbackError);
+  }
+
+  const lockfileRollbackError = await rollbackFile(
+    LOCKFILE_PATH,
+    state.originalLockfileContent,
+    state.updatedLockfileContent,
+    state.lockfileWriteCompleted
+  );
+  if (lockfileRollbackError) {
+    rollbackErrors.push(lockfileRollbackError);
   }
 
   if (rollbackErrors.length === 0) {
@@ -781,15 +827,13 @@ export async function skillsAddCommand(
     // Load lockfile early — we need it for collision detection AND to write
     // the new entry below.
     let originalLockfileContent: string | undefined;
-    if (existsSync(LOCKFILE_PATH)) {
-      try {
-        originalLockfileContent = await readLockfileContent();
-      } catch (error) {
-        throw new Error(
-          `Cannot read ${LOCKFILE_PATH}: ${error instanceof Error ? error.message : String(error)}`,
-          { cause: error }
-        );
-      }
+    try {
+      originalLockfileContent = await readLockfileForRollback();
+    } catch (error) {
+      throw new Error(
+        `Cannot read ${LOCKFILE_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
     }
     const lockfile = await loadLockfile(originalLockfileContent);
     const parsedSource = parseSkillSource(source);
@@ -916,13 +960,18 @@ export async function skillsAddCommand(
     rollbackState = {
       entryFile,
       originalEntryContent: content,
+      updatedEntryContent: updatedContent,
       originalLockfileContent,
       updatedLockfileContent,
+      entryWriteCompleted: false,
       lockfileWriteCompleted: false,
     };
 
     // Write both files as one transaction from the user's perspective.
+    await assertFileUnchanged(entryFile, content);
     await writeFile(entryFile, updatedContent, 'utf-8');
+    rollbackState.entryWriteCompleted = true;
+    await assertFileUnchanged(LOCKFILE_PATH, originalLockfileContent);
     await writeFile(LOCKFILE_PATH, updatedLockfileContent, 'utf-8');
     rollbackState.lockfileWriteCompleted = true;
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -466,7 +466,14 @@ async function isStaleSkillsAddLock(lockPath: string): Promise<boolean> {
   }
 
   if (metadata && Number.isInteger(metadata.pid) && metadata.pid > 0) {
-    return !isProcessAlive(metadata.pid);
+    if (!isProcessAlive(metadata.pid)) {
+      return true;
+    }
+    // A recycled PID can look alive forever, so age still expires the lock.
+    return (
+      Number.isFinite(metadata.acquiredAt) &&
+      Date.now() - metadata.acquiredAt > SKILLS_ADD_LOCK_STALE_MS
+    );
   }
 
   try {

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -17,6 +17,7 @@ import {
   hashContent,
   createGitRegistry,
   normalizeGitUrl,
+  DEFAULT_GIT_TIMEOUT_MS,
   type SkillValidationIssue,
 } from '@promptscript/resolver';
 
@@ -58,11 +59,30 @@ function resolveSkillDependency(
   requestedVersions: string[],
   existing: LockfileDependency | undefined,
   forceUpdate: boolean,
-  gitUrl: string | undefined
+  gitUrl: string | undefined,
+  timeout = DEFAULT_GIT_TIMEOUT_MS
 ): Promise<LockfileDependency> {
   return gitUrl
-    ? resolveRemoteDependency(repoUrl, requestedVersions, existing, forceUpdate, gitUrl)
-    : resolveRemoteDependency(repoUrl, requestedVersions, existing, forceUpdate);
+    ? resolveRemoteDependency(
+        repoUrl,
+        requestedVersions,
+        existing,
+        forceUpdate,
+        gitUrl,
+        undefined,
+        {
+          timeout,
+        }
+      )
+    : resolveRemoteDependency(
+        repoUrl,
+        requestedVersions,
+        existing,
+        forceUpdate,
+        undefined,
+        undefined,
+        { timeout }
+      );
 }
 
 function isSkillMetadataEntry(key: string, dependency: LockfileDependency): boolean {
@@ -289,7 +309,10 @@ async function fetchAndValidateRemoteSkill(
   const repoName = basename(parseSkillSource(source).path.split('/')[2]!);
   const cloneDir = !skillFilePath.includes('/') ? join(tmp, repoName) : tmp;
   try {
-    const gitRegistry = createGitRegistry({ url: repoUrl });
+    const gitRegistry = createGitRegistry({
+      url: repoUrl,
+      timeout: DEFAULT_GIT_TIMEOUT_MS,
+    });
     const cloneRef =
       options.version === 'latest' || /^[0-9a-f]{40}$/i.test(options.version)
         ? undefined
@@ -636,16 +659,43 @@ interface SkillsAddRollbackState {
   entryFile: string;
   originalEntryContent: string;
   originalLockfileContent: string | undefined;
+  updatedLockfileContent: string;
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT'
+  );
+}
+
+async function readLockfileForRollback(): Promise<string | undefined> {
+  try {
+    return await readLockfileContent();
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 async function rollbackSkillsAdd(state: SkillsAddRollbackState): Promise<Error | undefined> {
   const rollbackErrors: Error[] = [];
 
   try {
-    if (state.originalLockfileContent === undefined) {
-      await rm(LOCKFILE_PATH, { force: true });
+    const currentLockfileContent = await readLockfileForRollback();
+    if (currentLockfileContent === state.originalLockfileContent) {
+      // The lockfile write did not change its contents.
+    } else if (currentLockfileContent === state.updatedLockfileContent) {
+      if (state.originalLockfileContent === undefined) {
+        await rm(LOCKFILE_PATH, { force: true });
+      } else {
+        await writeFile(LOCKFILE_PATH, state.originalLockfileContent, 'utf-8');
+      }
     } else {
-      await writeFile(LOCKFILE_PATH, state.originalLockfileContent, 'utf-8');
+      throw new Error(
+        `Cannot roll back ${LOCKFILE_PATH}: it changed during skills add; leaving current contents untouched`
+      );
     }
   } catch (error) {
     rollbackErrors.push(error instanceof Error ? error : new Error(String(error)));
@@ -858,15 +908,17 @@ export async function skillsAddCommand(
       return;
     }
 
+    const updatedLockfileContent = stringifyYaml(lockfile);
     rollbackState = {
       entryFile,
       originalEntryContent: content,
       originalLockfileContent,
+      updatedLockfileContent,
     };
 
     // Write both files as one transaction from the user's perspective.
     await writeFile(entryFile, updatedContent, 'utf-8');
-    await saveLockfile(lockfile);
+    await writeFile(LOCKFILE_PATH, updatedLockfileContent, 'utf-8');
 
     spinner.succeed('Skill added');
     ConsoleOutput.newline();

--- a/packages/core/src/__tests__/git-timeout.spec.ts
+++ b/packages/core/src/__tests__/git-timeout.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { isGitTimeoutError } from '../git-timeout.js';
+
+describe('isGitTimeoutError', () => {
+  it('classifies an ETIMEDOUT error code', () => {
+    const error = Object.assign(new Error('connect failed'), { code: 'ETIMEDOUT' });
+
+    expect(isGitTimeoutError(error)).toBe(true);
+  });
+
+  it('classifies an ETIMEDOUT code on the cause', () => {
+    const cause = Object.assign(new Error('connect failed'), { code: 'etimedout' });
+    const error = new Error('clone failed', { cause });
+
+    expect(isGitTimeoutError(error)).toBe(true);
+  });
+
+  it('classifies a simple-git block timeout message', () => {
+    const error = new Error('block timeout reached');
+
+    expect(isGitTimeoutError(error)).toBe(true);
+  });
+
+  it('classifies a timeout message on the cause', () => {
+    const error = new Error('clone failed', { cause: new Error('operation timed out') });
+
+    expect(isGitTimeoutError(error)).toBe(true);
+  });
+
+  it('does not classify a repository URL containing timeout', () => {
+    const error = new Error('Authentication failed for https://example.com/timeout-repo');
+
+    expect(isGitTimeoutError(error)).toBe(false);
+  });
+
+  it('does not classify an SSH remote containing timeout', () => {
+    const error = new Error('could not read from remote git@example.com:org/timeout.git');
+
+    expect(isGitTimeoutError(error)).toBe(false);
+  });
+
+  it('does not classify a missing ref named timeout', () => {
+    const error = new Error("Could not find remote ref 'timeout'");
+
+    expect(isGitTimeoutError(error)).toBe(false);
+  });
+
+  it('does not classify a remote branch named timeout', () => {
+    const error = new Error("remote branch 'timeout' not found");
+
+    expect(isGitTimeoutError(error)).toBe(false);
+  });
+
+  it('does not classify an unrelated failure', () => {
+    const error = new Error('Authentication failed');
+
+    expect(isGitTimeoutError(error)).toBe(false);
+  });
+
+  it('does not classify a non-string error code', () => {
+    const error = Object.assign(new Error('clone failed'), { code: 128 });
+
+    expect(isGitTimeoutError(error)).toBe(false);
+  });
+
+  it('does not classify a non-Error cause', () => {
+    const error = new Error('clone failed', { cause: 'timed out' });
+
+    expect(isGitTimeoutError(error)).toBe(false);
+  });
+
+  it('classifies a timeout word bounded by punctuation', () => {
+    const error = new Error('fetch failed (timeout).');
+
+    expect(isGitTimeoutError(error)).toBe(true);
+  });
+});

--- a/packages/core/src/git-timeout.ts
+++ b/packages/core/src/git-timeout.ts
@@ -1,0 +1,38 @@
+/**
+ * Classify an error as a Git operation timeout.
+ *
+ * simple-git surfaces its block timeout as a plain message rather than a typed
+ * error, so the message is inspected as well as `code`. URLs, ref names, and
+ * branch names are stripped first: a repository or ref literally called
+ * "timeout" must not be mistaken for a timed-out operation, because callers use
+ * this classification to stop retrying with other credentials.
+ */
+export function isGitTimeoutError(error: Error): boolean {
+  const errorWithCode = error as Error & { code?: unknown; cause?: unknown };
+  const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
+  const cause = errorWithCode.cause;
+  const causeCode =
+    cause instanceof Error &&
+    'code' in cause &&
+    typeof (cause as { code?: unknown }).code === 'string'
+      ? (cause as { code: string }).code.toLowerCase()
+      : '';
+
+  return (
+    code === 'etimedout' ||
+    containsTimeoutMessage(error.message) ||
+    (cause instanceof Error && containsTimeoutMessage(cause.message)) ||
+    causeCode === 'etimedout'
+  );
+}
+
+function containsTimeoutMessage(message: string): boolean {
+  const withoutUrlsAndRefs = message
+    .toLowerCase()
+    .replace(/\b[a-z][a-z\d+.-]*:\/\/[^\s'"]+|git@[\w.-]+:[^\s'"]+/g, '')
+    .replace(/\b(?:remote\s+)?ref(?:erence)?\s+["']?[^\s"']+/g, '')
+    .replace(/\bremote\s+branch\s+["']?[^\s"']+/g, '');
+  return /(?:^|[\s:()[\],.!?])(timeout|timed out|etimedout)(?=$|[\s:()[\],.!?])/i.test(
+    withoutUrlsAndRefs
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,3 +45,6 @@ export * from './target-catalog.js';
 
 // Hook capabilities
 export * from './hook-capabilities.js';
+
+// Git timeout classification
+export * from './git-timeout.js';

--- a/packages/resolver/src/__tests__/git-registry-extensions.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry-extensions.spec.ts
@@ -169,6 +169,31 @@ describe('GitRegistry — extended methods', () => {
         registry.cloneAtTag('https://github.com/org/repo.git', 'v1.0.0', join(testCacheDir, 't'))
       ).rejects.toThrow(GitCloneError);
     });
+
+    it('reports timeout before authentication when Git supplies ETIMEDOUT', async () => {
+      // Arrange
+      mockGit.clone.mockRejectedValueOnce(
+        Object.assign(new Error('Authentication failed while contacting remote'), {
+          code: 'ETIMEDOUT',
+        })
+      );
+
+      // Act / Assert
+      let error: unknown;
+      try {
+        await registry.cloneAtTag(
+          'https://github.com/org/repo.git',
+          'v1.0.0',
+          join(testCacheDir, 'timeout-target'),
+          'git@github.com:org/repo.git'
+        );
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error).toBeInstanceOf(GitCloneError);
+      expect(error).not.toBeInstanceOf(GitAuthError);
+      expect(mockGit.clone).toHaveBeenCalledTimes(1);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -646,6 +671,31 @@ describe('GitRegistry — extended methods', () => {
 
       expect(mockGit.fetch).toHaveBeenNthCalledWith(3, ['origin']);
       expect(mockGit.checkout).toHaveBeenCalledWith('cafe99');
+    });
+
+    it('reports checkout timeout before authentication', async () => {
+      mockGit.fetch.mockRejectedValueOnce(
+        Object.assign(new Error('Authentication failed while fetching remote'), {
+          code: 'ETIMEDOUT',
+        })
+      );
+
+      const timeoutRegistry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+        timeout: 25,
+      });
+
+      let error: unknown;
+      try {
+        await timeoutRegistry.checkoutCommit(join(testCacheDir, 'checkout-timeout'), 'deadbeef');
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error).toBeInstanceOf(GitCloneError);
+      expect(error).not.toBeInstanceOf(GitAuthError);
+      expect((error as Error).message).toContain('timed out after 25ms');
+      expect(mockGit.fetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/resolver/src/__tests__/git-registry-extensions.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry-extensions.spec.ts
@@ -275,6 +275,30 @@ describe('GitRegistry — extended methods', () => {
       const cached = await cache.getTagsMeta(repoUrl);
       expect(cached?.tags).toContain('v3.0.0');
     });
+
+    it('reports timeout from ls-remote before returning tags', async () => {
+      mockGit.listRemote.mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(registry.listTags('https://github.com/org/repo.git')).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+    });
+
+    it('rethrows non-timeout ls-remote errors unchanged', async () => {
+      const failure = new Error('remote unavailable');
+      mockGit.listRemote.mockRejectedValueOnce(failure);
+
+      await expect(registry.listTags('https://github.com/org/repo.git')).rejects.toBe(failure);
+    });
+
+    it('normalizes non-Error ls-remote failures before timeout detection', async () => {
+      mockGit.listRemote.mockRejectedValueOnce('remote unavailable');
+
+      await expect(registry.listTags('https://github.com/org/repo.git')).rejects.toBe(
+        'remote unavailable'
+      );
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -442,6 +466,22 @@ describe('GitRegistry — extended methods', () => {
         )
       ).rejects.toThrow(GitCloneError);
     });
+
+    it('reports timeout from the initial sparse clone', async () => {
+      mockGit.clone.mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.cloneSparse(
+          'https://github.com/org/repo.git',
+          'main',
+          join(testCacheDir, 'sparse-timeout'),
+          'src/'
+        )
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -579,6 +619,25 @@ describe('GitRegistry — extended methods', () => {
         )
       ).rejects.toThrow(GitCloneError);
     });
+
+    it('reports timeout when the fallback clone stalls', async () => {
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.cloneAtTag(
+          'https://github.com/org/repo.git',
+          'v1.0.0',
+          join(testCacheDir, 'fb-timeout'),
+          'git@github.com:org/repo.git'
+        )
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.clone).toHaveBeenCalledTimes(2);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -621,6 +680,26 @@ describe('GitRegistry — extended methods', () => {
           'git@github.com:org/repo.git'
         )
       ).rejects.toThrow(GitAuthError);
+    });
+
+    it('reports timeout when the sparse fallback clone stalls', async () => {
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.cloneSparse(
+          'https://github.com/org/repo.git',
+          'main',
+          join(testCacheDir, 'sparse-fb-timeout'),
+          'src/',
+          'git@github.com:org/repo.git'
+        )
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.clone).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -697,6 +776,90 @@ describe('GitRegistry — extended methods', () => {
       expect((error as Error).message).toContain('timed out after 25ms');
       expect(mockGit.fetch).toHaveBeenCalledTimes(1);
     });
+
+    it('reports timeout while applying repository config', async () => {
+      mockGit.raw.mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.checkoutCommit(join(testCacheDir, 'checkout-config-timeout'), 'deadbeef')
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.fetch).not.toHaveBeenCalled();
+    });
+
+    it('reports timeout while unshallowing a commit', async () => {
+      mockGit.fetch
+        .mockRejectedValueOnce(new Error('commit not found'))
+        .mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.checkoutCommit(join(testCacheDir, 'checkout-unshallow-timeout'), 'deadbeef')
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.fetch).toHaveBeenNthCalledWith(2, ['--unshallow']);
+    });
+
+    it('reports timeout while performing the full fetch fallback', async () => {
+      mockGit.fetch
+        .mockRejectedValueOnce(new Error('commit not found'))
+        .mockRejectedValueOnce(new Error('unshallow not supported'))
+        .mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.checkoutCommit(join(testCacheDir, 'checkout-full-fetch-timeout'), 'deadbeef')
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.fetch).toHaveBeenNthCalledWith(3, ['origin']);
+    });
+
+    it('reports timeout while checking out the pinned commit', async () => {
+      mockGit.checkout.mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.checkoutCommit(join(testCacheDir, 'checkout-checkout-timeout'), 'deadbeef')
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.reset).not.toHaveBeenCalled();
+    });
+
+    it('rethrows non-timeout repository config failures', async () => {
+      const failure = new Error('config failed');
+      mockGit.raw.mockRejectedValueOnce(failure);
+
+      await expect(
+        registry.checkoutCommit(join(testCacheDir, 'checkout-config-failure'), 'deadbeef')
+      ).rejects.toBe(failure);
+      expect(mockGit.fetch).not.toHaveBeenCalled();
+    });
+
+    it('rethrows a non-timeout full-fetch failure', async () => {
+      const failure = new Error('full fetch failed');
+      mockGit.fetch
+        .mockRejectedValueOnce(new Error('commit not found'))
+        .mockRejectedValueOnce(new Error('unshallow not supported'))
+        .mockRejectedValueOnce(failure);
+
+      await expect(
+        registry.checkoutCommit(join(testCacheDir, 'checkout-full-fetch-failure'), 'deadbeef')
+      ).rejects.toBe(failure);
+    });
+
+    it('rethrows non-timeout checkout failures', async () => {
+      const failure = new Error('checkout failed');
+      mockGit.checkout.mockRejectedValueOnce(failure);
+
+      await expect(
+        registry.checkoutCommit(join(testCacheDir, 'checkout-failure'), 'deadbeef')
+      ).rejects.toBe(failure);
+    });
   });
 
   describe('removeRemote()', () => {
@@ -706,6 +869,26 @@ describe('GitRegistry — extended methods', () => {
       await registry.removeRemote(targetDir);
 
       expect(mockGit.raw).toHaveBeenCalledWith(['remote', 'remove', 'origin']);
+    });
+
+    it('reports timeout while removing the origin URL', async () => {
+      mockGit.raw.mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(
+        registry.removeRemote(join(testCacheDir, 'remove-remote-timeout'))
+      ).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+    });
+
+    it('rethrows non-timeout origin removal failures', async () => {
+      const failure = new Error('remote removal failed');
+      mockGit.raw.mockRejectedValueOnce(failure);
+
+      await expect(registry.removeRemote(join(testCacheDir, 'remove-remote-failure'))).rejects.toBe(
+        failure
+      );
     });
   });
 });

--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -24,6 +24,7 @@ const mockGit = {
   checkout: vi.fn().mockResolvedValue(undefined),
   reset: vi.fn().mockResolvedValue(undefined),
   revparse: vi.fn().mockResolvedValue('abc123def456'),
+  raw: vi.fn().mockResolvedValue(''),
   env: vi.fn().mockReturnThis(),
   listRemote: vi.fn().mockResolvedValue(''),
 };
@@ -50,6 +51,7 @@ describe('GitRegistry', () => {
     mockGit.checkout.mockResolvedValue(undefined);
     mockGit.reset.mockResolvedValue(undefined);
     mockGit.revparse.mockResolvedValue('abc123def456');
+    mockGit.raw.mockResolvedValue('');
     mockGit.env.mockReturnThis();
     mockGit.listRemote.mockResolvedValue('');
 
@@ -337,6 +339,75 @@ describe('GitRegistry', () => {
       const hash = await registry.getCommitHash();
       expect(hash).toBe('abc123def456');
     });
+
+    it('should report timeout while reading the current commit', async () => {
+      mockGit.revparse
+        .mockResolvedValueOnce('abc123def456')
+        .mockRejectedValueOnce(new Error('operation timed out'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.getCommitHash()).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.revparse).toHaveBeenCalledTimes(2);
+    });
+
+    it('should report timeout while caching the current commit', async () => {
+      mockGit.revparse.mockRejectedValueOnce(new Error('operation timed out'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.getCommitHash()).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.revparse).toHaveBeenCalledTimes(1);
+    });
+
+    it('should rethrow a non-timeout commit lookup error', async () => {
+      mockGit.revparse
+        .mockResolvedValueOnce('abc123def456')
+        .mockRejectedValueOnce(new Error('revparse failed'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.getCommitHash()).rejects.toThrow('revparse failed');
+    });
+
+    it('should preserve non-Error commit lookup failures', async () => {
+      mockGit.revparse
+        .mockResolvedValueOnce('abc123def456')
+        .mockRejectedValueOnce('revparse failed');
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.getCommitHash()).rejects.toBe('revparse failed');
+    });
+
+    it('should preserve non-Error current commit read failures', async () => {
+      mockGit.revparse.mockRejectedValueOnce('current commit read failed');
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.getCommitHash()).rejects.toBe('current commit read failed');
+    });
   });
 
   describe('authentication', () => {
@@ -446,6 +517,22 @@ describe('GitRegistry', () => {
     });
   });
 
+  it('should use the default timeout for invalid timeout values', async () => {
+    const registry = new GitRegistry({
+      url: 'https://github.com/org/repo.git',
+      cacheDir: testCacheDir,
+      timeout: 0,
+    });
+
+    await registry.fetch('@company/base');
+
+    expect(simpleGit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeout: { block: 60_000, stdErr: false, stdOut: false },
+      })
+    );
+  });
+
   describe('error handling', () => {
     it('should throw GitAuthError on authentication failure', async () => {
       mockGit.clone.mockRejectedValueOnce(new Error('Authentication failed'));
@@ -524,6 +611,44 @@ describe('GitRegistry', () => {
       });
 
       await expect(registry.fetch('@company/base')).rejects.toThrow(GitCloneError);
+    });
+
+    it('should report timeout while recovering a missing branch', async () => {
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Could not find remote branch feature'))
+        .mockImplementationOnce(async (_url: string, targetPath: string) => {
+          await fs.mkdir(targetPath, { recursive: true });
+        });
+      mockGit.fetch.mockRejectedValueOnce(new Error('operation timed out'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        ref: 'feature',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.fetch('@company/base')).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+    });
+
+    it('should report timeout from a configured fallback clone', async () => {
+      mockGit.clone
+        .mockRejectedValueOnce(new Error('Authentication failed'))
+        .mockRejectedValueOnce(new Error('operation timed out'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        fallbackUrl: 'git@github.com:org/repo.git',
+        cacheDir: testCacheDir,
+      });
+
+      await expect(registry.fetch('@company/base')).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after'),
+      });
+      expect(mockGit.clone).toHaveBeenCalledTimes(2);
     });
 
     it('should detect permission denied as auth error', async () => {
@@ -749,6 +874,44 @@ describe('GitRegistry', () => {
 
       await registry.fetch('@company/security');
       expect(mockGit.fetch).toHaveBeenCalledWith(['origin', '--tags', '--depth=1']);
+    });
+
+    it('should preserve timeout errors while refreshing a stale cache', async () => {
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+        cache: { enabled: true, ttl: 1 },
+      });
+
+      await registry.fetch('@company/base');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mockGit.fetch.mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(registry.fetch('@company/security')).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out'),
+      });
+      expect(mockGit.clone).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report timeout during tag fallback while refreshing a stale cache', async () => {
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+        cache: { enabled: true, ttl: 1 },
+      });
+
+      await registry.fetch('@company/base');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mockGit.fetch
+        .mockRejectedValueOnce(new Error('Could not find remote branch'))
+        .mockRejectedValueOnce(new Error('operation timed out'));
+
+      await expect(registry.fetch('@company/security')).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out'),
+      });
+      expect(mockGit.clone).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1004,6 +1167,43 @@ describe('validateRemoteAccess', () => {
     expect(result.accessible).toBe(false);
     expect(result.error).toContain('Timed out after 25ms');
     expect(result.error).not.toContain('Authentication failed');
+  });
+
+  it('should classify timeout codes nested in an error cause', async () => {
+    const cause = Object.assign(new Error('remote authentication failed'), {
+      code: 'ETIMEDOUT',
+    });
+    mockGit.listRemote.mockRejectedValue(new Error('remote probe failed', { cause }));
+
+    const result = await validateRemoteAccess('https://github.com/org/repo.git', undefined, {
+      timeout: 25,
+    });
+
+    expect(result.accessible).toBe(false);
+    expect(result.error).toContain('Timed out after 25ms');
+  });
+
+  it('should ignore non-timeout causes during network error classification', async () => {
+    const cause = new Error('connection reset');
+    mockGit.listRemote.mockRejectedValue(new Error('remote probe failed', { cause }));
+
+    const result = await validateRemoteAccess('https://github.com/org/repo.git');
+
+    expect(result.accessible).toBe(false);
+    expect(result.error).toContain('Failed to reach');
+  });
+
+  it('should normalize invalid validation timeout values', async () => {
+    mockGit.listRemote.mockRejectedValue(new Error('block timeout reached'));
+
+    const result = await validateRemoteAccess('https://github.com/org/repo.git', undefined, {
+      timeout: Number.NaN,
+    });
+
+    expect(result.error).toContain('Timed out after 60000ms');
+    expect(simpleGit).toHaveBeenCalledWith({
+      timeout: { block: 60_000, stdErr: false, stdOut: false },
+    });
   });
 });
 

--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -1120,6 +1120,28 @@ describe('validateRemoteAccess', () => {
     expect(result.error).toContain('network');
   });
 
+  it('should not classify timeout in a repository URL as a timeout', async () => {
+    mockGit.listRemote.mockRejectedValue(
+      new Error('Authentication failed for https://example.com/timeout-repo')
+    );
+
+    const result = await validateRemoteAccess('https://example.com/timeout-repo');
+
+    expect(result.accessible).toBe(false);
+    expect(result.error).toContain('Authentication failed');
+    expect(result.error).not.toContain('Timed out');
+  });
+
+  it('should not classify a missing remote ref named timeout as a timeout', async () => {
+    mockGit.listRemote.mockRejectedValue(new Error("Could not find remote ref 'timeout'"));
+
+    const result = await validateRemoteAccess('https://github.com/org/repo.git', 'timeout');
+
+    expect(result.accessible).toBe(false);
+    expect(result.error).toContain('Failed to reach');
+    expect(result.error).not.toContain('Timed out');
+  });
+
   it('should bound a stalled ls-remote and report an actionable timeout', async () => {
     mockGit.listRemote.mockRejectedValue(new Error('block timeout reached'));
 

--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -398,6 +398,22 @@ describe('GitRegistry', () => {
       expect(mockGit.env).toHaveBeenCalledWith('GIT_TERMINAL_PROMPT', '0');
       expect(mockGit.env).toHaveBeenCalledWith('GCM_INTERACTIVE', 'never');
     });
+
+    it('should apply a hard timeout to every registry Git client', async () => {
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+        timeout: 25,
+      });
+
+      await registry.fetch('@company/base');
+
+      expect(simpleGit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeout: { block: 25, stdErr: false, stdOut: false },
+        })
+      );
+    });
   });
 
   describe('error handling', () => {
@@ -942,6 +958,22 @@ describe('validateRemoteAccess', () => {
     expect(simpleGit).toHaveBeenCalledWith(expect.any(String), {
       timeout: { block: 25, stdErr: false, stdOut: false },
     });
+  });
+
+  it('should classify ETIMEDOUT as a timeout before authentication', async () => {
+    mockGit.listRemote.mockRejectedValue(
+      Object.assign(new Error('Authentication failed while contacting remote'), {
+        code: 'ETIMEDOUT',
+      })
+    );
+
+    const result = await validateRemoteAccess('https://github.com/org/repo.git', undefined, {
+      timeout: 25,
+    });
+
+    expect(result.accessible).toBe(false);
+    expect(result.error).toContain('Timed out after 25ms');
+    expect(result.error).not.toContain('Authentication failed');
   });
 });
 

--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -3,6 +3,7 @@ import { existsSync, promises as fs } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { FileNotFoundError } from '@promptscript/core';
+import { simpleGit } from 'simple-git';
 import {
   GitRegistry,
   GitCloneError,
@@ -908,6 +909,39 @@ describe('validateRemoteAccess', () => {
     expect(result.error).toContain('Failed to reach');
     expect(result.error).toContain('https://github.com/org/repo.git');
     expect(result.error).toContain('network');
+  });
+
+  it('should bound a stalled ls-remote and report an actionable timeout', async () => {
+    mockGit.listRemote.mockRejectedValue(new Error('block timeout reached'));
+
+    const result = await validateRemoteAccess('https://github.com/org/repo.git', undefined, {
+      timeout: 25,
+    });
+
+    expect(result.accessible).toBe(false);
+    expect(result.error).toContain('Timed out after 25ms');
+    expect(result.error).toContain('https://github.com/org/repo.git');
+    expect(simpleGit).toHaveBeenCalledWith({
+      timeout: { block: 25, stdErr: false, stdOut: false },
+    });
+    expect(mockGit.env).toHaveBeenCalledWith('GIT_TERMINAL_PROMPT', '0');
+    expect(mockGit.env).toHaveBeenCalledWith('GCM_INTERACTIVE', 'never');
+  });
+
+  it('should bound a stalled commit probe and report an actionable timeout', async () => {
+    const commit = 'feedfacefeedfacefeedfacefeedfacefeedface';
+    mockGit.fetch.mockRejectedValue(new Error('block timeout reached'));
+
+    const result = await validateRemoteAccess('https://github.com/org/repo.git', commit, {
+      timeout: 25,
+    });
+
+    expect(result.accessible).toBe(false);
+    expect(result.error).toContain('Timed out after 25ms');
+    expect(result.error).toContain('https://github.com/org/repo.git');
+    expect(simpleGit).toHaveBeenCalledWith(expect.any(String), {
+      timeout: { block: 25, stdErr: false, stdOut: false },
+    });
   });
 });
 

--- a/packages/resolver/src/__tests__/git-registry.spec.ts
+++ b/packages/resolver/src/__tests__/git-registry.spec.ts
@@ -243,6 +243,21 @@ describe('GitRegistry', () => {
       const exists = await registry.exists('@company/base');
       expect(exists).toBe(false);
     });
+
+    it('should rethrow typed timeout errors', async () => {
+      mockGit.clone.mockRejectedValueOnce(new Error('Network timeout'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+        timeout: 25,
+      });
+
+      await expect(registry.exists('@company/base')).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after 25ms'),
+      });
+    });
   });
 
   describe('list', () => {
@@ -277,6 +292,21 @@ describe('GitRegistry', () => {
 
       const files = await registry.list('@company');
       expect(files).toEqual([]);
+    });
+
+    it('should rethrow typed timeout errors', async () => {
+      mockGit.clone.mockRejectedValueOnce(new Error('Network timeout'));
+
+      const registry = new GitRegistry({
+        url: 'https://github.com/org/repo.git',
+        cacheDir: testCacheDir,
+        timeout: 25,
+      });
+
+      await expect(registry.list('@company')).rejects.toMatchObject({
+        name: 'GitCloneError',
+        message: expect.stringContaining('timed out after 25ms'),
+      });
     });
   });
 

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -25,6 +25,9 @@ import { parseGitUrl, parseVersionedPath, normalizeGitUrl } from './git-url-util
 /** 24-hour TTL for cached tag lists */
 const TAGS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+/** Default maximum wall-clock time for a Git operation. */
+const DEFAULT_GIT_TIMEOUT_MS = 60_000;
+
 /** Semver tag pattern: optional "v" prefix followed by major.minor.patch */
 const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+/;
 
@@ -148,7 +151,7 @@ export class GitRegistry implements Registry {
     this.subPath = options.path ?? '';
     this.auth = options.auth;
     this.cacheEnabled = options.cache?.enabled ?? true;
-    this.timeout = options.timeout ?? 60000;
+    this.timeout = options.timeout ?? DEFAULT_GIT_TIMEOUT_MS;
     this.cacheManager = new GitCacheManager({
       cacheDir: options.cacheDir,
       ttl: options.cache?.ttl,
@@ -1009,6 +1012,36 @@ export interface RemoteValidation {
 }
 
 /**
+ * Options for validating remote repository accessibility.
+ */
+export interface RemoteValidationOptions {
+  /** Maximum wall-clock time for each Git operation in milliseconds */
+  timeout?: number;
+}
+
+/**
+ * Create a non-interactive Git client with a hard operation timeout.
+ */
+function createRemoteValidationGit(baseDir: string | undefined, timeout: number): SimpleGit {
+  const options: Partial<SimpleGitOptions> = {
+    timeout: {
+      block: timeout,
+      stdErr: false,
+      stdOut: false,
+    },
+  };
+  const git = baseDir ? simpleGit(baseDir, options) : simpleGit(options);
+  git.env('GIT_TERMINAL_PROMPT', '0');
+  git.env('GCM_INTERACTIVE', 'never');
+  return git;
+}
+
+function isGitTimeoutError(error: Error): boolean {
+  const message = error.message.toLowerCase();
+  return message.includes('timeout') || message.includes('timed out');
+}
+
+/**
  * Validate that a remote Git repository is accessible via `git ls-remote`.
  *
  * Use this before writing a lockfile entry to catch auth/network problems early
@@ -1016,21 +1049,25 @@ export interface RemoteValidation {
  *
  * @param repoUrl - Repository URL to check (HTTPS or SSH)
  * @param ref - Optional branch, tag, or commit to resolve
+ * @param options - Optional Git operation timeout
  * @returns RemoteValidation result with accessibility status and optional commit hash
  */
 export async function validateRemoteAccess(
   repoUrl: string,
-  ref?: string
+  ref?: string,
+  options: RemoteValidationOptions = {}
 ): Promise<RemoteValidation> {
-  const git = simpleGit().env('GIT_TERMINAL_PROMPT', '0').env('GCM_INTERACTIVE', 'never');
+  const timeout =
+    options.timeout !== undefined && Number.isFinite(options.timeout) && options.timeout > 0
+      ? options.timeout
+      : DEFAULT_GIT_TIMEOUT_MS;
+  const git = createRemoteValidationGit(undefined, timeout);
   try {
     const isCommit = ref !== undefined && /^[0-9a-f]{40}$/i.test(ref);
     if (isCommit) {
       const probeDir = await fs.mkdtemp(join(tmpdir(), 'promptscript-ref-'));
       try {
-        const probe = simpleGit(probeDir)
-          .env('GIT_TERMINAL_PROMPT', '0')
-          .env('GCM_INTERACTIVE', 'never');
+        const probe = createRemoteValidationGit(probeDir, timeout);
         await probe.init();
         await probe.addRemote('origin', repoUrl);
         await probe.fetch(['origin', ref, '--depth=1']);
@@ -1075,6 +1112,13 @@ export async function validateRemoteAccess(
       return {
         accessible: false,
         error: `Authentication failed for ${repoUrl}. If behind a firewall/VPN, configure a GitHub personal access token.`,
+      };
+    }
+
+    if (isGitTimeoutError(error)) {
+      return {
+        accessible: false,
+        error: `Timed out after ${timeout}ms while contacting ${repoUrl}. Check your network connection and VPN settings.`,
       };
     }
 

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -1158,25 +1158,31 @@ function createRemoteValidationGit(baseDir: string | undefined, timeout: number)
 }
 
 function isGitTimeoutError(error: Error): boolean {
-  const message = error.message.toLowerCase();
   const errorWithCode = error as Error & { cause?: unknown; code?: unknown };
   const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
   const cause = errorWithCode.cause;
-  const causeMessage = cause instanceof Error ? cause.message.toLowerCase() : '';
   const causeCode =
     cause instanceof Error &&
     'code' in cause &&
     typeof (cause as { code?: unknown }).code === 'string'
       ? ((cause as { code: string }).code ?? '').toLowerCase()
       : '';
+
+  const containsTimeoutMessage = (message: string): boolean => {
+    const withoutUrlsAndRefs = message
+      .toLowerCase()
+      .replace(/\b[a-z][a-z\d+.-]*:\/\/[^\s'"]+|git@[\w.-]+:[^\s'"]+/g, '')
+      .replace(/\b(?:remote\s+)?ref(?:erence)?\s+["']?[^\s"']+/g, '')
+      .replace(/\bremote\s+branch\s+["']?[^\s"']+/g, '');
+    return /(?:^|[\s:()[\],.!?])(timeout|timed out|etimedout)(?=$|[\s:()[\],.!?])/i.test(
+      withoutUrlsAndRefs
+    );
+  };
+
   return (
-    message.includes('timeout') ||
-    message.includes('timed out') ||
-    message.includes('etimedout') ||
     code === 'etimedout' ||
-    causeMessage.includes('timeout') ||
-    causeMessage.includes('timed out') ||
-    causeMessage.includes('etimedout') ||
+    containsTimeoutMessage(error.message) ||
+    (cause instanceof Error && containsTimeoutMessage(cause.message)) ||
     causeCode === 'etimedout'
   );
 }

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -16,7 +16,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import type { SimpleGit, SimpleGitOptions } from 'simple-git';
 import { simpleGit } from 'simple-git';
-import { FileNotFoundError } from '@promptscript/core';
+import { FileNotFoundError, isGitTimeoutError } from '@promptscript/core';
 import type { Registry } from './registry.js';
 import { GitCacheManager } from './git-cache-manager.js';
 import type { RegistryCache } from './registry-cache.js';
@@ -1155,36 +1155,6 @@ function createRemoteValidationGit(baseDir: string | undefined, timeout: number)
   git.env('GIT_TERMINAL_PROMPT', '0');
   git.env('GCM_INTERACTIVE', 'never');
   return git;
-}
-
-function isGitTimeoutError(error: Error): boolean {
-  const errorWithCode = error as Error & { cause?: unknown; code?: unknown };
-  const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
-  const cause = errorWithCode.cause;
-  const causeCode =
-    cause instanceof Error &&
-    'code' in cause &&
-    typeof (cause as { code?: unknown }).code === 'string'
-      ? ((cause as { code: string }).code ?? '').toLowerCase()
-      : '';
-
-  const containsTimeoutMessage = (message: string): boolean => {
-    const withoutUrlsAndRefs = message
-      .toLowerCase()
-      .replace(/\b[a-z][a-z\d+.-]*:\/\/[^\s'"]+|git@[\w.-]+:[^\s'"]+/g, '')
-      .replace(/\b(?:remote\s+)?ref(?:erence)?\s+["']?[^\s"']+/g, '')
-      .replace(/\bremote\s+branch\s+["']?[^\s"']+/g, '');
-    return /(?:^|[\s:()[\],.!?])(timeout|timed out|etimedout)(?=$|[\s:()[\],.!?])/i.test(
-      withoutUrlsAndRefs
-    );
-  };
-
-  return (
-    code === 'etimedout' ||
-    containsTimeoutMessage(error.message) ||
-    (cause instanceof Error && containsTimeoutMessage(cause.message)) ||
-    causeCode === 'etimedout'
-  );
 }
 
 function createGitTimeoutError(url: string, timeout: number, cause: Error): GitCloneError {

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -207,7 +207,11 @@ export class GitRegistry implements Registry {
       const filePath = this.resolveFilePath(repoPath, basePath);
 
       return existsSync(filePath);
-    } catch {
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
       return false;
     }
   }
@@ -232,7 +236,11 @@ export class GitRegistry implements Registry {
 
       const entries = await fs.readdir(dirPath, { withFileTypes: true });
       return entries.map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
-    } catch {
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
       return [];
     }
   }

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -258,26 +258,71 @@ export class GitRegistry implements Registry {
    */
   async checkoutCommit(targetDir: string, commit: string): Promise<void> {
     const git = this.createGit(targetDir);
-    await git.raw(['config', 'core.autocrlf', 'false']);
-    await git.raw(['config', 'core.eol', 'lf']);
+    try {
+      await git.raw(['config', 'core.autocrlf', 'false']);
+      await git.raw(['config', 'core.eol', 'lf']);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
+      throw err;
+    }
+
     try {
       await git.fetch(['origin', commit, '--depth=1']);
-    } catch {
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
+
       // Commit may not be directly fetchable (shallow clone); try unshallow
       try {
         await git.fetch(['--unshallow']);
-      } catch {
+      } catch (unshallowErr) {
+        const error =
+          unshallowErr instanceof Error ? unshallowErr : new Error(String(unshallowErr));
+        if (isGitTimeoutError(error)) {
+          throw createGitTimeoutError(this.url, this.timeout, error);
+        }
+
         // If unshallow fails, try a full fetch
-        await git.fetch(['origin']);
+        try {
+          await git.fetch(['origin']);
+        } catch (fullFetchErr) {
+          const error =
+            fullFetchErr instanceof Error ? fullFetchErr : new Error(String(fullFetchErr));
+          if (isGitTimeoutError(error)) {
+            throw createGitTimeoutError(this.url, this.timeout, error);
+          }
+          throw fullFetchErr;
+        }
       }
     }
-    await git.checkout(commit);
-    await git.reset(['--hard', commit]);
+    try {
+      await git.checkout(commit);
+      await git.reset(['--hard', commit]);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
+      throw err;
+    }
   }
 
   /** Remove clone transport metadata before a repository is vendored. */
   async removeRemote(targetDir: string): Promise<void> {
-    await this.createGit(targetDir).raw(['remote', 'remove', 'origin']);
+    try {
+      await this.createGit(targetDir).raw(['remote', 'remove', 'origin']);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
+      throw err;
+    }
   }
 
   /**
@@ -291,8 +336,16 @@ export class GitRegistry implements Registry {
     const repoPath = await this.ensureCloned(targetRef);
 
     const git = this.createGit(repoPath);
-    const result = await git.revparse(['HEAD']);
-    return result.trim();
+    try {
+      const result = await git.revparse(['HEAD']);
+      return result.trim();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
+      throw err;
+    }
   }
 
   /**
@@ -323,6 +376,9 @@ export class GitRegistry implements Registry {
       await git.clone(cloneUrl, targetDir, cloneOptions);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(repoUrl, this.timeout, error);
+      }
       if (tag && this.isRefError(error)) {
         throw new GitRefNotFoundError(tag, repoUrl);
       }
@@ -334,6 +390,9 @@ export class GitRegistry implements Registry {
           } catch (fallbackErr) {
             const fbError =
               fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
+            if (isGitTimeoutError(fbError)) {
+              throw createGitTimeoutError(fallbackRepoUrl, this.timeout, fbError);
+            }
             if (this.isAccessError(fbError)) {
               throw new GitAuthError(
                 `Authentication failed for both ${repoUrl} and fallback ${fallbackRepoUrl}`,
@@ -376,7 +435,16 @@ export class GitRegistry implements Registry {
     }
 
     const git = this.createGit();
-    const raw = await git.listRemote(['--tags', this.auth ? this.transportUrl : repoUrl]);
+    let raw: string;
+    try {
+      raw = await git.listRemote(['--tags', this.auth ? this.transportUrl : repoUrl]);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(repoUrl, this.timeout, error);
+      }
+      throw err;
+    }
 
     // Parse "abc123\trefs/tags/v1.0.0" lines; strip peeled tag suffixes (^{})
     const tags = [
@@ -442,6 +510,9 @@ export class GitRegistry implements Registry {
       await this.doCloneSparse(git, repoUrl, ref, targetDir, sparsePath);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(repoUrl, this.timeout, error);
+      }
       if (this.isAccessError(error) && fallbackRepoUrl) {
         try {
           await this.doCloneSparse(git, fallbackRepoUrl, ref, targetDir, sparsePath);
@@ -449,6 +520,9 @@ export class GitRegistry implements Registry {
         } catch (fallbackErr) {
           const fbError =
             fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
+          if (isGitTimeoutError(fbError)) {
+            throw createGitTimeoutError(fallbackRepoUrl, this.timeout, fbError);
+          }
           if (this.isAccessError(fbError)) {
             throw new GitAuthError(
               `Authentication failed for both ${repoUrl} and fallback ${fallbackRepoUrl}`,
@@ -523,7 +597,10 @@ export class GitRegistry implements Registry {
           const commitHash = await this.getCurrentCommit(entry.path);
           await this.cacheManager.touch(this.url, ref, commitHash);
           return entry.path;
-        } catch {
+        } catch (err) {
+          if (err instanceof Error && isGitTimeoutError(err)) {
+            throw err;
+          }
           // If fetch fails, try a fresh clone
           await this.cacheManager.remove(this.url, ref);
         }
@@ -564,6 +641,10 @@ export class GitRegistry implements Registry {
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
 
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
+
       // Check if ref doesn't exist first (more specific than auth errors)
       // A "branch not found" can sometimes look like an auth error to git
       if (this.isRefError(error)) {
@@ -575,6 +656,9 @@ export class GitRegistry implements Registry {
           await repoGit.checkout(ref);
         } catch (fetchErr) {
           const fetchError = fetchErr instanceof Error ? fetchErr : new Error(String(fetchErr));
+          if (isGitTimeoutError(fetchError)) {
+            throw createGitTimeoutError(this.url, this.timeout, fetchError);
+          }
           if (this.isRefError(fetchError)) {
             throw new GitRefNotFoundError(ref, this.url);
           }
@@ -634,6 +718,9 @@ export class GitRegistry implements Registry {
       await git.clone(url, targetPath, ['--depth=1', `--branch=${ref}`, '--single-branch']);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(url, this.timeout, error);
+      }
       if (this.isRefError(error)) {
         try {
           await git.clone(url, targetPath, ['--depth=1']);
@@ -642,6 +729,9 @@ export class GitRegistry implements Registry {
           await repoGit.checkout(ref);
         } catch (fetchErr) {
           const fetchError = fetchErr instanceof Error ? fetchErr : new Error(String(fetchErr));
+          if (isGitTimeoutError(fetchError)) {
+            throw createGitTimeoutError(url, this.timeout, fetchError);
+          }
           if (this.isRefError(fetchError)) {
             throw new GitRefNotFoundError(ref, url);
           }
@@ -669,6 +759,9 @@ export class GitRegistry implements Registry {
       await git.reset(['--hard', `origin/${ref}`]);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
 
       // If ref is a tag or commit, try direct checkout
       if (this.isRefError(error)) {
@@ -676,7 +769,11 @@ export class GitRegistry implements Registry {
           await git.fetch(['origin', '--tags', '--depth=1']);
           await git.checkout(ref);
           return;
-        } catch {
+        } catch (fallbackErr) {
+          const error = fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
+          if (isGitTimeoutError(error)) {
+            throw createGitTimeoutError(this.url, this.timeout, error);
+          }
           throw new GitRefNotFoundError(ref, this.url);
         }
       }
@@ -690,8 +787,16 @@ export class GitRegistry implements Registry {
    */
   private async getCurrentCommit(repoPath: string): Promise<string> {
     const git = this.createGit(repoPath);
-    const result = await git.revparse(['HEAD']);
-    return result.trim();
+    try {
+      const result = await git.revparse(['HEAD']);
+      return result.trim();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (isGitTimeoutError(error)) {
+        throw createGitTimeoutError(this.url, this.timeout, error);
+      }
+      throw err;
+    }
   }
 
   /**
@@ -1046,13 +1151,36 @@ function createRemoteValidationGit(baseDir: string | undefined, timeout: number)
 
 function isGitTimeoutError(error: Error): boolean {
   const message = error.message.toLowerCase();
-  const errorWithCode = error as Error & { code?: unknown };
+  const errorWithCode = error as Error & { cause?: unknown; code?: unknown };
   const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
+  const cause = errorWithCode.cause;
+  const causeMessage = cause instanceof Error ? cause.message.toLowerCase() : '';
+  const causeCode =
+    cause instanceof Error &&
+    'code' in cause &&
+    typeof (cause as { code?: unknown }).code === 'string'
+      ? ((cause as { code: string }).code ?? '').toLowerCase()
+      : '';
   return (
     message.includes('timeout') ||
     message.includes('timed out') ||
     message.includes('etimedout') ||
-    code === 'etimedout'
+    code === 'etimedout' ||
+    causeMessage.includes('timeout') ||
+    causeMessage.includes('timed out') ||
+    causeMessage.includes('etimedout') ||
+    causeCode === 'etimedout'
+  );
+}
+
+function createGitTimeoutError(url: string, timeout: number, cause: Error): GitCloneError {
+  if (cause instanceof GitCloneError && isGitTimeoutError(cause)) {
+    return cause;
+  }
+  return new GitCloneError(
+    `Git operation timed out after ${timeout}ms while contacting ${url}`,
+    url,
+    cause
   );
 }
 

--- a/packages/resolver/src/git-registry.ts
+++ b/packages/resolver/src/git-registry.ts
@@ -26,10 +26,16 @@ import { parseGitUrl, parseVersionedPath, normalizeGitUrl } from './git-url-util
 const TAGS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 /** Default maximum wall-clock time for a Git operation. */
-const DEFAULT_GIT_TIMEOUT_MS = 60_000;
+export const DEFAULT_GIT_TIMEOUT_MS = 60_000;
 
 /** Semver tag pattern: optional "v" prefix followed by major.minor.patch */
 const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+/;
+
+function normalizeGitTimeout(timeout: number | undefined): number {
+  return timeout !== undefined && Number.isFinite(timeout) && timeout > 0
+    ? timeout
+    : DEFAULT_GIT_TIMEOUT_MS;
+}
 
 /**
  * Authentication options for Git registry.
@@ -151,7 +157,7 @@ export class GitRegistry implements Registry {
     this.subPath = options.path ?? '';
     this.auth = options.auth;
     this.cacheEnabled = options.cache?.enabled ?? true;
-    this.timeout = options.timeout ?? DEFAULT_GIT_TIMEOUT_MS;
+    this.timeout = normalizeGitTimeout(options.timeout);
     this.cacheManager = new GitCacheManager({
       cacheDir: options.cacheDir,
       ttl: options.cache?.ttl,
@@ -710,6 +716,8 @@ export class GitRegistry implements Registry {
     const options: Partial<SimpleGitOptions> = {
       timeout: {
         block: this.timeout,
+        stdErr: false,
+        stdOut: false,
       },
     };
 
@@ -1038,7 +1046,14 @@ function createRemoteValidationGit(baseDir: string | undefined, timeout: number)
 
 function isGitTimeoutError(error: Error): boolean {
   const message = error.message.toLowerCase();
-  return message.includes('timeout') || message.includes('timed out');
+  const errorWithCode = error as Error & { code?: unknown };
+  const code = typeof errorWithCode.code === 'string' ? errorWithCode.code.toLowerCase() : '';
+  return (
+    message.includes('timeout') ||
+    message.includes('timed out') ||
+    message.includes('etimedout') ||
+    code === 'etimedout'
+  );
 }
 
 /**
@@ -1057,10 +1072,7 @@ export async function validateRemoteAccess(
   ref?: string,
   options: RemoteValidationOptions = {}
 ): Promise<RemoteValidation> {
-  const timeout =
-    options.timeout !== undefined && Number.isFinite(options.timeout) && options.timeout > 0
-      ? options.timeout
-      : DEFAULT_GIT_TIMEOUT_MS;
+  const timeout = normalizeGitTimeout(options.timeout);
   const git = createRemoteValidationGit(undefined, timeout);
   try {
     const isCommit = ref !== undefined && /^[0-9a-f]{40}$/i.test(ref);
@@ -1103,6 +1115,13 @@ export async function validateRemoteAccess(
     const error = err instanceof Error ? err : new Error(String(err));
     const msg = error.message.toLowerCase();
 
+    if (isGitTimeoutError(error)) {
+      return {
+        accessible: false,
+        error: `Timed out after ${timeout}ms while contacting ${repoUrl}. Check your network connection and VPN settings.`,
+      };
+    }
+
     if (
       msg.includes('authentication') ||
       msg.includes('could not read from remote') ||
@@ -1112,13 +1131,6 @@ export async function validateRemoteAccess(
       return {
         accessible: false,
         error: `Authentication failed for ${repoUrl}. If behind a firewall/VPN, configure a GitHub personal access token.`,
-      };
-    }
-
-    if (isGitTimeoutError(error)) {
-      return {
-        accessible: false,
-        error: `Timed out after ${timeout}ms while contacting ${repoUrl}. Check your network connection and VPN settings.`,
       };
     }
 

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -47,6 +47,7 @@ export {
   GitCloneError,
   GitAuthError,
   GitRefNotFoundError,
+  DEFAULT_GIT_TIMEOUT_MS,
   type GitRegistryOptions,
   type GitAuthOptions,
   type RemoteValidation,

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -50,6 +50,7 @@ export {
   type GitRegistryOptions,
   type GitAuthOptions,
   type RemoteValidation,
+  type RemoteValidationOptions,
 } from './git-registry.js';
 
 // Git utilities


### PR DESCRIPTION
## Summary
- Bound Git clone, fetch, checkout, and registry operations with actionable timeouts.
- Classify timeouts before authentication failures, avoid timeout fallback retries, and ignore timeout words embedded only in URLs or refs.
- Serialize `skills add` transactions with project locks and atomic stale-lock quarantine.
- Preserve file modes, reject symlink replacement, use same-directory atomic writes, clean temporary files, and guard rollback against concurrent edits.
- Propagate Git timeouts through registry `exists` and `list` operations.
- Document the timeout and transaction behavior and add regression coverage.

## Verification
- Full eight-step repository verification passed.
- All GitHub CI checks are green.

Closes #400