### PR TITLE
fix(resolver,compiler): keep local discovery inside the project

### DIFF
--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { CanonicalProgram, Program, SourceLocation } from '@promptscript/core';
 import type { Formatter, CompilerOptions } from '../types.js';
 import { FormatterRegistry } from '@promptscript/formatters';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 // Create mock classes before importing Compiler
 const mockResolve = vi.fn();
@@ -10,9 +12,14 @@ const mockValidate = vi.fn();
 const mockUpdateConfig = vi.fn();
 const mockVerifyReferenceHashes = vi.fn().mockResolvedValue([]);
 const mockRegistryCacheConstructor = vi.fn();
+const mockResolverConstructor = vi.fn();
 
 vi.mock('@promptscript/resolver', () => ({
   Resolver: class MockResolver {
+    constructor(options: unknown) {
+      mockResolverConstructor(options);
+    }
+
     resolve = mockResolve;
     verifyReferenceHashes = mockVerifyReferenceHashes;
   },
@@ -41,11 +48,23 @@ vi.mock('@promptscript/validator', () => ({
 }));
 
 // Import after mocks are set up
-import { Compiler, createCompiler, compile } from '../compiler.js';
+import { MAX_ENTRY_RESOLVERS, Compiler, createCompiler, compile } from '../compiler.js';
 
 afterEach(() => {
   vi.unstubAllEnvs();
 });
+
+function createMarkedWorkspace(): { root: string; entry: string } {
+  const root = mkdtempSync(join(tmpdir(), 'promptscript-compiler-'));
+  writeFileSync(join(root, 'package.json'), '{}');
+  const entry = join(root, 'entry.prs');
+  writeFileSync(entry, '@meta { id: "compiler-test" }\n');
+  return { root, entry };
+}
+
+function createSuccessfulResolverResult() {
+  return createResolveSuccess(createTestProgram());
+}
 
 /**
  * Create a minimal valid AST for testing.
@@ -174,6 +193,163 @@ describe('Compiler', () => {
 
       const compiler = createCompiler(options);
       expect(compiler).toBeInstanceOf(Compiler);
+    });
+
+    it('should preserve cwd registry lookup defaults in compile', async () => {
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      await compile('entry.prs', { formatters: [] });
+
+      expect(mockResolverConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ registryPath: process.cwd() })
+      );
+    });
+
+    it('should reuse one entry resolver for entries under one marked root', async () => {
+      const workspace = createMarkedWorkspace();
+      const secondEntry = join(workspace.root, 'second.prs');
+      writeFileSync(secondEntry, '@meta { id: "second" }\n');
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        const compiler = new Compiler({
+          resolver: { registryPath: '/registry' },
+          formatters: [],
+        });
+
+        await compiler.compile(workspace.entry);
+        await compiler.compile(secondEntry);
+
+        expect(mockResolverConstructor).toHaveBeenCalledTimes(2);
+      } finally {
+        rmSync(workspace.root, { recursive: true, force: true });
+      }
+    });
+
+    it('should share an entry resolver across symlinked roots', async () => {
+      const workspace = createMarkedWorkspace();
+      const linkParent = mkdtempSync(join(tmpdir(), 'promptscript-compiler-link-'));
+      const linkRoot = join(linkParent, 'linked-root');
+      symlinkSync(workspace.root, linkRoot, 'dir');
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        const compiler = new Compiler({
+          resolver: { registryPath: '/registry' },
+          formatters: [],
+        });
+
+        await compiler.compile(workspace.entry);
+        await compiler.compile(join(linkRoot, 'entry.prs'));
+
+        expect(mockResolverConstructor).toHaveBeenCalledTimes(2);
+      } finally {
+        rmSync(workspace.root, { recursive: true, force: true });
+        rmSync(linkParent, { recursive: true, force: true });
+      }
+    });
+
+    it('should use the configured local path for entries elsewhere', async () => {
+      const workspace = createMarkedWorkspace();
+      const entry = join(tmpdir(), `promptscript-local-entry-${Date.now()}.prs`);
+      writeFileSync(entry, '@meta { id: "outside" }\n');
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        const compiler = new Compiler({
+          resolver: { registryPath: '/registry', localPath: workspace.root },
+          formatters: [],
+        });
+
+        await compiler.compile(entry);
+
+        expect(mockResolverConstructor).toHaveBeenCalledTimes(1);
+        expect(mockResolverConstructor).toHaveBeenCalledWith(
+          expect.objectContaining({ localPath: workspace.root })
+        );
+      } finally {
+        rmSync(workspace.root, { recursive: true, force: true });
+        rmSync(entry, { force: true });
+      }
+    });
+
+    it('should use the configured project root for entries elsewhere', async () => {
+      const workspace = createMarkedWorkspace();
+      const entry = join(tmpdir(), `promptscript-project-entry-${Date.now()}.prs`);
+      writeFileSync(entry, '@meta { id: "outside" }\n');
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        const compiler = new Compiler({
+          resolver: { registryPath: '/registry', projectRoot: workspace.root },
+          formatters: [],
+        });
+
+        await compiler.compile(entry);
+
+        expect(mockResolverConstructor).toHaveBeenCalledTimes(1);
+        expect(mockResolverConstructor).toHaveBeenCalledWith(
+          expect.objectContaining({ projectRoot: workspace.root })
+        );
+      } finally {
+        rmSync(workspace.root, { recursive: true, force: true });
+        rmSync(entry, { force: true });
+      }
+    });
+
+    it('should verify lockfile hashes with the entry resolver', async () => {
+      const workspace = createMarkedWorkspace();
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        const compiler = new Compiler({
+          resolver: {
+            registryPath: '/registry',
+            lockfile: { version: 1, dependencies: {}, references: {} },
+          },
+          formatters: [],
+        });
+
+        const result = await compiler.compile(workspace.entry);
+
+        expect(result.success).toBe(true);
+        expect(mockVerifyReferenceHashes).toHaveBeenCalledOnce();
+      } finally {
+        rmSync(workspace.root, { recursive: true, force: true });
+      }
+    });
+
+    it('should evict oldest entry resolvers after reaching the bound', async () => {
+      const workspaces = Array.from({ length: MAX_ENTRY_RESOLVERS + 1 }, () =>
+        createMarkedWorkspace()
+      );
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        const compiler = new Compiler({
+          resolver: { registryPath: '/registry' },
+          formatters: [],
+        });
+
+        for (const workspace of workspaces) {
+          await compiler.compile(workspace.entry);
+        }
+
+        const cache = (compiler as unknown as { entryResolvers: Map<string, unknown> })
+          .entryResolvers;
+        expect(cache.size).toBeLessThanOrEqual(MAX_ENTRY_RESOLVERS);
+      } finally {
+        for (const workspace of workspaces) {
+          rmSync(workspace.root, { recursive: true, force: true });
+        }
+      }
     });
 
     it('should load formatter instances', () => {

--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -360,6 +360,32 @@ describe('Compiler', () => {
       }
     });
 
+    it('should append the default extension before resolving a missing entry', async () => {
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [],
+      });
+
+      await compiler.compile('missing-entry');
+
+      expect(mockResolve).toHaveBeenCalledWith(resolve(process.cwd(), 'missing-entry.prs'));
+    });
+
+    it('should preserve registry aliases during entry resolution', async () => {
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+      const compiler = new Compiler({
+        resolver: { registryPath: '/registry' },
+        formatters: [],
+      });
+
+      await compiler.compile('@vendor/project');
+
+      expect(mockResolve).toHaveBeenCalledWith('@vendor/project');
+    });
+
     it('should verify lockfile hashes with the entry resolver', async () => {
       const workspace = createMarkedWorkspace();
       mockResolve.mockResolvedValue(createSuccessfulResolverResult());

--- a/packages/compiler/src/__tests__/compiler.spec.ts
+++ b/packages/compiler/src/__tests__/compiler.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { CanonicalProgram, Program, SourceLocation } from '@promptscript/core';
 import type { Formatter, CompilerOptions } from '../types.js';
 import { FormatterRegistry } from '@promptscript/formatters';
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
 // Create mock classes before importing Compiler
@@ -246,6 +246,9 @@ describe('Compiler', () => {
         await compiler.compile(join(linkRoot, 'entry.prs'));
 
         expect(mockResolverConstructor).toHaveBeenCalledTimes(2);
+        expect(mockResolverConstructor).toHaveBeenLastCalledWith(
+          expect.objectContaining({ projectRoot: realpathSync(workspace.root) })
+        );
       } finally {
         rmSync(workspace.root, { recursive: true, force: true });
         rmSync(linkParent, { recursive: true, force: true });
@@ -299,6 +302,61 @@ describe('Compiler', () => {
       } finally {
         rmSync(workspace.root, { recursive: true, force: true });
         rmSync(entry, { force: true });
+      }
+    });
+
+    it('should preserve an explicit native skill project root', async () => {
+      const workspace = createMarkedWorkspace();
+      const skillRoot = mkdtempSync(join(tmpdir(), 'promptscript-skill-root-'));
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        const compiler = new Compiler({
+          resolver: {
+            registryPath: '/registry',
+            skills: { universalDir: '.agents', projectRoot: skillRoot },
+          },
+          formatters: [],
+        });
+
+        await compiler.compile(workspace.entry);
+
+        expect(mockResolverConstructor).toHaveBeenCalledTimes(2);
+        expect(mockResolverConstructor).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            skills: expect.objectContaining({ projectRoot: skillRoot }),
+          })
+        );
+      } finally {
+        rmSync(workspace.root, { recursive: true, force: true });
+        rmSync(skillRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('should resolve relative entries from cwd before applying the inferred root', async () => {
+      const workspace = createMarkedWorkspace();
+      const nestedDir = join(workspace.root, 'nested');
+      const nestedEntry = join(nestedDir, 'nested.prs');
+      const originalCwd = process.cwd();
+      mkdirSync(nestedDir, { recursive: true });
+      writeFileSync(nestedEntry, '@meta { id: "nested" }\n');
+      mockResolve.mockResolvedValue(createSuccessfulResolverResult());
+      mockValidate.mockReturnValue(createValidationSuccess());
+
+      try {
+        process.chdir(nestedDir);
+        const compiler = new Compiler({
+          resolver: { registryPath: '/registry' },
+          formatters: [],
+        });
+
+        await compiler.compile('nested.prs');
+
+        expect(mockResolve).toHaveBeenCalledWith(realpathSync(resolve(nestedDir, 'nested.prs')));
+      } finally {
+        process.chdir(originalCwd);
+        rmSync(workspace.root, { recursive: true, force: true });
       }
     });
 
@@ -1527,7 +1585,7 @@ describe('compile (standalone)', () => {
     const result = await compile('./test.prs');
 
     expect(result.success).toBe(true);
-    expect(mockResolve).toHaveBeenCalledWith('./test.prs');
+    expect(mockResolve).toHaveBeenCalledWith(resolve('./test.prs'));
     expect(mockValidate).toHaveBeenCalled();
   });
 
@@ -1596,7 +1654,7 @@ describe('Compiler.compileFile', () => {
     const result = await compiler.compileFile('./test.prs');
 
     expect(result.success).toBe(true);
-    expect(mockResolve).toHaveBeenCalledWith('./test.prs');
+    expect(mockResolve).toHaveBeenCalledWith(resolve('./test.prs'));
 
     vi.restoreAllMocks();
   });

--- a/packages/compiler/src/__tests__/hook-script-validator.spec.ts
+++ b/packages/compiler/src/__tests__/hook-script-validator.spec.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, rm, symlink, writeFile } from 'fs/promises';
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import type { Program, SourceLocation, Value } from '@promptscript/core';
-import { inferProjectRoot, validateHookScriptResources } from '../hook-script-validator.js';
+import {
+  findProjectRootMarker,
+  inferProjectRoot,
+  validateHookScriptResources,
+} from '../hook-script-validator.js';
 
 const loc: SourceLocation = { file: '.promptscript/project.prs', line: 1, column: 1 };
 
@@ -230,5 +234,19 @@ describe('hook script resource validation', () => {
       projectRoot
     );
     expect(inferProjectRoot('/ignored', projectRoot)).toBe(projectRoot);
+  });
+
+  it('finds markers through a symlinked entry file', async () => {
+    const linkDirectory = await mkdtemp(join(tmpdir(), 'promptscript-hook-link-'));
+    const entryPath = join(projectRoot, 'project.prs');
+    const linkedEntryPath = join(linkDirectory, 'project.prs');
+    await writeFile(entryPath, '@identity { role: "Test" }\n');
+    await symlink(entryPath, linkedEntryPath);
+
+    try {
+      expect(findProjectRootMarker(linkedEntryPath)).toBe(await realpath(projectRoot));
+    } finally {
+      await rm(linkDirectory, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/compiler/src/__tests__/project-root-isolation.spec.ts
+++ b/packages/compiler/src/__tests__/project-root-isolation.spec.ts
@@ -1,10 +1,21 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { execFile } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type { Lockfile } from '@promptscript/core';
+import {
+  VENDOR_GIT_DIR,
+  VENDOR_MANIFEST_FILE,
+  getVendorRepositoryRelativePath,
+  hashContent,
+  hashVendorRepository,
+} from '@promptscript/resolver';
 import { Compiler } from '../compiler.js';
 
 const directories: string[] = [];
+const execFileAsync = promisify(execFile);
 
 function createDirectory(prefix: string): string {
   const directory = mkdtempSync(join(tmpdir(), prefix));
@@ -78,6 +89,7 @@ describe('project root isolation', () => {
     const outside = createDirectory('promptscript-outside-');
     writeSkill(outside, 'cwd-skill');
     const project = createDirectory('promptscript-project-');
+    mkdirSync(join(project, '.promptscript'));
     writeSkill(project, 'entry-skill');
     const entryPath = writeEntry(project);
 
@@ -121,5 +133,173 @@ describe('project root isolation', () => {
     } finally {
       process.chdir(originalCwd);
     }
+  });
+
+  it('should walk from an entry directory to a project marker for imports', async () => {
+    const project = createDirectory('promptscript-marked-project-');
+    writeFileSync(join(project, 'package.json'), '{}');
+    mkdirSync(join(project, 'tools'), { recursive: true });
+    mkdirSync(join(project, 'shared'), { recursive: true });
+    writeFileSync(
+      join(project, 'shared', 'x.prs'),
+      `@identity {
+  role: "Shared"
+}
+`
+    );
+    const entryPath = join(project, 'tools', 'main.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "marked-import"
+  syntax: "1.4.0"
+}
+
+@use ../shared/x
+
+@identity {
+  role: "Main"
+}
+`
+    );
+
+    const compiler = new Compiler({
+      resolver: { registryPath: project },
+      formatters: [],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should keep cwd resolution for entries with no project marker', async () => {
+    const project = createDirectory('promptscript-unmarked-project-');
+    const realProject = realpathSync(project);
+    mkdirSync(join(realProject, 'tools'), { recursive: true });
+    mkdirSync(join(realProject, 'shared'), { recursive: true });
+    writeFileSync(
+      join(realProject, 'shared', 'x.prs'),
+      `@identity {
+  role: "Shared"
+}
+`
+    );
+    const entryPath = join(realProject, 'tools', 'main.prs');
+    writeFileSync(
+      entryPath,
+      `@meta {
+  id: "unmarked-import"
+  syntax: "1.4.0"
+}
+
+@use ../shared/x
+
+@identity {
+  role: "Main"
+}
+`
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(project);
+    try {
+      const compiler = new Compiler({
+        resolver: { registryPath: project },
+        formatters: [],
+      });
+
+      const result = await compiler.compile(entryPath);
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('should verify vendored reference hashes with an entry-scoped resolver', async () => {
+    const project = createDirectory('promptscript-vendor-project-');
+    mkdirSync(join(project, '.promptscript'));
+    const vendorDir = createDirectory('promptscript-vendor-');
+    const repoUrl = 'https://github.com/acme/vendor';
+    const version = 'v1.0.0';
+    const repositoryPath = join(vendorDir, getVendorRepositoryRelativePath(repoUrl));
+    mkdirSync(repositoryPath, { recursive: true });
+    const referenceContent = 'vendored reference\n';
+    writeFileSync(join(repositoryPath, 'reference.md'), referenceContent);
+
+    await execFileAsync('git', ['init', '--quiet', repositoryPath]);
+    await execFileAsync('git', ['-C', repositoryPath, 'add', '.']);
+    await execFileAsync(
+      'git',
+      [
+        '-C',
+        repositoryPath,
+        '-c',
+        'user.name=PromptScript Test',
+        '-c',
+        'user.email=test@example.com',
+        'commit',
+        '--quiet',
+        '-m',
+        'vendor',
+      ],
+      {
+        env: {
+          ...process.env,
+          GIT_CONFIG_GLOBAL: '/dev/null',
+          GIT_CONFIG_NOSYSTEM: '1',
+        },
+      }
+    );
+    const { stdout } = await execFileAsync('git', ['-C', repositoryPath, 'rev-parse', 'HEAD']);
+    const commit = stdout.trim();
+    renameSync(join(repositoryPath, '.git'), join(repositoryPath, VENDOR_GIT_DIR));
+    const integrity = await hashVendorRepository(repositoryPath);
+    writeFileSync(
+      join(vendorDir, VENDOR_MANIFEST_FILE),
+      JSON.stringify({
+        version: 1,
+        dependencies: {
+          [repoUrl]: {
+            commit,
+            integrity,
+            path: getVendorRepositoryRelativePath(repoUrl),
+            version,
+          },
+        },
+      })
+    );
+
+    const lockfile: Lockfile = {
+      version: 1,
+      dependencies: {
+        [repoUrl]: { version, commit, integrity },
+      },
+      references: {
+        [`${repoUrl}\0reference.md\0${version}`]: {
+          hash: hashContent(Buffer.from(referenceContent)),
+          lockedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    };
+    const entryPath = join(project, 'project.prs');
+    writeFileSync(entryPath, '@meta { id: "vendor-project" syntax: "1.4.0" }\n');
+
+    const compiler = new Compiler({
+      resolver: {
+        registryPath: project,
+        vendorDir,
+        lockfile,
+      },
+      formatters: [],
+    });
+
+    const result = await compiler.compile(entryPath);
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
   });
 });

--- a/packages/compiler/src/__tests__/project-root-isolation.spec.ts
+++ b/packages/compiler/src/__tests__/project-root-isolation.spec.ts
@@ -74,6 +74,32 @@ describe('project root isolation', () => {
     }
   });
 
+  it('should infer the project root from the entry path when none is configured', async () => {
+    const outside = createDirectory('promptscript-outside-');
+    writeSkill(outside, 'cwd-skill');
+    const project = createDirectory('promptscript-project-');
+    writeSkill(project, 'entry-skill');
+    const entryPath = writeEntry(project);
+
+    const originalCwd = process.cwd();
+    process.chdir(outside);
+    try {
+      const compiler = new Compiler({
+        resolver: { registryPath: project },
+        formatters: [{ name: 'claude', config: { version: 'full' } }],
+      });
+
+      const result = await compiler.compile(entryPath);
+
+      expect(result.success).toBe(true);
+      const outputs = [...result.outputs.keys()];
+      expect(outputs).toContain('.claude/skills/entry-skill/SKILL.md');
+      expect(outputs).not.toContain('.claude/skills/cwd-skill/SKILL.md');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it('should discover skills inside the project root without an explicit local path', async () => {
     const outside = createDirectory('promptscript-outside-');
     const project = createDirectory('promptscript-project-');

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -41,11 +41,7 @@ interface LoadedFormatter {
 export const MAX_ENTRY_RESOLVERS = 50;
 
 function resolverCacheKey(projectRoot: string): string {
-  try {
-    return realpathSync.native(projectRoot);
-  } catch {
-    return resolve(projectRoot);
-  }
+  return realpathSync.native(projectRoot);
 }
 
 function resolveEntryPath(entryPath: string): string {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -152,6 +152,7 @@ function shouldIncludeSkill(name: string, config?: TargetConfig): boolean {
  */
 export class Compiler {
   private readonly resolver: Resolver;
+  private readonly entryResolvers = new Map<string, Resolver>();
   private readonly validator: Validator;
   private readonly loadedFormatters: LoadedFormatter[];
   private readonly logger: Logger;
@@ -166,6 +167,30 @@ export class Compiler {
   }
 
   /**
+   * Get the resolver to use for an entry file.
+   *
+   * Hook script validation infers the project root from the entry path, so a
+   * resolver left on the cwd default would discover skills, commands and
+   * agents from a different directory than the one being compiled.
+   *
+   * @param entryPath - Path to the entry file
+   * @returns Resolver scoped to the entry file's project root
+   */
+  private resolverFor(entryPath: string): Resolver {
+    if (this.options.resolver.localPath || this.options.resolver.projectRoot) {
+      return this.resolver;
+    }
+
+    const projectRoot = inferProjectRoot(undefined, undefined, entryPath);
+    const cached = this.entryResolvers.get(projectRoot);
+    if (cached) return cached;
+
+    const resolver = new Resolver({ ...this.options.resolver, projectRoot, logger: this.logger });
+    this.entryResolvers.set(projectRoot, resolver);
+    return resolver;
+  }
+
+  /**
    * Compile a PromptScript file through the full pipeline.
    *
    * @param entryPath - Path to the entry file
@@ -177,6 +202,7 @@ export class Compiler {
       `Targets: ${this.loadedFormatters.map((f) => f.formatter.name).join(', ')}`
     );
 
+    const resolver = this.resolverFor(entryPath);
     const startTotal = Date.now();
     const stats: CompileStats = {
       resolveTime: 0,
@@ -195,7 +221,7 @@ export class Compiler {
     let resolved: ResolvedAST;
 
     try {
-      resolved = await this.resolver.resolve(entryPath);
+      resolved = await resolver.resolve(entryPath);
     } catch (err) {
       stats.resolveTime = Date.now() - startResolve;
       stats.totalTime = Date.now() - startTotal;
@@ -356,7 +382,7 @@ export class Compiler {
       }
 
       // Verify reference file hashes against lockfile
-      const hashErrors = await this.resolver.verifyReferenceHashes(this.options.resolver.lockfile);
+      const hashErrors = await resolver.verifyReferenceHashes(this.options.resolver.lockfile);
       for (const err of hashErrors) {
         compileErrors.push(this.toCompileError(err));
       }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -48,6 +48,18 @@ function resolverCacheKey(projectRoot: string): string {
   }
 }
 
+function resolveEntryPath(entryPath: string): string {
+  if (entryPath.startsWith('@')) return entryPath;
+  const fileName =
+    entryPath.endsWith('.prs') || entryPath.endsWith('.md') ? entryPath : `${entryPath}.prs`;
+  const absolutePath = isAbsolute(fileName) ? fileName : resolve(process.cwd(), fileName);
+  try {
+    return realpathSync.native(absolutePath);
+  } catch {
+    return absolutePath;
+  }
+}
+
 function normalizeRepositoryKey(value: string): string {
   return value
     .replace(/^(?:https?:\/\/|git:\/\/)/i, '')
@@ -182,6 +194,10 @@ export class Compiler {
     this.logger.debug(`Compiler initialized with ${this.loadedFormatters.length} formatters`);
   }
 
+  private hasExplicitResolverScope(): boolean {
+    return Boolean(this.options.resolver.localPath || this.options.resolver.projectRoot);
+  }
+
   /**
    * Get the resolver to use for an entry file.
    *
@@ -193,7 +209,7 @@ export class Compiler {
    * @returns Resolver scoped to the entry file's project root
    */
   private resolverFor(entryPath: string): Resolver {
-    if (this.options.resolver.localPath || this.options.resolver.projectRoot) {
+    if (this.hasExplicitResolverScope()) {
       return this.resolver;
     }
 
@@ -207,7 +223,11 @@ export class Compiler {
     const cached = this.entryResolvers.get(cacheKey);
     if (cached) return cached;
 
-    const resolver = new Resolver({ ...this.options.resolver, projectRoot, logger: this.logger });
+    const resolver = new Resolver({
+      ...this.options.resolver,
+      projectRoot: cacheKey,
+      logger: this.logger,
+    });
     if (this.entryResolvers.size >= MAX_ENTRY_RESOLVERS) {
       // Bound per-project caches for long-lived watch and server compilers.
       const oldestKey = this.entryResolvers.keys().next().value;
@@ -229,7 +249,10 @@ export class Compiler {
       `Targets: ${this.loadedFormatters.map((f) => f.formatter.name).join(', ')}`
     );
 
-    const resolver = this.resolverFor(entryPath);
+    const resolvedEntryPath = this.hasExplicitResolverScope()
+      ? entryPath
+      : resolveEntryPath(entryPath);
+    const resolver = this.resolverFor(resolvedEntryPath);
     const startTotal = Date.now();
     const stats: CompileStats = {
       resolveTime: 0,
@@ -248,7 +271,7 @@ export class Compiler {
     let resolved: ResolvedAST;
 
     try {
-      resolved = await resolver.resolve(entryPath);
+      resolved = await resolver.resolve(resolvedEntryPath);
     } catch (err) {
       stats.resolveTime = Date.now() - startResolve;
       stats.totalTime = Date.now() - startTotal;
@@ -464,7 +487,7 @@ export class Compiler {
       inferProjectRoot(
         this.options.resolver.localPath,
         this.options.resolver.projectRoot,
-        entryPath
+        resolvedEntryPath
       )
     );
     stats.validateTime = Date.now() - startValidate;

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from 'fs';
 import { noopLogger, type Logger, type PSError } from '@promptscript/core';
 import { FormatterRegistry, formatProgram } from '@promptscript/formatters';
 import {
@@ -10,7 +11,11 @@ import { Validator, type ValidatorConfig, type ValidationMessage } from '@prompt
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- imported for upcoming formatter integration
 import { verifyReferenceIntegrity } from './reference-verifier.js';
-import { inferProjectRoot, validateHookScriptResources } from './hook-script-validator.js';
+import {
+  findProjectRootMarker,
+  inferProjectRoot,
+  validateHookScriptResources,
+} from './hook-script-validator.js';
 import type {
   CompilerOptions,
   CompileResult,
@@ -30,6 +35,17 @@ import type {
 interface LoadedFormatter {
   formatter: Formatter;
   config?: TargetConfig;
+}
+
+/** Maximum number of project-scoped resolvers retained by a long-lived compiler. */
+export const MAX_ENTRY_RESOLVERS = 50;
+
+function resolverCacheKey(projectRoot: string): string {
+  try {
+    return realpathSync.native(projectRoot);
+  } catch {
+    return resolve(projectRoot);
+  }
 }
 
 function normalizeRepositoryKey(value: string): string {
@@ -181,12 +197,23 @@ export class Compiler {
       return this.resolver;
     }
 
-    const projectRoot = inferProjectRoot(undefined, undefined, entryPath);
-    const cached = this.entryResolvers.get(projectRoot);
+    const projectRoot = findProjectRootMarker(entryPath);
+    if (!projectRoot) {
+      // Keep cwd-based resolution when an entry is outside a marked project.
+      return this.resolver;
+    }
+
+    const cacheKey = resolverCacheKey(projectRoot);
+    const cached = this.entryResolvers.get(cacheKey);
     if (cached) return cached;
 
     const resolver = new Resolver({ ...this.options.resolver, projectRoot, logger: this.logger });
-    this.entryResolvers.set(projectRoot, resolver);
+    if (this.entryResolvers.size >= MAX_ENTRY_RESOLVERS) {
+      // Bound per-project caches for long-lived watch and server compilers.
+      const oldestKey = this.entryResolvers.keys().next().value;
+      if (oldestKey !== undefined) this.entryResolvers.delete(oldestKey);
+    }
+    this.entryResolvers.set(cacheKey, resolver);
     return resolver;
   }
 

--- a/packages/compiler/src/hook-script-validator.ts
+++ b/packages/compiler/src/hook-script-validator.ts
@@ -1,5 +1,5 @@
 import { lstat, realpath } from 'fs/promises';
-import { existsSync, statSync } from 'fs';
+import { existsSync, realpathSync, statSync } from 'fs';
 import { dirname, isAbsolute, relative, resolve, sep } from 'path';
 import type { Program } from '@promptscript/core';
 import { extractHooks, getEnabledHookScriptResources } from '@promptscript/formatters';
@@ -35,7 +35,14 @@ function isProjectMarker(directory: string, marker: (typeof PROJECT_MARKERS)[num
  * @returns Marked project root, or undefined when no marker exists
  */
 export function findProjectRootMarker(entryPath: string): string | undefined {
-  const start = dirname(resolve(entryPath));
+  const resolvedEntryPath = resolve(entryPath);
+  let canonicalEntryPath: string;
+  try {
+    canonicalEntryPath = realpathSync.native(resolvedEntryPath);
+  } catch {
+    canonicalEntryPath = resolvedEntryPath;
+  }
+  const start = dirname(canonicalEntryPath);
 
   for (const marker of PROJECT_MARKERS) {
     let directory = start;

--- a/packages/compiler/src/hook-script-validator.ts
+++ b/packages/compiler/src/hook-script-validator.ts
@@ -1,5 +1,5 @@
 import { lstat, realpath } from 'fs/promises';
-import { existsSync, realpathSync, statSync } from 'fs';
+import { realpathSync, statSync } from 'fs';
 import { dirname, isAbsolute, relative, resolve, sep } from 'path';
 import type { Program } from '@promptscript/core';
 import { extractHooks, getEnabledHookScriptResources } from '@promptscript/formatters';
@@ -17,15 +17,12 @@ function isInside(root: string, candidate: string): boolean {
 
 function isProjectMarker(directory: string, marker: (typeof PROJECT_MARKERS)[number]): boolean {
   const markerPath = resolve(directory, marker);
-  if (!existsSync(markerPath)) return false;
-  if (marker === '.promptscript') {
-    try {
-      return statSync(markerPath).isDirectory();
-    } catch {
-      return false;
-    }
+  try {
+    const markerStat = statSync(markerPath);
+    return marker !== '.promptscript' || markerStat.isDirectory();
+  } catch {
+    return false;
   }
-  return true;
 }
 
 /**

--- a/packages/compiler/src/hook-script-validator.ts
+++ b/packages/compiler/src/hook-script-validator.ts
@@ -1,8 +1,11 @@
 import { lstat, realpath } from 'fs/promises';
+import { existsSync, statSync } from 'fs';
 import { dirname, isAbsolute, relative, resolve, sep } from 'path';
 import type { Program } from '@promptscript/core';
 import { extractHooks, getEnabledHookScriptResources } from '@promptscript/formatters';
 import type { CompileError } from './types.js';
+
+const PROJECT_MARKERS = ['.promptscript', '.git', 'package.json'] as const;
 
 function isInside(root: string, candidate: string): boolean {
   const relation = relative(root, candidate);
@@ -12,12 +15,51 @@ function isInside(root: string, candidate: string): boolean {
   );
 }
 
+function isProjectMarker(directory: string, marker: (typeof PROJECT_MARKERS)[number]): boolean {
+  const markerPath = resolve(directory, marker);
+  if (!existsSync(markerPath)) return false;
+  if (marker === '.promptscript') {
+    try {
+      return statSync(markerPath).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Find a project root marker above an entry file.
+ *
+ * @param entryPath - Path to the entry file
+ * @returns Marked project root, or undefined when no marker exists
+ */
+export function findProjectRootMarker(entryPath: string): string | undefined {
+  const start = dirname(resolve(entryPath));
+
+  for (const marker of PROJECT_MARKERS) {
+    let directory = start;
+    while (true) {
+      if (isProjectMarker(directory, marker)) return directory;
+      const parent = dirname(directory);
+      if (parent === directory) break;
+      directory = parent;
+    }
+  }
+
+  return undefined;
+}
+
 export function inferProjectRoot(
   localPath: string | undefined,
   configuredProjectRoot: string | undefined,
   entryPath?: string
 ): string {
   if (configuredProjectRoot) return resolve(configuredProjectRoot);
+  if (!localPath && entryPath) {
+    const markedRoot = findProjectRootMarker(entryPath);
+    if (markedRoot) return markedRoot;
+  }
   const local = localPath
     ? resolve(localPath)
     : entryPath

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -8,7 +8,7 @@
  */
 
 // Compiler
-export { Compiler, createCompiler, compile } from './compiler.js';
+export { Compiler, createCompiler, compile, MAX_ENTRY_RESOLVERS } from './compiler.js';
 
 // Types
 export type {

--- a/packages/resolver/src/__tests__/resolver.spec.ts
+++ b/packages/resolver/src/__tests__/resolver.spec.ts
@@ -33,6 +33,14 @@ describe('Resolver', () => {
       const loader = resolver.getLoader();
       expect(loader.getRegistryPath()).toBe(resolve(FIXTURES_DIR, 'registry'));
     });
+
+    it('should expose the project root used for discovery', () => {
+      const r = createResolver({
+        registryPath: '/registry',
+        localPath: '/project/.promptscript',
+      });
+      expect(r.getLoader().getProjectRoot()).toBe(resolve('/project'));
+    });
   });
 
   describe('resolve', () => {

--- a/packages/resolver/src/__tests__/skills.spec.ts
+++ b/packages/resolver/src/__tests__/skills.spec.ts
@@ -793,6 +793,64 @@ Universal skill content.
       expect(resources[0]!.relativePath).toBe('data.csv');
     });
 
+    it('should look for the universal directory under an explicit projectRoot', async () => {
+      // localPath is the project root itself, so the universal directory is a
+      // child of it rather than a sibling of localPath
+      const projectRoot = join(testDir, 'project');
+      const agentsSkillDir = join(projectRoot, '.agents', 'skills', 'in-project-skill');
+      await mkdir(agentsSkillDir, { recursive: true });
+      await writeFile(
+        join(agentsSkillDir, 'SKILL.md'),
+        `---
+name: in-project-skill
+description: Lives inside the project
+---
+
+In-project skill content.
+`
+      );
+
+      const result = await resolveNativeSkills(
+        createProgram([]),
+        registryPath,
+        join(projectRoot, 'test.prs'),
+        projectRoot,
+        { universalDir: '.agents', projectRoot }
+      );
+
+      const skillsBlock = result.blocks.find((b) => b.name === 'skills');
+      const skillsContent = skillsBlock!.content as ObjectContent;
+      const skill = skillsContent.properties['in-project-skill'] as Record<string, unknown>;
+      expect((skill['content'] as TextContent).value).toContain('In-project skill content.');
+    });
+
+    it('should not discover a universal directory above the project root', async () => {
+      const projectRoot = join(testDir, 'project');
+      const outsideSkillDir = join(testDir, '.agents', 'skills', 'outside-skill');
+      await mkdir(projectRoot, { recursive: true });
+      await mkdir(outsideSkillDir, { recursive: true });
+      await writeFile(
+        join(outsideSkillDir, 'SKILL.md'),
+        `---
+name: outside-skill
+description: Lives next to the project
+---
+
+Outside skill content.
+`
+      );
+
+      const result = await resolveNativeSkills(
+        createProgram([]),
+        registryPath,
+        join(projectRoot, 'test.prs'),
+        projectRoot,
+        { universalDir: '.agents', projectRoot }
+      );
+
+      expect(result.blocks.find((b) => b.name === 'skills')).toBeUndefined();
+    });
+
     it('should ignore a SKILL.md that PromptScript generated', async () => {
       const localPath = join(testDir, '.promptscript');
       const agentsSkillDir = join(testDir, '.agents', 'skills', 'generated-skill');

--- a/packages/resolver/src/__tests__/skills.spec.ts
+++ b/packages/resolver/src/__tests__/skills.spec.ts
@@ -948,6 +948,45 @@ Generated skill content.
       expect(skill['__rawFrontmatter']).toBeUndefined();
     });
 
+    it('should ignore an explicitly declared local SKILL.md that PromptScript generated', async () => {
+      const localPath = join(testDir, '.promptscript');
+      const localSkillDir = join(localPath, 'skills', 'generated-skill');
+      await mkdir(localSkillDir, { recursive: true });
+
+      await writeFile(
+        join(localSkillDir, 'SKILL.md'),
+        `---
+# promptscript-generated: 2026-07-27T16:59:01.673Z | source: project.prs | target: codex
+name: generated-skill
+description: Emitted by a previous compilation
+---
+
+Generated skill content.
+`
+      );
+
+      const ast = createProgram([
+        createSkillsBlock({
+          'generated-skill': { content: 'Authored content.' },
+        }),
+      ]);
+
+      const result = await resolveNativeSkills(
+        ast,
+        registryPath,
+        join(localPath, 'test.prs'),
+        localPath,
+        { universalDir: '.agents' }
+      );
+
+      const skillsBlock = result.blocks.find((b) => b.name === 'skills');
+      const skillsContent = skillsBlock!.content as ObjectContent;
+      const skill = skillsContent.properties['generated-skill'] as Record<string, unknown>;
+
+      expect(skill['content']).toBe('Authored content.');
+      expect(skill['__rawFrontmatter']).toBeUndefined();
+    });
+
     it('should prefer .promptscript/skills/ over .agents/skills/', async () => {
       const localPath = join(testDir, '.promptscript');
       const localSkillDir = join(localPath, 'skills', 'my-skill');

--- a/packages/resolver/src/__tests__/skills.spec.ts
+++ b/packages/resolver/src/__tests__/skills.spec.ts
@@ -43,6 +43,63 @@ describe('resolveNativeSkills', () => {
     loc: { file: 'test.prs', line: 1, column: 1, offset: 0 },
   });
 
+  it('should use the legacy universal parent fallback for a .promptscript local path', async () => {
+    const localPath = join(testDir, '.promptscript');
+    const skillDir = join(testDir, '.agents', 'skills', 'fallback-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: fallback-skill\ndescription: Fallback skill\n---\n\nFallback body.\n'
+    );
+
+    const ast = createProgram([]);
+    const result = await resolveNativeSkills(
+      ast,
+      registryPath,
+      join(localPath, 'project.prs'),
+      localPath,
+      { universalDir: '.agents' }
+    );
+
+    const skillsBlock = result.blocks.find((block) => block.name === 'skills');
+    expect(skillsBlock).toBeDefined();
+    expect(Object.keys((skillsBlock!.content as ObjectContent).properties)).toEqual([
+      'fallback-skill',
+    ]);
+  });
+
+  it('should replace an explicitly declared skill from the universal candidate', async () => {
+    const localPath = join(testDir, '.promptscript');
+    const skillDir = join(testDir, '.agents', 'skills', 'foo');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: foo\ndescription: Universal foo\n---\n\nUniversal foo body.\n'
+    );
+    await mkdir(localPath, { recursive: true });
+    await symlink(join(testDir, 'missing-skills'), join(localPath, 'skills'));
+
+    const ast = createProgram([
+      createSkillsBlock({
+        foo: {},
+      }),
+    ]);
+    const result = await resolveNativeSkills(
+      ast,
+      registryPath,
+      join(localPath, 'project.prs'),
+      localPath,
+      { universalDir: '.agents', projectRoot: testDir }
+    );
+
+    const skillsBlock = result.blocks.find((block) => block.name === 'skills');
+    const foo = (skillsBlock!.content as ObjectContent).properties['foo'] as Record<
+      string,
+      unknown
+    >;
+    expect((foo['content'] as TextContent).value).toContain('Universal foo body.');
+  });
+
   describe('when no @skills block exists', () => {
     it('should return AST unchanged', async () => {
       const ast = createProgram([

--- a/packages/resolver/src/__tests__/universal-dir-scope.spec.ts
+++ b/packages/resolver/src/__tests__/universal-dir-scope.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Block, ObjectContent } from '@promptscript/core';
+import { Resolver } from '../resolver.js';
+
+const testDirectories: string[] = [];
+
+const PROJECT_SOURCE = `@identity {
+  role: "Probe"
+}
+`;
+
+function skillFile(name: string): string {
+  return `---
+name: ${name}
+description: Discovered from a universal directory
+---
+
+Body of ${name}.
+`;
+}
+
+async function writeSkill(baseDir: string, name: string): Promise<void> {
+  const skillDir = join(baseDir, 'skills', name);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(join(skillDir, 'SKILL.md'), skillFile(name));
+}
+
+async function createWorkspace(): Promise<{ workspace: string; projectRoot: string }> {
+  const workspace = await mkdtemp(join(tmpdir(), 'prs-universal-'));
+  testDirectories.push(workspace);
+  const projectRoot = join(workspace, 'project');
+  await mkdir(projectRoot, { recursive: true });
+  await writeFile(join(projectRoot, 'project.prs'), PROJECT_SOURCE);
+  return { workspace, projectRoot };
+}
+
+function skillNames(blocks: Block[]): string[] {
+  const block = blocks.find((candidate) => candidate.name === 'skills');
+  if (!block || block.content.type !== 'ObjectContent') return [];
+  return Object.keys((block.content as ObjectContent).properties);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    testDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe('universal directory scope', () => {
+  it('should discover skills from the universal directory inside the project root', async () => {
+    const { projectRoot } = await createWorkspace();
+    await writeSkill(join(projectRoot, '.agents'), 'in-project-skill');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      projectRoot,
+      cache: false,
+      skills: { universalDir: '.agents' },
+    });
+
+    const result = await resolver.resolve(join(projectRoot, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual(['in-project-skill']);
+  });
+
+  it('should not discover skills from a universal directory above the project root', async () => {
+    const { workspace, projectRoot } = await createWorkspace();
+    await writeSkill(join(workspace, '.agents'), 'outside-skill');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      projectRoot,
+      cache: false,
+      skills: { universalDir: '.agents' },
+    });
+
+    const result = await resolver.resolve(join(projectRoot, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual([]);
+  });
+
+  it('should still treat the universal directory as a sibling of .promptscript', async () => {
+    const { projectRoot } = await createWorkspace();
+    const localPath = join(projectRoot, '.promptscript');
+    await mkdir(localPath, { recursive: true });
+    await writeFile(join(localPath, 'project.prs'), PROJECT_SOURCE);
+    await writeSkill(join(projectRoot, '.agents'), 'sibling-skill');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      localPath,
+      cache: false,
+      skills: { universalDir: '.agents' },
+    });
+
+    const result = await resolver.resolve(join(localPath, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual(['sibling-skill']);
+  });
+});

--- a/packages/resolver/src/__tests__/universal-dir-scope.spec.ts
+++ b/packages/resolver/src/__tests__/universal-dir-scope.spec.ts
@@ -43,6 +43,33 @@ function skillNames(blocks: Block[]): string[] {
   return Object.keys((block.content as ObjectContent).properties);
 }
 
+function objectBlockNames(blocks: Block[], blockName: string): string[] {
+  const block = blocks.find((candidate) => candidate.name === blockName);
+  if (!block || block.content.type !== 'ObjectContent') return [];
+  return Object.keys((block.content as ObjectContent).properties);
+}
+
+async function writeCommand(baseDir: string, name: string): Promise<void> {
+  const commandDir = join(baseDir, 'commands');
+  await mkdir(commandDir, { recursive: true });
+  await writeFile(join(commandDir, `${name}.md`), `Run ${name}.`);
+}
+
+async function writeAgent(baseDir: string, name: string): Promise<void> {
+  const agentDir = join(baseDir, 'agents');
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(
+    join(agentDir, `${name}.md`),
+    `---
+name: ${name}
+description: Agent fixture
+---
+
+Use ${name}.
+`
+  );
+}
+
 afterEach(async () => {
   await Promise.all(
     testDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true }))
@@ -102,5 +129,46 @@ describe('universal directory scope', () => {
 
     expect(result.errors).toEqual([]);
     expect(skillNames(result.ast!.blocks)).toEqual(['sibling-skill']);
+  });
+
+  it('should discover commands and agents from the scoped universal directory', async () => {
+    const { workspace, projectRoot } = await createWorkspace();
+    await writeCommand(join(projectRoot, '.agents'), 'in-project-command');
+    await writeAgent(join(projectRoot, '.agents'), 'in-project-agent');
+    await writeCommand(join(workspace, '.agents'), 'outside-command');
+    await writeAgent(join(workspace, '.agents'), 'outside-agent');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      projectRoot,
+      cache: false,
+      skills: { universalDir: '.agents' },
+    });
+
+    const result = await resolver.resolve(join(projectRoot, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(objectBlockNames(result.ast!.blocks, 'shortcuts')).toEqual(['/in-project-command']);
+    expect(objectBlockNames(result.ast!.blocks, 'agents')).toEqual(['in-project-agent']);
+  });
+
+  it('should preserve the parent fallback for a custom local path', async () => {
+    const { projectRoot } = await createWorkspace();
+    const localPath = join(projectRoot, 'custom');
+    await mkdir(localPath, { recursive: true });
+    await writeFile(join(localPath, 'project.prs'), PROJECT_SOURCE);
+    await writeSkill(join(projectRoot, '.agents'), 'custom-local-skill');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      localPath,
+      cache: false,
+      skills: { universalDir: '.agents' },
+    });
+
+    const result = await resolver.resolve(join(localPath, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual(['custom-local-skill']);
   });
 });

--- a/packages/resolver/src/__tests__/universal-dir-scope.spec.ts
+++ b/packages/resolver/src/__tests__/universal-dir-scope.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Block, ObjectContent } from '@promptscript/core';
@@ -94,6 +94,27 @@ describe('universal directory scope', () => {
     expect(skillNames(result.ast!.blocks)).toEqual(['in-project-skill']);
   });
 
+  it('should preserve an explicit universal discovery root', async () => {
+    const { workspace, projectRoot } = await createWorkspace();
+    const discoveryRoot = join(workspace, 'shared-skills');
+    await writeSkill(join(discoveryRoot, '.agents'), 'shared-skill');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      projectRoot,
+      cache: false,
+      skills: {
+        universalDir: '.agents',
+        projectRoot: discoveryRoot,
+      },
+    });
+
+    const result = await resolver.resolve(join(projectRoot, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual(['shared-skill']);
+  });
+
   it('should not discover skills from a universal directory above the project root', async () => {
     const { workspace, projectRoot } = await createWorkspace();
     await writeSkill(join(workspace, '.agents'), 'outside-skill');
@@ -170,5 +191,63 @@ describe('universal directory scope', () => {
 
     expect(result.errors).toEqual([]);
     expect(skillNames(result.ast!.blocks)).toEqual(['custom-local-skill']);
+  });
+
+  it('should reject absolute universal directories', async () => {
+    const { workspace, projectRoot } = await createWorkspace();
+    const outsideUniversalDir = join(workspace, 'outside-agents');
+    await writeSkill(outsideUniversalDir, 'outside-skill');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      projectRoot,
+      cache: false,
+      skills: { universalDir: outsideUniversalDir },
+    });
+
+    const result = await resolver.resolve(join(projectRoot, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual([]);
+  });
+
+  it('should reject traversing universal directories', async () => {
+    const { workspace, projectRoot } = await createWorkspace();
+    await writeSkill(join(workspace, '.agents'), 'outside-skill');
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      projectRoot,
+      cache: false,
+      skills: { universalDir: '../.agents' },
+    });
+
+    const result = await resolver.resolve(join(projectRoot, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual([]);
+  });
+
+  it('should reject universal directory symlinks that leave the project root', async () => {
+    const { workspace, projectRoot } = await createWorkspace();
+    const outsideUniversalDir = join(workspace, 'outside-agents');
+    await writeSkill(outsideUniversalDir, 'outside-skill');
+    await writeCommand(outsideUniversalDir, 'outside-command');
+    await writeAgent(outsideUniversalDir, 'outside-agent');
+    await symlink(outsideUniversalDir, join(projectRoot, '.agents'));
+
+    const resolver = new Resolver({
+      registryPath: projectRoot,
+      projectRoot,
+      cache: false,
+      skills: { universalDir: '.agents' },
+    });
+
+    const result = await resolver.resolve(join(projectRoot, 'project.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(skillNames(result.ast!.blocks)).toEqual([]);
+    expect(objectBlockNames(result.ast!.blocks, 'shortcuts')).toEqual([]);
+    expect(objectBlockNames(result.ast!.blocks, 'agents')).toEqual([]);
   });
 });

--- a/packages/resolver/src/loader.ts
+++ b/packages/resolver/src/loader.ts
@@ -219,6 +219,13 @@ export class FileLoader {
   getLocalPath(): string {
     return this.localPath;
   }
+
+  /**
+   * Get the project root used as the traversal safety boundary.
+   */
+  getProjectRoot(): string {
+    return this.projectRoot;
+  }
 }
 
 /** Remove a trailing `@version` from an import path. */

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -245,7 +245,7 @@ export class Resolver {
 
     // Resolve native skill files (replace @skills content with SKILL.md files if available)
     // Preserve the parent fallback for custom local paths.
-    const configuredProjectRoot = this.options.projectRoot ?? this.options.skills?.projectRoot;
+    const configuredProjectRoot = this.options.skills?.projectRoot ?? this.options.projectRoot;
     const projectRoot =
       configuredProjectRoot ??
       (basename(this.loader.getLocalPath()) === '.promptscript'

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -244,25 +244,25 @@ export class Resolver {
     });
 
     // Resolve native skill files (replace @skills content with SKILL.md files if available)
+    const discoveryOptions = {
+      ...this.options.skills,
+      projectRoot: this.loader.getProjectRoot(),
+      logger: this.logger,
+    };
+
     ast = await resolveNativeSkills(
       ast,
       this.loader.getRegistryPath(),
       absPath,
       this.loader.getLocalPath(),
-      { ...this.options.skills, logger: this.logger }
+      discoveryOptions
     );
 
     // Auto-discover command files from local and universal directories
-    ast = await resolveNativeCommands(ast, absPath, this.loader.getLocalPath(), {
-      ...this.options.skills,
-      logger: this.logger,
-    });
+    ast = await resolveNativeCommands(ast, absPath, this.loader.getLocalPath(), discoveryOptions);
 
     // Auto-discover agent files from local and universal directories
-    ast = await resolveNativeAgents(ast, absPath, this.loader.getLocalPath(), {
-      ...this.options.skills,
-      logger: this.logger,
-    });
+    ast = await resolveNativeAgents(ast, absPath, this.loader.getLocalPath(), discoveryOptions);
 
     this.logger.debug(`Resolved ${sources.length} source file(s)`);
     return {

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -244,9 +244,16 @@ export class Resolver {
     });
 
     // Resolve native skill files (replace @skills content with SKILL.md files if available)
+    // Preserve the parent fallback for custom local paths.
+    const configuredProjectRoot = this.options.projectRoot ?? this.options.skills?.projectRoot;
+    const projectRoot =
+      configuredProjectRoot ??
+      (basename(this.loader.getLocalPath()) === '.promptscript'
+        ? this.loader.getProjectRoot()
+        : undefined);
     const discoveryOptions = {
       ...this.options.skills,
-      projectRoot: this.loader.getProjectRoot(),
+      ...(projectRoot ? { projectRoot } : {}),
       logger: this.logger,
     };
 

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -1095,6 +1095,41 @@ function universalRoot(localPath: string, projectRoot: string | undefined): stri
   return projectRoot ? resolve(projectRoot) : resolve(localPath, '..');
 }
 
+function isInside(root: string, candidate: string): boolean {
+  const relation = relative(root, candidate);
+  return (
+    relation === '' ||
+    (relation !== '..' && !relation.startsWith(`..${sep}`) && !isAbsolute(relation))
+  );
+}
+
+async function resolveUniversalDiscoveryDir(
+  localPath: string,
+  options: NativeSkillOptions,
+  contentDir: 'skills' | 'commands' | 'agents'
+): Promise<string | null> {
+  const portableDir = options.universalDir?.replace(/\\/g, '/');
+  if (!portableDir || portableDir.startsWith('/') || /^[a-zA-Z]:\//.test(portableDir)) {
+    return null;
+  }
+
+  const segments = portableDir.split('/').filter((segment) => segment.length > 0);
+  if (segments.length === 0 || segments.some((segment) => segment === '..')) {
+    return null;
+  }
+
+  const root = universalRoot(localPath, options.projectRoot);
+  const candidate = resolve(root, ...segments, contentDir);
+  if (!isInside(root, candidate)) return null;
+
+  try {
+    const [realRoot, realCandidate] = await Promise.all([realpath(root), realpath(candidate)]);
+    return isInside(realRoot, realCandidate) ? realCandidate : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Check whether a file is PromptScript compilation output.
  *
@@ -1210,14 +1245,14 @@ export async function resolveNativeSkills(
   // Auto-discover skills from local and universal directories
   // Tracks discovered skill name → absolute directory path for later resolution
   const discoveredSkillPaths = new Map<string, string>();
+  const universalSkillsDir =
+    !isSkillsDir && localPath && options?.universalDir
+      ? await resolveUniversalDiscoveryDir(localPath, options, 'skills')
+      : null;
 
   if (!isSkillsDir && localPath) {
     const discoveryDirs: string[] = [resolve(localPath, 'skills')];
-    if (options?.universalDir && localPath) {
-      discoveryDirs.push(
-        resolve(universalRoot(localPath, options.projectRoot), options.universalDir, 'skills')
-      );
-    }
+    if (universalSkillsDir) discoveryDirs.push(universalSkillsDir);
 
     for (const dir of discoveryDirs) {
       const discovered = await discoverSkillDirs(dir);
@@ -1281,16 +1316,9 @@ export async function resolveNativeSkills(
           const localCandidate = localPath
             ? resolve(localPath, 'skills', skillName, 'SKILL.md')
             : null;
-          const universalCandidate =
-            options?.universalDir && localPath
-              ? resolve(
-                  universalRoot(localPath, options.projectRoot),
-                  options.universalDir,
-                  'skills',
-                  skillName,
-                  'SKILL.md'
-                )
-              : null;
+          const universalCandidate = universalSkillsDir
+            ? resolve(universalSkillsDir, skillName, 'SKILL.md')
+            : null;
           const registryCandidate = resolve(registryPath, '@skills', skillName, 'SKILL.md');
 
           if (localCandidate && (await fileExists(localCandidate))) return localCandidate;
@@ -1548,13 +1576,13 @@ export async function resolveNativeCommands(
 
   // Universal commands (don't overwrite local)
   if (options?.universalDir) {
-    const universalCommands = await discoverCommandFiles(
-      resolve(universalRoot(localPath, options.projectRoot), options.universalDir, 'commands'),
-      logger
-    );
-    for (const [name, value] of Object.entries(universalCommands)) {
-      if (!(name in allCommands)) {
-        allCommands[name] = value;
+    const universalCommandsDir = await resolveUniversalDiscoveryDir(localPath, options, 'commands');
+    if (universalCommandsDir) {
+      const universalCommands = await discoverCommandFiles(universalCommandsDir, logger);
+      for (const [name, value] of Object.entries(universalCommands)) {
+        if (!(name in allCommands)) {
+          allCommands[name] = value;
+        }
       }
     }
   }
@@ -1788,13 +1816,13 @@ export async function resolveNativeAgents(
 
   // Universal agents (don't overwrite local)
   if (options?.universalDir) {
-    const universalAgents = await discoverAgentFiles(
-      resolve(universalRoot(localPath, options.projectRoot), options.universalDir, 'agents'),
-      logger
-    );
-    for (const [name, value] of Object.entries(universalAgents)) {
-      if (!(name in allAgents)) {
-        allAgents[name] = value;
+    const universalAgentsDir = await resolveUniversalDiscoveryDir(localPath, options, 'agents');
+    if (universalAgentsDir) {
+      const universalAgents = await discoverAgentFiles(universalAgentsDir, logger);
+      for (const [name, value] of Object.entries(universalAgents)) {
+        if (!(name in allAgents)) {
+          allAgents[name] = value;
+        }
       }
     }
   }

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -1074,8 +1074,25 @@ export interface NativeSkillOptions {
    * Defaults to undefined (disabled). Typically set to `.agents`.
    */
   universalDir?: string;
+  /**
+   * Project root the universal directory sits in. Without it the root is
+   * guessed as the parent of `localPath`, which only holds while `localPath`
+   * is the `.promptscript` directory.
+   */
+  projectRoot?: string;
   /** Logger for reporting skipped files and resolution decisions. */
   logger?: Logger;
+}
+
+/**
+ * Resolve the directory the universal directory (`.agents`, ...) sits in.
+ *
+ * @param localPath - Base path for local discovery
+ * @param projectRoot - Configured project root, when known
+ * @returns Absolute path to search the universal directory under
+ */
+function universalRoot(localPath: string, projectRoot: string | undefined): string {
+  return projectRoot ? resolve(projectRoot) : resolve(localPath, '..');
 }
 
 /**
@@ -1197,7 +1214,9 @@ export async function resolveNativeSkills(
   if (!isSkillsDir && localPath) {
     const discoveryDirs: string[] = [resolve(localPath, 'skills')];
     if (options?.universalDir && localPath) {
-      discoveryDirs.push(resolve(localPath, '..', options.universalDir, 'skills'));
+      discoveryDirs.push(
+        resolve(universalRoot(localPath, options.projectRoot), options.universalDir, 'skills')
+      );
     }
 
     for (const dir of discoveryDirs) {
@@ -1264,7 +1283,13 @@ export async function resolveNativeSkills(
             : null;
           const universalCandidate =
             options?.universalDir && localPath
-              ? resolve(localPath, '..', options.universalDir, 'skills', skillName, 'SKILL.md')
+              ? resolve(
+                  universalRoot(localPath, options.projectRoot),
+                  options.universalDir,
+                  'skills',
+                  skillName,
+                  'SKILL.md'
+                )
               : null;
           const registryCandidate = resolve(registryPath, '@skills', skillName, 'SKILL.md');
 
@@ -1349,8 +1374,7 @@ export async function resolveNativeSkills(
           const refResources = await resolveSkillReferences(skillRefs, skillDir, logger);
           const existingResources =
             (updatedSkill['resources'] as
-              | Array<{ relativePath: string; content: string }>
-              | undefined) ?? [];
+              Array<{ relativePath: string; content: string }> | undefined) ?? [];
           updatedSkill['resources'] = [
             ...existingResources,
             ...refResources.map((r) => ({
@@ -1368,8 +1392,7 @@ export async function resolveNativeSkills(
           const scriptResources = await resolveSkillScripts(skillScripts, skillDir, logger);
           const existingResources =
             (updatedSkill['resources'] as
-              | Array<{ relativePath: string; content: string }>
-              | undefined) ?? [];
+              Array<{ relativePath: string; content: string }> | undefined) ?? [];
           updatedSkill['resources'] = [
             ...existingResources,
             ...scriptResources.map((r) => ({
@@ -1526,7 +1549,7 @@ export async function resolveNativeCommands(
   // Universal commands (don't overwrite local)
   if (options?.universalDir) {
     const universalCommands = await discoverCommandFiles(
-      resolve(localPath, '..', options.universalDir, 'commands'),
+      resolve(universalRoot(localPath, options.projectRoot), options.universalDir, 'commands'),
       logger
     );
     for (const [name, value] of Object.entries(universalCommands)) {
@@ -1766,7 +1789,7 @@ export async function resolveNativeAgents(
   // Universal agents (don't overwrite local)
   if (options?.universalDir) {
     const universalAgents = await discoverAgentFiles(
-      resolve(localPath, '..', options.universalDir, 'agents'),
+      resolve(universalRoot(localPath, options.projectRoot), options.universalDir, 'agents'),
       logger
     );
     for (const [name, value] of Object.entries(universalAgents)) {

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -1402,9 +1402,7 @@ export async function resolveNativeSkills(
         const skillRefs = parsed.references;
         if (skillRefs && skillRefs.length > 0) {
           const refResources = await resolveSkillReferences(skillRefs, skillDir, logger);
-          const existingResources =
-            (updatedSkill['resources'] as
-              Array<{ relativePath: string; content: string }> | undefined) ?? [];
+          const existingResources = (updatedSkill['resources'] as Value[] | undefined) ?? [];
           updatedSkill['resources'] = [
             ...existingResources,
             ...refResources.map((r) => ({
@@ -1420,9 +1418,7 @@ export async function resolveNativeSkills(
         const skillScripts = parsed.scripts;
         if (skillScripts && skillScripts.length > 0) {
           const scriptResources = await resolveSkillScripts(skillScripts, skillDir, logger);
-          const existingResources =
-            (updatedSkill['resources'] as
-              Array<{ relativePath: string; content: string }> | undefined) ?? [];
+          const existingResources = (updatedSkill['resources'] as Value[] | undefined) ?? [];
           updatedSkill['resources'] = [
             ...existingResources,
             ...scriptResources.map((r) => ({

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -1114,13 +1114,15 @@ async function resolveUniversalDiscoveryDir(
   }
 
   const segments = portableDir.split('/').filter((segment) => segment.length > 0);
-  if (segments.length === 0 || segments.some((segment) => segment === '..')) {
+  if (
+    segments.length === 0 ||
+    segments.some((segment) => segment === '..' || /^[a-zA-Z]:/.test(segment))
+  ) {
     return null;
   }
 
   const root = universalRoot(localPath, options.projectRoot);
   const candidate = resolve(root, ...segments, contentDir);
-  if (!isInside(root, candidate)) return null;
 
   try {
     const [realRoot, realCandidate] = await Promise.all([realpath(root), realpath(candidate)]);


### PR DESCRIPTION
Follow-up to #407. Same class of bug, one level further out: local content was
discovered relative to something other than the project being compiled.

## 1. The universal directory could sit above the project root

Skills, commands and agents from a universal directory (`.agents`) were looked up at
`<localPath>/../<universalDir>/`. That is correct only while `localPath` is the
`.promptscript` directory - which every CLI call site passes, and no library caller
has to.

Reproduced against `main` before the fix:

```
/tmp/probe/parent/.agents/skills/leaked-universal/SKILL.md   <- outside the project
/tmp/probe/parent/proj/project.prs                           <- projectRoot
```

```ts
new Resolver({ registryPath: projectRoot, projectRoot, skills: { universalDir: '.agents' } })
```

```
discovered skills: ["leaked-universal"]
```

The skill body from the neighbouring directory was pulled into the AST and would have
been written into the compiled output.

Discovery now resolves the universal directory under the project root the loader
already computes (`FileLoader.getProjectRoot()`, exposed for this), and only falls back
to the parent-of-`localPath` guess when no project root is known. The
`.promptscript`-sibling layout is unchanged and covered by a test.

## 2. Resolver and hook validation disagreed on the project root

`inferProjectRoot(localPath, projectRoot, entryPath)` falls back to `dirname(entryPath)`,
so hook scripts were validated against the entry file's project. The resolver never saw
the entry path, so with neither `localPath` nor `projectRoot` configured it fell back to
`process.cwd()`. One compile, two different roots: hooks checked in one project, skills
and commands discovered from another.

The resolver is now scoped to the same inferred root. Instances are cached per root so
watch mode and repeated compiles do not rebuild them, and callers that configure
`localPath` or `projectRoot` keep the resolver they asked for.

`compile()`'s `registryPath` default is deliberately left at `process.cwd()`. The
registry is an ambient, shared resource rather than project-scoped content, and moving
its default would change where `@namespace/...` imports resolve for existing callers.

## Tests

- `universal-dir-scope.spec.ts` (new): in-project universal dir found; universal dir
  above the root not found; `.promptscript` sibling layout still works - all through the
  real `Resolver`.
- `skills.spec.ts`: the same two cases at the `resolveNativeSkills` level.
- `resolver.spec.ts`: `getProjectRoot()` derives the root from a `.promptscript`
  localPath.
- `project-root-isolation.spec.ts`: entry-derived root wins over a decoy `skills/`
  directory in the cwd.

Both new invariants were checked against a reverted fix and fail without it.

## Verification

Full pipeline: format, lint, typecheck, test, `prs validate --strict`, `schema:check`,
`skill:check`, `grammar:check`. `nx run-many -t test`: 12 projects green.

## Review follow-up (commit b1796a170e)

- Entry files outside any '.promptscript' directory: the project root is now inferred by walking up for a marker ('.promptscript', then '.git', then 'package.json'). When no marker exists, the compiler keeps the pre-PR cwd-based resolver instead of scoping to dirname(entry) - no traversal-boundary regression for exotic layouts.
- The per-entry resolver cache is bounded (50 roots, oldest evicted) and keyed by realpath when available, so watch mode and symlinked entries do not leak or duplicate resolvers.
- Direct Resolver callers with a custom localPath not named '.promptscript' keep the legacy parent-of-localPath universal directory; the project-root scoping applies only when the root was explicitly configured or derived from a '.promptscript' localPath.
- Coverage gaps closed: universal fallback without projectRoot, commands/agents scoping, named-skill universal candidate, cache hit/bypass/bound, marker-walk imports, vendored hash verification, registry default.