### PR TITLE
fix(compiler): only report collisions on differing content

### DIFF
--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -884,6 +884,72 @@ describe('Compiler', () => {
       expect(result.outputs.get('AGENTS.md')?.managedOutputFiles).toEqual(['.factory/hooks.json']);
     });
 
+    it('should not warn when formatters write identical content to one path', async () => {
+      const ast = createTestProgram();
+      const formatter1 = createMockFormatter('codex', 'AGENTS.md');
+      const formatter2 = createMockFormatter('amp', 'AGENTS.md');
+      vi.mocked(formatter1.format).mockReturnValue({
+        path: 'AGENTS.md',
+        content: '# Shared AGENTS output',
+      });
+      vi.mocked(formatter2.format).mockReturnValue({
+        path: 'AGENTS.md',
+        content: '# Shared AGENTS output',
+      });
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [formatter1, formatter2],
+      });
+
+      const result = await compiler.compile('./test.prs');
+
+      expect(result.success).toBe(true);
+      expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(false);
+      expect(result.outputs.get('AGENTS.md')?.content).toContain('# Shared AGENTS output');
+    });
+
+    it('should not warn when formatters emit an identical additional file', async () => {
+      const ast = createTestProgram();
+      const sharedSkill = {
+        path: '.agents/skills/demo/SKILL.md',
+        content: '---\nname: demo\n---\n\nShared body.\n',
+      };
+      const formatter1: Formatter = {
+        ...createMockFormatter('codex', 'AGENTS.md'),
+        format: vi.fn(() => ({
+          path: 'AGENTS.md',
+          content: '# Codex',
+          additionalFiles: [sharedSkill],
+        })),
+      };
+      const formatter2: Formatter = {
+        ...createMockFormatter('cursor', '.cursor/rules/project.mdc'),
+        format: vi.fn(() => ({
+          path: '.cursor/rules/project.mdc',
+          content: '# Cursor',
+          additionalFiles: [sharedSkill],
+        })),
+      };
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [formatter1, formatter2],
+      });
+
+      const result = await compiler.compile('./test.prs');
+
+      expect(result.success).toBe(true);
+      expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(false);
+      expect(result.outputs.has('.agents/skills/demo/SKILL.md')).toBe(true);
+    });
+
     it('should warn and skip when additional file collides with existing output (PS4001)', async () => {
       const ast = createTestProgram();
 
@@ -1238,7 +1304,7 @@ describe('Compiler', () => {
       expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(true);
     });
 
-    it('should produce collision warning when two formatters share dotDir', async () => {
+    it('should not warn when two formatters share dotDir with identical content', async () => {
       const ast = createTestProgram();
       const cline = createMockFormatter('cline', '.clinerules', '.agents/skills', 'SKILL.md');
       const codex = createMockFormatter('codex', 'AGENTS.md', '.agents/skills', 'SKILL.md');
@@ -1253,7 +1319,27 @@ describe('Compiler', () => {
       const collisionWarnings = result.warnings.filter(
         (w) => w.ruleId === 'PS4001' && w.message.includes('.agents/skills/promptscript/SKILL.md')
       );
-      expect(collisionWarnings.length).toBeGreaterThanOrEqual(1);
+      expect(collisionWarnings).toEqual([]);
+    });
+
+    it('should warn when two formatters share dotDir with different content', async () => {
+      const ast = createTestProgram();
+      const cline = createMockFormatter('cline', '.clinerules', '.agents/skills', 'SKILL.md');
+      const codex: Formatter = {
+        ...createMockFormatter('codex', 'AGENTS.md', '.agents/skills', 'SKILL.md'),
+        transformInjectedSkillContent: (content: string) => `${content}\n<!-- codex flavour -->`,
+      };
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = createTestCompiler({ formatters: [cline, codex], skillContent });
+      const result = await compiler.compile('test.prs');
+      expect(result.success).toBe(true);
+      const collisionWarnings = result.warnings.filter(
+        (w) => w.ruleId === 'PS4001' && w.message.includes('.agents/skills/promptscript/SKILL.md')
+      );
+      expect(collisionWarnings.length).toBe(1);
     });
 
     it('should inject skill for multiple formatters with different paths', async () => {

--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -909,7 +909,84 @@ describe('Compiler', () => {
 
       expect(result.success).toBe(true);
       expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(false);
-      expect(result.outputs.get('AGENTS.md')?.content).toContain('# Shared AGENTS output');
+      expect(result.outputs.get('AGENTS.md')?.content).toMatch(
+        /^# Shared AGENTS output\n\n<!-- PromptScript .* \| target: codex - do not edit -->$/
+      );
+      expect(result.outputs.get('AGENTS.md')?.content).not.toContain(
+        '| target: amp - do not edit -->'
+      );
+    });
+
+    it('should preserve the first owner for identical main output collisions', async () => {
+      const ast = createTestProgram();
+      const formatterA = createMockFormatter('formatter-a', 'shared.md');
+      const formatterB = createMockFormatter('formatter-b', 'shared.md');
+      const formatterC = createMockFormatter('formatter-c', 'shared.md');
+      vi.mocked(formatterA.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# Shared content',
+      });
+      vi.mocked(formatterB.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# Shared content',
+      });
+      vi.mocked(formatterC.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# Different content',
+      });
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [formatterA, formatterB, formatterC],
+      });
+
+      const result = await compiler.compile('./test.prs');
+
+      expect(result.success).toBe(true);
+      const collisionWarnings = result.warnings.filter((w) => w.ruleId === 'PS4001');
+      expect(collisionWarnings).toHaveLength(1);
+      expect(collisionWarnings[0]?.message).toContain("'formatter-a'");
+      expect(collisionWarnings[0]?.message).toContain("'formatter-c'");
+    });
+
+    it('should warn when main output returns to the first content after a difference', async () => {
+      const ast = createTestProgram();
+      const formatterA = createMockFormatter('formatter-a', 'shared.md');
+      const formatterB = createMockFormatter('formatter-b', 'shared.md');
+      const formatterC = createMockFormatter('formatter-c', 'shared.md');
+      vi.mocked(formatterA.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# First content',
+      });
+      vi.mocked(formatterB.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# Different content',
+      });
+      vi.mocked(formatterC.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# First content',
+      });
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [formatterA, formatterB, formatterC],
+      });
+
+      const result = await compiler.compile('./test.prs');
+
+      expect(result.success).toBe(true);
+      const collisionWarnings = result.warnings.filter((w) => w.ruleId === 'PS4001');
+      expect(collisionWarnings).toHaveLength(2);
+      expect(collisionWarnings[0]?.message).toContain("'formatter-a'");
+      expect(collisionWarnings[0]?.message).toContain("'formatter-b'");
+      expect(collisionWarnings[1]?.message).toContain("'formatter-b'");
+      expect(collisionWarnings[1]?.message).toContain("'formatter-c'");
     });
 
     it('should not warn when formatters emit an identical additional file', async () => {
@@ -1247,7 +1324,7 @@ describe('Compiler', () => {
       expect(result.outputs.has('.gemini/skills/promptscript/SKILL.md')).toBe(false);
     });
 
-    it('should silently skip auto-injection when same formatter already output the skill', async () => {
+    it('should warn when same formatter already output a different skill', async () => {
       const ast = createTestProgram();
       const formatter: Formatter = {
         ...createMockFormatter('claude', 'CLAUDE.md', '.claude/skills', 'SKILL.md'),
@@ -1271,8 +1348,7 @@ describe('Compiler', () => {
       expect(result.success).toBe(true);
       const skillOutput = result.outputs.get('.claude/skills/promptscript/SKILL.md');
       expect(skillOutput?.content).toContain('User-defined promptscript skill');
-      // Same formatter → no warning (auto-discovered skill takes precedence silently)
-      expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(false);
+      expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(true);
     });
 
     it('should warn when different formatter already output the skill at same path', async () => {

--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -917,6 +917,73 @@ describe('Compiler', () => {
       );
     });
 
+    it('should merge managed metadata from identical main output collisions', async () => {
+      const ast = createTestProgram();
+      const formatter1 = createMockFormatter('codex', 'AGENTS.md');
+      const formatter2 = createMockFormatter('amp', 'AGENTS.md');
+      vi.mocked(formatter1.format).mockReturnValue({
+        path: 'AGENTS.md',
+        content: '# Shared AGENTS output',
+        managedOutputDirectories: ['.codex/rules'],
+        managedOutputFiles: ['.codex/settings.json'],
+      });
+      vi.mocked(formatter2.format).mockReturnValue({
+        path: 'AGENTS.md',
+        content: '# Shared AGENTS output',
+        managedOutputDirectories: ['.amp/rules'],
+        managedOutputFiles: ['.amp/settings.json'],
+      });
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [formatter1, formatter2],
+      });
+
+      const result = await compiler.compile('./test.prs');
+
+      expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(false);
+      expect(result.outputs.get('AGENTS.md')?.managedOutputDirectories).toEqual([
+        '.codex/rules',
+        '.amp/rules',
+      ]);
+      expect(result.outputs.get('AGENTS.md')?.managedOutputFiles).toEqual([
+        '.codex/settings.json',
+        '.amp/settings.json',
+      ]);
+    });
+
+    it('should warn when identical main content has different write settings', async () => {
+      const ast = createTestProgram();
+      const formatter1 = createMockFormatter('formatter-a', 'shared.md');
+      const formatter2 = createMockFormatter('formatter-b', 'shared.md');
+      vi.mocked(formatter1.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# Shared content',
+        mode: 0o644,
+      });
+      vi.mocked(formatter2.format).mockReturnValue({
+        path: 'shared.md',
+        content: '# Shared content',
+        mode: 0o755,
+      });
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [formatter1, formatter2],
+      });
+
+      const result = await compiler.compile('./test.prs');
+
+      expect(result.warnings.filter((w) => w.ruleId === 'PS4001')).toHaveLength(1);
+      expect(result.outputs.get('shared.md')?.mode).toBe(0o755);
+    });
+
     it('should preserve the first owner for identical main output collisions', async () => {
       const ast = createTestProgram();
       const formatterA = createMockFormatter('formatter-a', 'shared.md');
@@ -1025,6 +1092,41 @@ describe('Compiler', () => {
       expect(result.success).toBe(true);
       expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(false);
       expect(result.outputs.has('.agents/skills/demo/SKILL.md')).toBe(true);
+    });
+
+    it('should warn when identical additional content has different modes', async () => {
+      const ast = createTestProgram();
+      const formatter1: Formatter = {
+        ...createMockFormatter('formatter-a', 'a.md'),
+        format: vi.fn(() => ({
+          path: 'a.md',
+          content: '# A',
+          additionalFiles: [{ path: 'scripts/run.sh', content: 'echo test\n', mode: 0o644 }],
+        })),
+      };
+      const formatter2: Formatter = {
+        ...createMockFormatter('formatter-b', 'b.md'),
+        format: vi.fn(() => ({
+          path: 'b.md',
+          content: '# B',
+          additionalFiles: [{ path: 'scripts/run.sh', content: 'echo test\n', mode: 0o755 }],
+        })),
+      };
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [formatter1, formatter2],
+      });
+
+      const result = await compiler.compile('./test.prs');
+
+      const collisionWarning = result.warnings.find((w) => w.ruleId === 'PS4001');
+      expect(collisionWarning?.message).toContain('write settings');
+      expect(collisionWarning?.message).toContain('first output will be preserved');
+      expect(result.outputs.get('scripts/run.sh')?.mode).toBe(0o644);
     });
 
     it('should warn and skip when additional file collides with existing output (PS4001)', async () => {
@@ -1349,6 +1451,40 @@ describe('Compiler', () => {
       const skillOutput = result.outputs.get('.claude/skills/promptscript/SKILL.md');
       expect(skillOutput?.content).toContain('User-defined promptscript skill');
       expect(result.warnings.some((w) => w.ruleId === 'PS4001')).toBe(true);
+    });
+
+    it('should report injected skill transform failures as formatter errors', async () => {
+      const ast = createTestProgram();
+      const formatter: Formatter = {
+        ...createMockFormatter('claude', 'CLAUDE.md', '.claude/skills', 'SKILL.md'),
+        format: vi.fn(() => ({
+          path: 'CLAUDE.md',
+          content: '# Claude',
+          additionalFiles: [
+            {
+              path: '.claude/skills/promptscript/SKILL.md',
+              content: skillContent,
+            },
+          ],
+        })),
+        transformInjectedSkillContent: () => {
+          throw new Error('invalid injected skill');
+        },
+      };
+
+      mockResolve.mockResolvedValue(createResolveSuccess(ast));
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      const compiler = createTestCompiler({ formatters: [formatter], skillContent });
+      const result = await compiler.compile('test.prs');
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: 'PS4000',
+          message: expect.stringContaining('invalid injected skill'),
+        })
+      );
     });
 
     it('should warn when different formatter already output the skill at same path', async () => {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -434,6 +434,10 @@ export class Compiler {
     const formatErrors: CompileError[] = [];
     const formatWarnings: ValidationMessage[] = [];
     const outputPathOwners = new Map<string, string>();
+    // Content as produced by the formatter, before the generated marker is added.
+    // Markers embed the target name and a timestamp, so comparing marked content
+    // would report every shared path as a conflict.
+    const outputPathContents = new Map<string, string>();
 
     for (const { formatter, config } of this.loadedFormatters) {
       const formatterStart = Date.now();
@@ -459,18 +463,25 @@ export class Compiler {
           });
         }
 
-        // Warn if multiple formatters target the same output path
+        // Warn if multiple formatters target the same output path with different content
         const existingOwner = outputPathOwners.get(output.path);
         if (existingOwner) {
-          formatWarnings.push({
-            ruleId: 'PS4001',
-            ruleName: 'output-path-collision',
-            severity: 'warning',
-            message: `Output path '${output.path}' is written by both '${existingOwner}' and '${formatter.name}'. The latter will overwrite the former.`,
-            suggestion: `Configure distinct output paths for these formatters, or disable one of them.`,
-          });
+          if (outputPathContents.get(output.path) === output.content) {
+            this.logger.debug(
+              `  Output path '${output.path}' already written by '${existingOwner}' with identical content. No conflict.`
+            );
+          } else {
+            formatWarnings.push({
+              ruleId: 'PS4001',
+              ruleName: 'output-path-collision',
+              severity: 'warning',
+              message: `Output path '${output.path}' is written by both '${existingOwner}' and '${formatter.name}' with different content. The latter will overwrite the former.`,
+              suggestion: `Configure distinct output paths for these formatters, or disable one of them.`,
+            });
+          }
         }
         outputPathOwners.set(output.path, formatter.name);
+        outputPathContents.set(output.path, output.content);
 
         // Add PromptScript marker to all outputs for overwrite detection
         const markedOutput = addMarkerToOutput(output, sourceLabel, formatter.name);
@@ -503,13 +514,19 @@ export class Compiler {
             // Check for path collisions with previously written outputs
             const existingAdditionalOwner = outputPathOwners.get(additionalFile.path);
             if (existingAdditionalOwner) {
-              formatWarnings.push({
-                ruleId: 'PS4001',
-                ruleName: 'output-path-collision',
-                severity: 'warning',
-                message: `Output path '${additionalFile.path}' is written by both '${existingAdditionalOwner}' and '${formatter.name}'. The latter will overwrite the former.`,
-                suggestion: `Configure distinct output paths for these formatters, or disable one of them.`,
-              });
+              if (outputPathContents.get(additionalFile.path) === additionalFile.content) {
+                this.logger.debug(
+                  `  Output path '${additionalFile.path}' already written by '${existingAdditionalOwner}' with identical content. No conflict.`
+                );
+              } else {
+                formatWarnings.push({
+                  ruleId: 'PS4001',
+                  ruleName: 'output-path-collision',
+                  severity: 'warning',
+                  message: `Output path '${additionalFile.path}' is written by both '${existingAdditionalOwner}' and '${formatter.name}' with different content. The latter will overwrite the former.`,
+                  suggestion: `Configure distinct output paths for these formatters, or disable one of them.`,
+                });
+              }
               // Skip writing this additional file — preserve the original owner's output
               if (additionalFile.additionalFiles) {
                 queue.push(...additionalFile.additionalFiles);
@@ -517,6 +534,7 @@ export class Compiler {
               continue;
             }
             outputPathOwners.set(additionalFile.path, formatter.name);
+            outputPathContents.set(additionalFile.path, additionalFile.content);
 
             outputs.set(
               additionalFile.path,
@@ -556,12 +574,19 @@ export class Compiler {
         }
 
         const skillPath = `${skillBasePath}/promptscript/${skillFileName}`;
+        const injectedContent = formatter.transformInjectedSkillContent
+          ? formatter.transformInjectedSkillContent(this.options.skillContent)
+          : this.options.skillContent;
         const existingOwner = outputPathOwners.get(skillPath);
         if (existingOwner) {
           // If the same formatter already output the promptscript skill (e.g. via
           // auto-discovered @skills block), silently skip — the content is identical.
           // Only warn when a *different* formatter caused the collision.
-          if (existingOwner !== formatter.name) {
+          if (outputPathContents.get(skillPath) === injectedContent) {
+            this.logger.debug(
+              `  Skill path '${skillPath}' already written by '${existingOwner}' with identical content. No conflict.`
+            );
+          } else if (existingOwner !== formatter.name) {
             formatWarnings.push({
               ruleId: 'PS4001',
               ruleName: 'output-path-collision',
@@ -577,12 +602,11 @@ export class Compiler {
           continue;
         }
         outputPathOwners.set(skillPath, `${formatter.name}:promptscript-skill`);
+        outputPathContents.set(skillPath, injectedContent);
 
         const skillOutput: FormatterOutput = {
           path: skillPath,
-          content: formatter.transformInjectedSkillContent
-            ? formatter.transformInjectedSkillContent(this.options.skillContent)
-            : this.options.skillContent,
+          content: injectedContent,
         };
         outputs.set(skillPath, addMarkerToOutput(skillOutput, sourceLabel, 'promptscript'));
         this.logger.verbose(`  → ${skillPath} (auto-injected promptscript skill)`);

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -465,8 +465,10 @@ export class Compiler {
 
         // Warn if multiple formatters target the same output path with different content
         const existingOwner = outputPathOwners.get(output.path);
-        if (existingOwner) {
-          if (outputPathContents.get(output.path) === output.content) {
+        const isIdenticalOutput =
+          existingOwner !== undefined && outputPathContents.get(output.path) === output.content;
+        if (existingOwner !== undefined) {
+          if (isIdenticalOutput) {
             this.logger.debug(
               `  Output path '${output.path}' already written by '${existingOwner}' with identical content. No conflict.`
             );
@@ -480,28 +482,32 @@ export class Compiler {
             });
           }
         }
-        outputPathOwners.set(output.path, formatter.name);
-        outputPathContents.set(output.path, output.content);
 
-        // Add PromptScript marker to all outputs for overwrite detection
-        const markedOutput = addMarkerToOutput(output, sourceLabel, formatter.name);
-        const previousManagedDirectories = outputs.get(output.path)?.managedOutputDirectories ?? [];
-        const previousManagedFiles = outputs.get(output.path)?.managedOutputFiles ?? [];
-        const managedOutputDirectories = [
-          ...new Set([
-            ...previousManagedDirectories,
-            ...(markedOutput.managedOutputDirectories ?? []),
-          ]),
-        ];
-        const managedOutputFiles = [
-          ...new Set([...previousManagedFiles, ...(markedOutput.managedOutputFiles ?? [])]),
-        ];
-        outputs.set(output.path, {
-          ...markedOutput,
-          managedOutputDirectories:
-            managedOutputDirectories.length > 0 ? managedOutputDirectories : undefined,
-          managedOutputFiles: managedOutputFiles.length > 0 ? managedOutputFiles : undefined,
-        });
+        if (!isIdenticalOutput) {
+          outputPathOwners.set(output.path, formatter.name);
+          outputPathContents.set(output.path, output.content);
+
+          // Add PromptScript marker to all outputs for overwrite detection
+          const markedOutput = addMarkerToOutput(output, sourceLabel, formatter.name);
+          const previousManagedDirectories =
+            outputs.get(output.path)?.managedOutputDirectories ?? [];
+          const previousManagedFiles = outputs.get(output.path)?.managedOutputFiles ?? [];
+          const managedOutputDirectories = [
+            ...new Set([
+              ...previousManagedDirectories,
+              ...(markedOutput.managedOutputDirectories ?? []),
+            ]),
+          ];
+          const managedOutputFiles = [
+            ...new Set([...previousManagedFiles, ...(markedOutput.managedOutputFiles ?? [])]),
+          ];
+          outputs.set(output.path, {
+            ...markedOutput,
+            managedOutputDirectories:
+              managedOutputDirectories.length > 0 ? managedOutputDirectories : undefined,
+            managedOutputFiles: managedOutputFiles.length > 0 ? managedOutputFiles : undefined,
+          });
+        }
 
         // Also add any additional files (e.g., .cursor/commands/, .github/prompts/)
         // Recursively collect nested additionalFiles (e.g., skill resource files)
@@ -579,14 +585,12 @@ export class Compiler {
           : this.options.skillContent;
         const existingOwner = outputPathOwners.get(skillPath);
         if (existingOwner) {
-          // If the same formatter already output the promptscript skill (e.g. via
-          // auto-discovered @skills block), silently skip — the content is identical.
-          // Only warn when a *different* formatter caused the collision.
+          // Preserve previously written skills and warn on differing content.
           if (outputPathContents.get(skillPath) === injectedContent) {
             this.logger.debug(
               `  Skill path '${skillPath}' already written by '${existingOwner}' with identical content. No conflict.`
             );
-          } else if (existingOwner !== formatter.name) {
+          } else {
             formatWarnings.push({
               ruleId: 'PS4001',
               ruleName: 'output-path-collision',
@@ -594,10 +598,6 @@ export class Compiler {
               message: `Output path '${skillPath}' is already written by '${existingOwner}'. Skipping auto-injected PromptScript skill for '${formatter.name}'.`,
               suggestion: `The user-defined skill takes precedence. To use the bundled skill, remove the custom one or rename it.`,
             });
-          } else {
-            this.logger.debug(
-              `  Skill path '${skillPath}' already output by '${formatter.name}' (auto-discovered). Skipping auto-injection.`
-            );
           }
           continue;
         }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -8,6 +8,7 @@ import {
 } from '@promptscript/resolver';
 import { Validator, type ValidatorConfig, type ValidationMessage } from '@promptscript/validator';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
+import { isDeepStrictEqual } from 'node:util';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- imported for upcoming formatter integration
 import { verifyReferenceIntegrity } from './reference-verifier.js';
 import { inferProjectRoot, validateHookScriptResources } from './hook-script-validator.js';
@@ -124,6 +125,39 @@ function shouldIncludeSkill(name: string, config?: TargetConfig): boolean {
   if (includeSkills === false) return false;
   if (Array.isArray(includeSkills)) return includeSkills.includes(name);
   return true;
+}
+
+function hasIdenticalWriteSemantics(
+  existing: FormatterOutput,
+  candidate: FormatterOutput
+): boolean {
+  return (
+    existing.content === candidate.content &&
+    existing.mode === candidate.mode &&
+    isDeepStrictEqual(existing.merge, candidate.merge)
+  );
+}
+
+function mergeManagedOutputMetadata(
+  existing: FormatterOutput,
+  candidate: FormatterOutput
+): FormatterOutput {
+  const managedOutputDirectories = [
+    ...new Set([
+      ...(existing.managedOutputDirectories ?? []),
+      ...(candidate.managedOutputDirectories ?? []),
+    ]),
+  ];
+  const managedOutputFiles = [
+    ...new Set([...(existing.managedOutputFiles ?? []), ...(candidate.managedOutputFiles ?? [])]),
+  ];
+
+  return {
+    ...existing,
+    managedOutputDirectories:
+      managedOutputDirectories.length > 0 ? managedOutputDirectories : undefined,
+    managedOutputFiles: managedOutputFiles.length > 0 ? managedOutputFiles : undefined,
+  };
 }
 
 /**
@@ -434,10 +468,10 @@ export class Compiler {
     const formatErrors: CompileError[] = [];
     const formatWarnings: ValidationMessage[] = [];
     const outputPathOwners = new Map<string, string>();
-    // Content as produced by the formatter, before the generated marker is added.
+    // Output as produced by the formatter, before the generated marker is added.
     // Markers embed the target name and a timestamp, so comparing marked content
     // would report every shared path as a conflict.
-    const outputPathContents = new Map<string, string>();
+    const outputPathDefinitions = new Map<string, FormatterOutput>();
 
     for (const { formatter, config } of this.loadedFormatters) {
       const formatterStart = Date.now();
@@ -465,13 +499,20 @@ export class Compiler {
 
         // Warn if multiple formatters target the same output path with different content
         const existingOwner = outputPathOwners.get(output.path);
+        const existingDefinition = outputPathDefinitions.get(output.path);
         const isIdenticalOutput =
-          existingOwner !== undefined && outputPathContents.get(output.path) === output.content;
+          existingOwner !== undefined &&
+          existingDefinition !== undefined &&
+          hasIdenticalWriteSemantics(existingDefinition, output);
         if (existingOwner !== undefined) {
           if (isIdenticalOutput) {
             this.logger.debug(
               `  Output path '${output.path}' already written by '${existingOwner}' with identical content. No conflict.`
             );
+            const existingOutput = outputs.get(output.path);
+            if (existingOutput) {
+              outputs.set(output.path, mergeManagedOutputMetadata(existingOutput, output));
+            }
           } else {
             formatWarnings.push({
               ruleId: 'PS4001',
@@ -485,7 +526,7 @@ export class Compiler {
 
         if (!isIdenticalOutput) {
           outputPathOwners.set(output.path, formatter.name);
-          outputPathContents.set(output.path, output.content);
+          outputPathDefinitions.set(output.path, output);
 
           // Add PromptScript marker to all outputs for overwrite detection
           const markedOutput = addMarkerToOutput(output, sourceLabel, formatter.name);
@@ -520,7 +561,11 @@ export class Compiler {
             // Check for path collisions with previously written outputs
             const existingAdditionalOwner = outputPathOwners.get(additionalFile.path);
             if (existingAdditionalOwner) {
-              if (outputPathContents.get(additionalFile.path) === additionalFile.content) {
+              const existingAdditionalDefinition = outputPathDefinitions.get(additionalFile.path);
+              if (
+                existingAdditionalDefinition &&
+                hasIdenticalWriteSemantics(existingAdditionalDefinition, additionalFile)
+              ) {
                 this.logger.debug(
                   `  Output path '${additionalFile.path}' already written by '${existingAdditionalOwner}' with identical content. No conflict.`
                 );
@@ -529,7 +574,7 @@ export class Compiler {
                   ruleId: 'PS4001',
                   ruleName: 'output-path-collision',
                   severity: 'warning',
-                  message: `Output path '${additionalFile.path}' is written by both '${existingAdditionalOwner}' and '${formatter.name}' with different content. The latter will overwrite the former.`,
+                  message: `Output path '${additionalFile.path}' is written by both '${existingAdditionalOwner}' and '${formatter.name}' with different content or write settings. The first output will be preserved.`,
                   suggestion: `Configure distinct output paths for these formatters, or disable one of them.`,
                 });
               }
@@ -540,7 +585,7 @@ export class Compiler {
               continue;
             }
             outputPathOwners.set(additionalFile.path, formatter.name);
-            outputPathContents.set(additionalFile.path, additionalFile.content);
+            outputPathDefinitions.set(additionalFile.path, additionalFile);
 
             outputs.set(
               additionalFile.path,
@@ -563,53 +608,64 @@ export class Compiler {
     // Inject PromptScript SKILL.md into each formatter's skill directory
     if (this.options.skillContent) {
       for (const { formatter, config } of this.loadedFormatters) {
-        if (!shouldIncludeSkill('promptscript', config)) {
-          this.logger.debug(
-            `  Skipping skill injection for ${formatter.name} (promptscript not included)`
-          );
-          continue;
-        }
-
-        const skillBasePath = config?.skillBaseDir
-          ? normalizeOutputDir(config.skillBaseDir)
-          : formatter.getSkillBasePath();
-        const skillFileName = formatter.getSkillFileName();
-        if (!skillBasePath || !skillFileName) {
-          this.logger.debug(`  Skipping skill injection for ${formatter.name} (no skill support)`);
-          continue;
-        }
-
-        const skillPath = `${skillBasePath}/promptscript/${skillFileName}`;
-        const injectedContent = formatter.transformInjectedSkillContent
-          ? formatter.transformInjectedSkillContent(this.options.skillContent)
-          : this.options.skillContent;
-        const existingOwner = outputPathOwners.get(skillPath);
-        if (existingOwner) {
-          // Preserve previously written skills and warn on differing content.
-          if (outputPathContents.get(skillPath) === injectedContent) {
+        try {
+          if (!shouldIncludeSkill('promptscript', config)) {
             this.logger.debug(
-              `  Skill path '${skillPath}' already written by '${existingOwner}' with identical content. No conflict.`
+              `  Skipping skill injection for ${formatter.name} (promptscript not included)`
             );
-          } else {
-            formatWarnings.push({
-              ruleId: 'PS4001',
-              ruleName: 'output-path-collision',
-              severity: 'warning',
-              message: `Output path '${skillPath}' is already written by '${existingOwner}'. Skipping auto-injected PromptScript skill for '${formatter.name}'.`,
-              suggestion: `The user-defined skill takes precedence. To use the bundled skill, remove the custom one or rename it.`,
-            });
+            continue;
           }
-          continue;
-        }
-        outputPathOwners.set(skillPath, `${formatter.name}:promptscript-skill`);
-        outputPathContents.set(skillPath, injectedContent);
 
-        const skillOutput: FormatterOutput = {
-          path: skillPath,
-          content: injectedContent,
-        };
-        outputs.set(skillPath, addMarkerToOutput(skillOutput, sourceLabel, 'promptscript'));
-        this.logger.verbose(`  → ${skillPath} (auto-injected promptscript skill)`);
+          const skillBasePath = config?.skillBaseDir
+            ? normalizeOutputDir(config.skillBaseDir)
+            : formatter.getSkillBasePath();
+          const skillFileName = formatter.getSkillFileName();
+          if (!skillBasePath || !skillFileName) {
+            this.logger.debug(
+              `  Skipping skill injection for ${formatter.name} (no skill support)`
+            );
+            continue;
+          }
+
+          const skillPath = `${skillBasePath}/promptscript/${skillFileName}`;
+          const injectedContent = formatter.transformInjectedSkillContent
+            ? formatter.transformInjectedSkillContent(this.options.skillContent)
+            : this.options.skillContent;
+          const skillOutput: FormatterOutput = {
+            path: skillPath,
+            content: injectedContent,
+          };
+          const existingOwner = outputPathOwners.get(skillPath);
+          if (existingOwner) {
+            // Preserve previously written skills and warn on differing content.
+            const existingDefinition = outputPathDefinitions.get(skillPath);
+            if (existingDefinition && hasIdenticalWriteSemantics(existingDefinition, skillOutput)) {
+              this.logger.debug(
+                `  Skill path '${skillPath}' already written by '${existingOwner}' with identical content. No conflict.`
+              );
+            } else {
+              formatWarnings.push({
+                ruleId: 'PS4001',
+                ruleName: 'output-path-collision',
+                severity: 'warning',
+                message: `Output path '${skillPath}' is already written by '${existingOwner}'. Skipping auto-injected PromptScript skill for '${formatter.name}'.`,
+                suggestion: `The user-defined skill takes precedence. To use the bundled skill, remove the custom one or rename it.`,
+              });
+            }
+            continue;
+          }
+          outputPathOwners.set(skillPath, `${formatter.name}:promptscript-skill`);
+          outputPathDefinitions.set(skillPath, skillOutput);
+
+          outputs.set(skillPath, addMarkerToOutput(skillOutput, sourceLabel, 'promptscript'));
+          this.logger.verbose(`  → ${skillPath} (auto-injected promptscript skill)`);
+        } catch (err) {
+          formatErrors.push({
+            name: 'FormatterError',
+            code: 'PS4000',
+            message: `Formatter '${formatter.name}' failed: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

PS4001 (`output-path-collision`) compared output paths only, never content. Several targets share output paths **by design**: `.agents/skills/<name>/SKILL.md` is the interoperable skill layout used by `codex`, `amp`, `mimo`, `deep-agents` and `cursor`.

Reproduced on `main` with one user-defined skill and targets `codex` + `amp`:

```
PS4001: Output path 'AGENTS.md' is written by both 'codex' and 'amp'.
PS4001: Output path '.agents/skills/demo-skill/SKILL.md' is written by both 'codex' and 'amp'.
```

The skill file is byte-identical between the two targets apart from the generated marker line, which embeds the target name and a timestamp. Nothing is lost and nothing is ambiguous, yet every such compile emitted a warning. Users enabling two AGENTS.md-ecosystem targets could not get a clean build.

The compiler already applied the correct reasoning in one narrow case, for the auto-injected skill when the *same* formatter had already written it:

```ts
// If the same formatter already output the promptscript skill (e.g. via
// auto-discovered @skills block), silently skip — the content is identical.
```

That reasoning was simply never extended across formatters.

## Fix

Collisions are now reported only when the colliding content actually differs.

- `outputPathContents` tracks each path's content **before** `addMarkerToOutput` is applied, since the marker would otherwise make every shared path look different.
- Identical writes are logged at debug level instead of warned.
- The warning text now says the two targets write *different content*, which is the actual problem being reported.
- All three collision sites follow the same rule: main outputs, additional files, and the injected PromptScript skill.

Behaviour on real conflicts is unchanged: the last writer still wins for main outputs, additional files are still skipped in favour of the first owner, and the warning still fires.

`AGENTS.md` between `codex` and `amp` still warns, correctly: those two produce genuinely different documents (marker placement and the `# AGENTS.md` heading differ), so one does overwrite the other.

## Tests

- Two formatters writing identical content to one path: no PS4001.
- Two formatters emitting an identical additional file: no PS4001, file present.
- Two formatters sharing a skill directory and receiving the same injected skill: no PS4001 (previously asserted the opposite).
- Two formatters sharing a skill directory where one applies `transformInjectedSkillContent`: exactly one PS4001.
- Existing differing-content cases keep asserting the warning.

The updated expectation in `should not warn when two formatters share dotDir with identical content` is a deliberate behaviour change, not a papered-over regression: the old test asserted a warning for two targets receiving the same bundled skill at the shared path.

## Verification

All eight pipeline steps green: format, lint, typecheck, test (12 projects, 616 in compiler), `prs validate --strict`, `schema:check`, `skill:check`, `grammar:check`.
