### PR TITLE
fix(resolver): scope local discovery to project root

### DIFF
--- a/packages/compiler/src/__tests__/project-root-isolation.spec.ts
+++ b/packages/compiler/src/__tests__/project-root-isolation.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Compiler } from '../compiler.js';
+
+const directories: string[] = [];
+
+function createDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  directories.push(directory);
+  return directory;
+}
+
+function writeSkill(root: string, name: string): void {
+  const skillDir = join(root, 'skills', name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---
+name: ${name}
+description: Skill fixture for project root isolation
+---
+
+Skill body for ${name}.
+`
+  );
+}
+
+function writeEntry(root: string): string {
+  const entryPath = join(root, 'project.prs');
+  writeFileSync(
+    entryPath,
+    `@meta {
+  id: "project-root-isolation"
+  syntax: "1.4.0"
+}
+
+@identity {
+  role: "Test project"
+}
+`
+  );
+  return entryPath;
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('project root isolation', () => {
+  it('should not discover skills outside the project root', async () => {
+    const outside = createDirectory('promptscript-outside-');
+    writeSkill(outside, 'leaked-skill');
+    const project = createDirectory('promptscript-project-');
+    const entryPath = writeEntry(project);
+
+    const originalCwd = process.cwd();
+    process.chdir(outside);
+    try {
+      const compiler = new Compiler({
+        resolver: { registryPath: project, projectRoot: project },
+        formatters: [{ name: 'claude', config: { version: 'full' } }],
+      });
+
+      const result = await compiler.compile(entryPath);
+
+      expect(result.success).toBe(true);
+      expect([...result.outputs.keys()]).not.toContain('.claude/skills/leaked-skill/SKILL.md');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should discover skills inside the project root without an explicit local path', async () => {
+    const outside = createDirectory('promptscript-outside-');
+    const project = createDirectory('promptscript-project-');
+    writeSkill(project, 'owned-skill');
+    const entryPath = writeEntry(project);
+
+    const originalCwd = process.cwd();
+    process.chdir(outside);
+    try {
+      const compiler = new Compiler({
+        resolver: { registryPath: project, projectRoot: project },
+        formatters: [{ name: 'claude', config: { version: 'full' } }],
+      });
+
+      const result = await compiler.compile(entryPath);
+
+      expect(result.success).toBe(true);
+      expect([...result.outputs.keys()]).toContain('.claude/skills/owned-skill/SKILL.md');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/packages/resolver/src/__tests__/loader.spec.ts
+++ b/packages/resolver/src/__tests__/loader.spec.ts
@@ -28,6 +28,23 @@ describe('FileLoader', () => {
       });
       expect(loader.getLocalPath()).toBe('/local');
     });
+
+    it('should fall back to project root instead of cwd', () => {
+      const loader = new FileLoader({
+        registryPath: '/registry',
+        projectRoot: '/project',
+      });
+      expect(loader.getLocalPath()).toBe('/project');
+    });
+
+    it('should prefer explicit local path over project root', () => {
+      const loader = new FileLoader({
+        registryPath: '/registry',
+        localPath: '/project/.promptscript',
+        projectRoot: '/project',
+      });
+      expect(loader.getLocalPath()).toBe('/project/.promptscript');
+    });
   });
 
   describe('load', () => {

--- a/packages/resolver/src/loader.ts
+++ b/packages/resolver/src/loader.ts
@@ -56,7 +56,7 @@ export function buildRegistryMarker(repoUrl: string, path: string, version: stri
 export interface LoaderOptions {
   /** Base path for registry lookups (@namespace/...) */
   registryPath: string;
-  /** Base path for local/relative file resolution */
+  /** Base path for local/relative file resolution (defaults to projectRoot, then cwd) */
   localPath?: string;
   /** Project root used as the traversal safety boundary */
   projectRoot?: string;
@@ -79,7 +79,9 @@ export class FileLoader {
 
   constructor(options: LoaderOptions) {
     this.registryPath = options.registryPath;
-    this.localPath = resolve(options.localPath ?? process.cwd());
+    // Falling back to cwd when a projectRoot is declared would resolve local
+    // skills, commands and agents from outside the project being compiled.
+    this.localPath = resolve(options.localPath ?? options.projectRoot ?? process.cwd());
     this.projectRoot = resolve(
       options.projectRoot ??
         (basename(this.localPath) === '.promptscript' ? dirname(this.localPath) : this.localPath)


### PR DESCRIPTION
## Problem

`FileLoader` defaulted `localPath` to `process.cwd()` even when a `projectRoot` was supplied:

```ts
this.localPath = resolve(options.localPath ?? process.cwd());
this.projectRoot = resolve(options.projectRoot ?? /* inferred from localPath */);
```

The inference was one-way: `projectRoot` could be derived from `localPath`, never the reverse. Local discovery of skills, commands and agents keys off `localPath` (`resolveNativeSkills` scans `resolve(localPath, 'skills')`), so a caller that declares `projectRoot` and omits `localPath` silently pulls content from the process working directory instead of the project being compiled.

## Impact

Any programmatic consumer that sets only `projectRoot` absorbs skills, commands and agents from outside its declared project root. That is a correctness problem and a content-provenance problem: files nobody declared end up compiled into the outputs.

It also made the compiler test suite cwd-dependent. `hooks-targets.smoke.spec.ts` constructs:

```ts
new Compiler({ resolver: { registryPath: directory, projectRoot: directory } })
```

Run through `nx test compiler` it passes. Run as `vitest --root packages/compiler` from the repository root it fails: this repo's own `skills/promptscript/SKILL.md` gets discovered, `cursor` and `codex` both emit `.agents/skills/promptscript/SKILL.md`, and PS4001 fires on the collision. The suite was green only because of where the runner happened to be invoked from.

## Fix

`localPath` now falls back to `projectRoot` before `process.cwd()`. The existing `.promptscript`-basename inference for `projectRoot` is unchanged.

Every CLI call site passes `localPath` explicitly (`validate.ts`, `resolve-cmd.ts`, `check.ts`, `skills.ts`, `diff.ts`), so CLI behaviour is untouched. The new fallback only affects callers that were getting cwd by accident.

## Tests

- `loader.spec.ts`: `localPath` falls back to `projectRoot`; an explicit `localPath` still wins over `projectRoot`.
- `project-root-isolation.spec.ts` (new): compiles a temp project with `projectRoot` set while cwd is a different directory containing `skills/leaked-skill/SKILL.md`. Asserts the outside skill is not emitted, and asserts the positive control that a skill inside the project root still is.

Both new compiler tests fail on `main` and pass with this change, so the coverage is not vacuous.

## Verification

All eight pipeline steps green: format, lint, typecheck, test (12 projects), `prs validate --strict`, `schema:check`, `skill:check`, `grammar:check`. The compiler suite now passes from the repository root as well as through `nx`.

## Follow-up, not in this PR

With the leak closed, the `cursor`/`codex` collision no longer fires spuriously, but it is still reachable: `cursor.ts` emits user skills to `.agents/skills/<name>/SKILL.md` in full mode, while `target-catalog.ts` declares cursor `skillPath: { basePath: null, fileName: null }` and `hasSkills: false`. Enabling `cursor` and `codex` together with any user-defined skill still produces a genuine PS4001. That is a product decision (is `.agents/skills` intended for cursor?) and deserves its own issue.
