### PR TITLE
fix(cli): refuse output paths that escape the output directory

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -670,10 +670,10 @@ error.
 
 !!! warning "Output paths stay inside the output directory"
 A target `output` that resolves outside the output directory (`../`, or an
-absolute path pointing elsewhere) aborts the compile before any file is
-written. Use `--output` or `output.baseDir` to change where the whole build
-lands; a base directory outside the project is allowed and reported as a
-warning.
+absolute path pointing elsewhere, including through a symlink) aborts the
+compile before any file is written. Use `--output` or `output.baseDir` to
+change where the whole build lands; a base directory outside the project is
+allowed and reported as a warning.
 
 !!! tip "Disabling Targets"
 Setting `enabled: false` skips the target during compilation.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -661,12 +661,19 @@ error.
 | Field           | Type                    | Default         | Description                                            |
 | --------------- | ----------------------- | --------------- | ------------------------------------------------------ |
 | `enabled`       | boolean                 | `true`          | Whether target is enabled                              |
-| `output`        | string                  | (see above)     | Custom output path                                     |
+| `output`        | string                  | (see above)     | Custom output path, relative to the output directory   |
 | `convention`    | string                  | `markdown`      | Output convention (`xml` or `markdown`)                |
 | `version`       | string                  | `full`          | Format version (varies by target, see below)           |
 | `rulesMode`     | `monolith` or `split`   | `monolith`      | Factory always-on rule layout                          |
 | `skillBaseDir`  | string                  | target-specific | Custom base directory for generated skill files        |
 | `includeSkills` | boolean or string array | `true`          | Emit all skills, no skills, or only listed skill names |
+
+!!! warning "Output paths stay inside the output directory"
+A target `output` that resolves outside the output directory (`../`, or an
+absolute path pointing elsewhere) aborts the compile before any file is
+written. Use `--output` or `output.baseDir` to change where the whole build
+lands; a base directory outside the project is allowed and reported as a
+warning.
 
 !!! tip "Disabling Targets"
 Setting `enabled: false` skips the target during compilation.

--- a/packages/cli/src/__tests__/compile-overwrite.spec.ts
+++ b/packages/cli/src/__tests__/compile-overwrite.spec.ts
@@ -429,6 +429,90 @@ describe('compile command - overwrite protection', () => {
       expect(mockPrompts.select).not.toHaveBeenCalled();
     });
 
+    it('should report a guarded rewrite failure for a regular output', async () => {
+      const outputs = new Map([['CLAUDE.md', createMockOutput('CLAUDE.md', 'new content')]]);
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(`# Header\n${PROMPTSCRIPT_MARKER}\n\nOld content`);
+      mockRewriteHookOutputIfUnchanged.mockResolvedValueOnce(false);
+
+      await compileCommand({}, mockServices);
+
+      expect(process.exitCode).toBe(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('changed or became unsafe while PromptScript was writing it')
+      );
+    });
+
+    it('should report a guarded rewrite failure for a hook output', async () => {
+      const path = '.github/hooks/promptscript.json';
+      const outputs = new Map([[path, createMockOutput(path, '{"version":1,"hooks":{}}')]]);
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          version: 1,
+          hooks: {
+            preToolUse: [
+              {
+                type: 'command',
+                bash: 'echo old # promptscript-generated:owned',
+              },
+            ],
+          },
+        })
+      );
+      mockRewriteHookOutputIfUnchanged.mockResolvedValueOnce(false);
+
+      await compileCommand({}, mockServices);
+
+      expect(process.exitCode).toBe(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('changed while PromptScript was writing hooks')
+      );
+    });
+
+    it('should report a guarded mode update failure for unchanged output', async () => {
+      const outputs = new Map([
+        [
+          'script.sh',
+          {
+            ...createMockOutput('script.sh', 'same content'),
+            mode: 0o755,
+          },
+        ],
+      ]);
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue('same content');
+      mockRewriteHookOutputIfUnchanged.mockResolvedValueOnce(false);
+
+      await compileCommand({}, mockServices);
+
+      expect(process.exitCode).toBe(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('changed or became unsafe while PromptScript was updating its mode')
+      );
+    });
+
     it('should overwrite a fully owned generated hook file', async () => {
       const path = '.github/hooks/promptscript.json';
       const outputs = new Map([[path, createMockOutput(path, '{"version":1,"hooks":{}}')]]);

--- a/packages/cli/src/__tests__/compile-overwrite.spec.ts
+++ b/packages/cli/src/__tests__/compile-overwrite.spec.ts
@@ -283,6 +283,27 @@ describe('compile command - overwrite protection', () => {
       expect(mockWriteFile).not.toHaveBeenCalled();
       expect(process.exitCode).toBe(1);
     });
+
+    it('should refuse an escaping path during dry-run', async () => {
+      const escaping = '../outside/CLAUDE.md';
+      const outputs = new Map([[escaping, createMockOutput(escaping, 'content')]]);
+
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+
+      await compileCommand({ dryRun: true }, mockServices);
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Refusing to write outside the output directory')
+      );
+      expect(process.exitCode).toBe(1);
+    });
   });
 
   describe('when file does not exist', () => {

--- a/packages/cli/src/__tests__/compile-overwrite.spec.ts
+++ b/packages/cli/src/__tests__/compile-overwrite.spec.ts
@@ -241,6 +241,50 @@ describe('compile command - overwrite protection', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  describe('when a target output escapes the output directory', () => {
+    it('should refuse to write anything', async () => {
+      const escaping = '../outside/CLAUDE.md';
+      const outputs = new Map([
+        ['CLAUDE.md', createMockOutput('CLAUDE.md', 'content')],
+        [escaping, createMockOutput(escaping, 'content')],
+      ]);
+
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+
+      await compileCommand({}, mockServices);
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Refusing to write outside the output directory')
+      );
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should refuse an absolute path outside the output directory', async () => {
+      const escaping = '/etc/promptscript-owned.md';
+      const outputs = new Map([[escaping, createMockOutput(escaping, 'content')]]);
+
+      mockCompile.mockResolvedValue({
+        success: true,
+        outputs,
+        stats: { totalTime: 100, resolveTime: 50, validateTime: 25, formatTime: 25 },
+        warnings: [],
+        errors: [],
+      });
+
+      await compileCommand({}, mockServices);
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
   describe('when file does not exist', () => {
     it('should write file normally without prompting', async () => {
       const outputs = new Map([['CLAUDE.md', createMockOutput('CLAUDE.md', 'content')]]);

--- a/packages/cli/src/__tests__/compile-overwrite.spec.ts
+++ b/packages/cli/src/__tests__/compile-overwrite.spec.ts
@@ -13,6 +13,7 @@ const {
   mockExistsSync,
   mockIsTTY,
   mockCreateHookOutputSafely,
+  mockRewriteHookOutputIfUnchanged,
   mockLoadConfig,
   mockChokidarWatch,
   mockWatcherOn,
@@ -27,6 +28,7 @@ const {
   const mockExistsSync = vi.fn();
   const mockIsTTY = vi.fn();
   const mockCreateHookOutputSafely = vi.fn();
+  const mockRewriteHookOutputIfUnchanged = vi.fn();
   const mockLoadConfig = vi.fn();
   const mockWatcherOn = vi.fn().mockReturnThis();
   const mockChokidarWatch = vi.fn().mockReturnValue({
@@ -46,6 +48,7 @@ const {
     mockExistsSync,
     mockIsTTY,
     mockCreateHookOutputSafely,
+    mockRewriteHookOutputIfUnchanged,
     mockLoadConfig,
     mockChokidarWatch,
     mockWatcherOn,
@@ -122,10 +125,15 @@ vi.mock('chalk', () => ({
 }));
 
 // Mock fs.existsSync for the entry file check
-vi.mock('fs', () => ({
-  existsSync: (path: string) => (path.endsWith('promptscript.lock') ? false : mockExistsSync(path)),
-  readFileSync: vi.fn().mockReturnValue(''),
-}));
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: (path: string) =>
+      path.endsWith('promptscript.lock') ? false : mockExistsSync(path),
+    readFileSync: vi.fn().mockReturnValue(''),
+  };
+});
 
 // Mock pager for isTTY
 vi.mock('../output/pager.js', () => ({
@@ -137,14 +145,22 @@ vi.mock('../utils/managed-output-cleanup.js', async (importOriginal) => {
   return {
     ...actual,
     createHookOutputSafely: mockCreateHookOutputSafely.mockImplementation(
-      async (path: string, _outputRoot: string, content: string) => {
+      async (path: string, _outputRoot: string, content: string, mode?: number) => {
         await mockWriteFile(path, content, 'utf-8');
+        if (mode !== undefined) await mockChmod(path, mode);
         return true;
       }
     ),
-    rewriteHookOutputIfUnchanged: vi.fn(
-      async (path: string, _outputRoot: string, _expectedContent: string, content: string) => {
+    rewriteHookOutputIfUnchanged: mockRewriteHookOutputIfUnchanged.mockImplementation(
+      async (
+        path: string,
+        _outputRoot: string,
+        _expectedContent: string,
+        content: string,
+        mode?: number
+      ) => {
         await mockWriteFile(path, content, 'utf-8');
+        if (mode !== undefined) await mockChmod(path, mode);
         return true;
       }
     ),
@@ -327,6 +343,12 @@ describe('compile command - overwrite protection', () => {
       await compileCommand({}, mockServices);
 
       expect(mockWriteFile).toHaveBeenCalledWith(resolve('CLAUDE.md'), 'content', 'utf-8');
+      expect(mockCreateHookOutputSafely).toHaveBeenCalledWith(
+        resolve('CLAUDE.md'),
+        process.cwd(),
+        'content',
+        undefined
+      );
       expect(mockPrompts.select).not.toHaveBeenCalled();
     });
   });
@@ -397,6 +419,13 @@ describe('compile command - overwrite protection', () => {
       await compileCommand({}, mockServices);
 
       expect(mockWriteFile).toHaveBeenCalledWith(resolve('CLAUDE.md'), 'new content', 'utf-8');
+      expect(mockRewriteHookOutputIfUnchanged).toHaveBeenCalledWith(
+        resolve('CLAUDE.md'),
+        process.cwd(),
+        expect.stringContaining(PROMPTSCRIPT_MARKER),
+        'new content',
+        undefined
+      );
       expect(mockPrompts.select).not.toHaveBeenCalled();
     });
 

--- a/packages/cli/src/__tests__/compile-utils.spec.ts
+++ b/packages/cli/src/__tests__/compile-utils.spec.ts
@@ -215,21 +215,33 @@ describe('validateOutputPath', () => {
   it('should reject an absolute path outside the project root', () => {
     const result = validateOutputPath('/outside/generated.md', '/repo/project');
 
-    expect(result).toBe('Output path "/outside/generated.md" escapes project root');
+    expect(result).toBe(
+      'Output path "/outside/generated.md" escapes the output directory /repo/project'
+    );
   });
 
   it('should reject a relative path containing traversal', () => {
     const result = validateOutputPath('../generated.md', '/repo/project');
 
-    expect(result).toBe('Output path "../generated.md" contains path traversal');
+    expect(result).toBe('Output path "../generated.md" escapes the output directory /repo/project');
   });
 
-  it.each(['/repo/project/generated.md', 'generated/output.md'])(
-    'should accept project-local path %s',
-    (outputPath) => {
-      expect(validateOutputPath(outputPath, '/repo/project')).toBeUndefined();
-    }
-  );
+  it('should reject traversal that only escapes after a subdirectory', () => {
+    expect(validateOutputPath('nested/../../generated.md', '/repo/project')).toBeDefined();
+  });
+
+  it('should reject the output directory itself', () => {
+    expect(validateOutputPath('.', '/repo/project')).toBeDefined();
+  });
+
+  it.each([
+    '/repo/project/generated.md',
+    'generated/output.md',
+    'nested/../generated.md',
+    'weird..name.md',
+  ])('should accept project-local path %s', (outputPath) => {
+    expect(validateOutputPath(outputPath, '/repo/project')).toBeUndefined();
+  });
 });
 
 describe('detectBuildOutputCollisions', () => {

--- a/packages/cli/src/__tests__/compile-utils.spec.ts
+++ b/packages/cli/src/__tests__/compile-utils.spec.ts
@@ -173,6 +173,7 @@ describe('findConfigInDir', () => {
 import {
   detectBuildOutputCollisions,
   detectOutputConflicts,
+  isPathInsideDir,
   resolveOutputPath,
   validateOutputPath,
 } from '../utils/conflict-detector.js';
@@ -241,6 +242,17 @@ describe('validateOutputPath', () => {
     'weird..name.md',
   ])('should accept project-local path %s', (outputPath) => {
     expect(validateOutputPath(outputPath, '/repo/project')).toBeUndefined();
+  });
+});
+
+describe('isPathInsideDir', () => {
+  it('should allow a directory equal to the root', () => {
+    expect(isPathInsideDir('.', '/repo/project')).toBe(true);
+    expect(isPathInsideDir('/repo/project', '/repo/project')).toBe(true);
+  });
+
+  it('should reject a directory outside the root', () => {
+    expect(isPathInsideDir('../sibling', '/repo/project')).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -934,6 +934,9 @@ describe('compile command - createCliLogger warn path', () => {
       },
     ]);
     expect(mockWriteFile).toHaveBeenCalledWith('/repo/logstrip/AGENTS.md', '# Agents\n', 'utf-8');
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.stringContaining('is outside the project root')
+    );
   });
 
   it('should let --output override a build profile output', async () => {
@@ -1323,8 +1326,7 @@ describe('compile command - createCliLogger warn path', () => {
       expect(mockWatch).toHaveBeenCalledTimes(1);
 
       const changeHandler = mockWatcherOn.mock.calls.find(([event]) => event === 'change')?.[1] as
-        | ((path: string) => void)
-        | undefined;
+        ((path: string) => void) | undefined;
       changeHandler?.('/repo/promptscript/.promptscript/project.prs');
       await vi.runAllTimersAsync();
 
@@ -1379,8 +1381,7 @@ describe('compile command - createCliLogger warn path', () => {
       ).toBe(false);
 
       const changeHandler = mockWatcherOn.mock.calls.find(([event]) => event === 'change')?.[1] as
-        | ((path: string) => void)
-        | undefined;
+        ((path: string) => void) | undefined;
       expect(changeHandler).toBeDefined();
       mockSpinnerStart.mockImplementationOnce(() => {
         throw 'watch rebuild failed';

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -152,10 +152,14 @@ vi.mock('chalk', () => ({
   },
 }));
 
-vi.mock('fs', () => ({
-  existsSync: (...args: unknown[]) => mockExistsSync(...args),
-  readFileSync: vi.fn().mockReturnValue(''),
-}));
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    readFileSync: vi.fn().mockReturnValue(''),
+  };
+});
 
 vi.mock('../../output/pager.js', () => ({
   isTTY: (...args: unknown[]) => mockIsTTY(...args),
@@ -179,12 +183,22 @@ vi.mock('../../utils/managed-output-cleanup.js', async (importOriginal) => {
     mergePromptScriptCodexConfig: vi.fn().mockReturnValue(undefined),
     mergePromptScriptHookOutput: vi.fn().mockReturnValue(undefined),
     removePromptScriptOwnedCodexHooks: vi.fn().mockReturnValue(undefined),
-    rewriteHookOutputIfUnchanged: (...args: unknown[]) => mockRewriteHookOutputIfUnchanged(...args),
+    rewriteHookOutputIfUnchanged: async (...args: unknown[]) => {
+      const rewritten = await mockRewriteHookOutputIfUnchanged(...args);
+      const mode = args[4];
+      if (rewritten && typeof mode === 'number') {
+        await mockChmod(String(args[0]), mode);
+      }
+      return rewritten;
+    },
     removeHookOutputIfUnchanged: (...args: unknown[]) => mockRemoveHookOutputIfUnchanged(...args),
-    createHookOutputSafely: vi.fn(async (path: string, _root: string, content: string) => {
-      await mockWriteFile(path, content, 'utf-8');
-      return true;
-    }),
+    createHookOutputSafely: vi.fn(
+      async (path: string, _root: string, content: string, mode?: number) => {
+        await mockWriteFile(path, content, 'utf-8');
+        if (mode !== undefined) await mockChmod(path, mode);
+        return true;
+      }
+    ),
   };
 });
 

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -939,6 +939,27 @@ describe('compile command - createCliLogger warn path', () => {
     );
   });
 
+  it('should not warn when output directory is the project root', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['claude'],
+      registry: { path: './registry' },
+      output: { baseDir: '.' },
+    });
+    mockCompile.mockResolvedValue({
+      success: true,
+      outputs: new Map([['CLAUDE.md', { path: 'CLAUDE.md', content: '# Claude\n' }]]),
+      stats: { totalTime: 10, resolveTime: 5, validateTime: 3, formatTime: 2 },
+      warnings: [],
+      errors: [],
+    });
+
+    await compileCommand({ cwd: '/repo/promptscript' }, mockServices);
+
+    expect(mockWarning).not.toHaveBeenCalledWith(
+      expect.stringContaining('is outside the project root')
+    );
+  });
+
   it('should let --output override a build profile output', async () => {
     mockLoadConfig.mockResolvedValue({
       targets: ['claude'],

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -13,7 +13,7 @@ import type {
   BuildProfileConfig,
   Lockfile,
 } from '@promptscript/core';
-import { isValidLockfile } from '@promptscript/core';
+import { ErrorCode, isValidLockfile, PSError } from '@promptscript/core';
 
 import type { CompileResult, FormatterOutput } from '@promptscript/compiler';
 import { loadEffectiveConfig, CONFIG_FILES } from '../config/loader.js';
@@ -26,7 +26,11 @@ import { type CliServices, createDefaultServices } from '../services.js';
 import { resolveRegistryPath } from '../utils/registry-resolver.js';
 import { parse as parseYaml } from 'yaml';
 import { stripMarkers } from '../utils/markers.js';
-import { detectOutputConflicts, validateOutputPath } from '../utils/conflict-detector.js';
+import {
+  detectOutputConflicts,
+  isPathInsideDir,
+  validateOutputPath,
+} from '../utils/conflict-detector.js';
 import {
   cleanupManagedOutputs,
   createHookOutputSafely,
@@ -448,8 +452,9 @@ async function writeOutputs(
     .map((output) => validateOutputPath(output.path, outputRoot))
     .filter((message): message is string => message !== undefined);
   if (escaping.length > 0) {
-    throw new Error(
-      `Refusing to write outside the output directory:\n${escaping.map((m) => `  - ${m}`).join('\n')}`
+    throw new PSError(
+      `Refusing to write outside the output directory:\n${escaping.map((m) => `  - ${m}`).join('\n')}`,
+      ErrorCode.INVALID_PATH
     );
   }
 
@@ -987,7 +992,7 @@ async function compileCommandWithResult(
     // Writing to a sibling directory is a supported build-profile layout, but a
     // base directory that leaves the project comes from a checked-in file, so
     // say where the files are going instead of doing it silently.
-    if (!options.output && configuredOutput && validateOutputPath(configuredOutput, projectRoot)) {
+    if (!options.output && configuredOutput && !isPathInsideDir(configuredOutput, projectRoot)) {
       ConsoleOutput.warning(
         `Configured output directory "${configuredOutput}" is outside the project root ${projectRoot}`
       );

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,6 +1,6 @@
 import { resolve, dirname, isAbsolute, relative } from 'path';
 import { fileURLToPath } from 'url';
-import { chmod, writeFile, mkdir, readFile } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import chokidar from 'chokidar';
 import { minimatch } from 'minimatch';
@@ -505,56 +505,29 @@ async function writeOutputs(
     }
   }
 
-  /** Write a file with graceful handling for ENOTDIR/EEXIST conflicts. */
-  async function safeWrite(path: string, content: string, mode?: number): Promise<boolean> {
-    try {
-      await mkdir(dirname(path), { recursive: true });
-      await writeFile(path, content, 'utf-8');
-      if (mode !== undefined) {
-        await chmod(path, mode);
-      }
-      return true;
-    } catch (err: unknown) {
-      const nodeErr = err as NodeJS.ErrnoException;
-      if (nodeErr.code === 'ENOTDIR') {
-        const conflictPath = nodeErr.path ?? dirname(path);
-        const msg = `Cannot create directory because '${conflictPath}' already exists as a file. Remove it or disable this target.`;
-        targetErrors.push(msg);
-        ConsoleOutput.error(msg);
-        return false;
-      }
-      if (nodeErr.code === 'EISDIR') {
-        const msg = `Cannot write '${path}' because a directory exists at that path.`;
-        targetErrors.push(msg);
-        ConsoleOutput.error(msg);
-        return false;
-      }
-      throw err;
-    }
-  }
-
   async function safeOverwrite(
     output: FormatterOutput,
     outputPath: string,
     existingContent: string | undefined,
     content: string
   ): Promise<boolean> {
-    if (!isHookOutputPath(output.path)) {
-      return safeWrite(outputPath, content, output.mode);
-    }
-
     const outputRoot = options.output ? resolve(options.output) : process.cwd();
     const rewritten =
       existingContent !== undefined &&
-      (await rewriteHookOutputIfUnchanged(outputPath, outputRoot, existingContent, content));
-    if (rewritten && output.mode !== undefined) {
-      await chmod(outputPath, output.mode);
-    }
+      (await rewriteHookOutputIfUnchanged(
+        outputPath,
+        outputRoot,
+        existingContent,
+        content,
+        output.mode
+      ));
     if (!rewritten) {
       const msg =
         existingContent === undefined
           ? `Skipped '${outputPath}' because it exists but could not be read.`
-          : `Skipped '${outputPath}' because it changed while PromptScript was writing hooks.`;
+          : isHookOutputPath(output.path)
+            ? `Skipped '${outputPath}' because it changed while PromptScript was writing hooks.`
+            : `Skipped '${outputPath}' because it changed or became unsafe while PromptScript was writing it.`;
       targetErrors.push(msg);
       ConsoleOutput.error(msg);
     }
@@ -566,14 +539,10 @@ async function writeOutputs(
     outputPath: string,
     content: string
   ): Promise<boolean> {
-    if (!isHookOutputPath(output.path)) {
-      return safeWrite(outputPath, content, output.mode);
-    }
-
     const outputRoot = options.output ? resolve(options.output) : process.cwd();
     const created = await createHookOutputSafely(outputPath, outputRoot, content, output.mode);
     if (!created) {
-      const msg = `Skipped '${outputPath}' because its hook path was not safe to create.`;
+      const msg = `Skipped '${outputPath}' because its output path was not safe to create.`;
       targetErrors.push(msg);
       ConsoleOutput.error(msg);
     }
@@ -646,8 +615,20 @@ async function writeOutputs(
 
     // Nothing but the marker would change - keep the file (and its timestamp)
     if (contentMatches) {
-      if (output.mode !== undefined) {
-        await chmod(outputPath, output.mode);
+      if (output.mode !== undefined && existingContent !== undefined) {
+        const modeUpdated = await rewriteHookOutputIfUnchanged(
+          outputPath,
+          options.output ? resolve(options.output) : process.cwd(),
+          existingContent,
+          existingContent,
+          output.mode
+        );
+        if (!modeUpdated) {
+          const msg = `Skipped '${outputPath}' because it changed or became unsafe while PromptScript was updating its mode.`;
+          targetErrors.push(msg);
+          ConsoleOutput.error(msg);
+          continue;
+        }
       }
       ConsoleOutput.unchanged(outputPath);
       result.unchanged.push(outputPath);

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -26,7 +26,7 @@ import { type CliServices, createDefaultServices } from '../services.js';
 import { resolveRegistryPath } from '../utils/registry-resolver.js';
 import { parse as parseYaml } from 'yaml';
 import { stripMarkers } from '../utils/markers.js';
-import { detectOutputConflicts } from '../utils/conflict-detector.js';
+import { detectOutputConflicts, validateOutputPath } from '../utils/conflict-detector.js';
 import {
   cleanupManagedOutputs,
   createHookOutputSafely,
@@ -439,6 +439,19 @@ async function writeOutputs(
   let overwriteAll = false;
   const conflicts: string[] = [];
   const targetErrors: string[] = [];
+
+  // Pre-flight: a target `output` comes from the config file, so a checked-in
+  // path may point anywhere the user can write. Reject the whole run before
+  // writing anything rather than planting files outside the output directory.
+  const outputRoot = options.output ?? process.cwd();
+  const escaping = [...outputs.values()]
+    .map((output) => validateOutputPath(output.path, outputRoot))
+    .filter((message): message is string => message !== undefined);
+  if (escaping.length > 0) {
+    throw new Error(
+      `Refusing to write outside the output directory:\n${escaping.map((m) => `  - ${m}`).join('\n')}`
+    );
+  }
 
   // Pre-flight: in non-interactive mode without --force, detect every
   // ownership conflict before writing anything so a refused overwrite cannot
@@ -971,6 +984,14 @@ async function compileCommandWithResult(
     }
 
     const configuredOutput = options.output ?? buildProfile?.output ?? config.output?.baseDir;
+    // Writing to a sibling directory is a supported build-profile layout, but a
+    // base directory that leaves the project comes from a checked-in file, so
+    // say where the files are going instead of doing it silently.
+    if (!options.output && configuredOutput && validateOutputPath(configuredOutput, projectRoot)) {
+      ConsoleOutput.warning(
+        `Configured output directory "${configuredOutput}" is outside the project root ${projectRoot}`
+      );
+    }
     const effectiveOptions = {
       ...options,
       output: resolveOutputBase(projectRoot, configuredOutput),

--- a/packages/cli/src/utils/__tests__/managed-output-cleanup.spec.ts
+++ b/packages/cli/src/utils/__tests__/managed-output-cleanup.spec.ts
@@ -594,6 +594,22 @@ command = "echo owned # promptscript-generated:owned"
     await expect(readFile(file, 'utf-8')).resolves.toBe('new');
   });
 
+  it.skipIf(process.platform === 'win32')(
+    'should apply output modes during guarded creates and rewrites',
+    async () => {
+      const project = await createTemporaryDirectory('promptscript-output-mode-');
+      const file = join(project, 'scripts', 'run.sh');
+
+      await expect(createHookOutputSafely(file, project, 'old', 0o755)).resolves.toBe(true);
+      expect((await lstat(file)).mode & 0o777).toBe(0o755);
+
+      await expect(rewriteHookOutputIfUnchanged(file, project, 'old', 'new', 0o644)).resolves.toBe(
+        true
+      );
+      expect((await lstat(file)).mode & 0o777).toBe(0o644);
+    }
+  );
+
   it('should refuse hook rewrites through a parent symlink', async () => {
     const project = await createTemporaryDirectory('promptscript-rewrite-root-');
     const outside = await createTemporaryDirectory('promptscript-rewrite-outside-');

--- a/packages/cli/src/utils/conflict-detector.spec.ts
+++ b/packages/cli/src/utils/conflict-detector.spec.ts
@@ -1,0 +1,51 @@
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { validateOutputPath } from './conflict-detector.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+async function createOutputRoot(): Promise<{ root: string; outputRoot: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'promptscript-output-path-'));
+  const outputRoot = join(root, 'output');
+  await mkdir(outputRoot);
+  temporaryDirectories.push(root);
+  return { root, outputRoot };
+}
+
+describe('validateOutputPath symlink containment', () => {
+  it('rejects a path through a symlink that escapes the output root', async () => {
+    const { root, outputRoot } = await createOutputRoot();
+    const outside = join(root, 'outside');
+    await mkdir(outside);
+    await symlink(outside, join(outputRoot, 'docs'), 'dir');
+
+    expect(validateOutputPath('docs/generated.md', outputRoot)).toBeDefined();
+  });
+
+  it('accepts a path through a symlink that stays inside the output root', async () => {
+    const { outputRoot } = await createOutputRoot();
+    const inside = join(outputRoot, 'shared');
+    await mkdir(inside);
+    await symlink(inside, join(outputRoot, 'docs'), 'dir');
+
+    expect(validateOutputPath('docs/generated.md', outputRoot)).toBeUndefined();
+  });
+
+  it('falls back to lexical containment for a broken symlink', async () => {
+    const { outputRoot } = await createOutputRoot();
+    await symlink(join(outputRoot, '..', 'missing'), join(outputRoot, 'docs'), 'dir');
+
+    expect(() => validateOutputPath('docs/generated.md', outputRoot)).not.toThrow();
+    expect(validateOutputPath('docs/generated.md', outputRoot)).toBeUndefined();
+  });
+});

--- a/packages/cli/src/utils/conflict-detector.spec.ts
+++ b/packages/cli/src/utils/conflict-detector.spec.ts
@@ -41,11 +41,18 @@ describe('validateOutputPath symlink containment', () => {
     expect(validateOutputPath('docs/generated.md', outputRoot)).toBeUndefined();
   });
 
-  it('falls back to lexical containment for a broken symlink', async () => {
+  it('rejects a path through a broken symlink', async () => {
     const { outputRoot } = await createOutputRoot();
     await symlink(join(outputRoot, '..', 'missing'), join(outputRoot, 'docs'), 'dir');
 
     expect(() => validateOutputPath('docs/generated.md', outputRoot)).not.toThrow();
-    expect(validateOutputPath('docs/generated.md', outputRoot)).toBeUndefined();
+    expect(validateOutputPath('docs/generated.md', outputRoot)).toContain('cannot be verified');
+  });
+
+  it('rejects a dangling symlink at the final output path', async () => {
+    const { root, outputRoot } = await createOutputRoot();
+    await symlink(join(root, 'missing.md'), join(outputRoot, 'generated.md'));
+
+    expect(validateOutputPath('generated.md', outputRoot)).toContain('cannot be verified');
   });
 });

--- a/packages/cli/src/utils/conflict-detector.spec.ts
+++ b/packages/cli/src/utils/conflict-detector.spec.ts
@@ -1,12 +1,33 @@
 import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const fsProbe = vi.hoisted(() => ({
+  errorCode: undefined as string | undefined,
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    lstatSync: (path: import('fs').PathLike) => {
+      if (fsProbe.errorCode) {
+        const error = new Error('Filesystem probe failed') as NodeJS.ErrnoException;
+        error.code = fsProbe.errorCode;
+        throw error;
+      }
+      return actual.lstatSync(path);
+    },
+  };
+});
+
 import { validateOutputPath } from './conflict-detector.js';
 
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
+  fsProbe.errorCode = undefined;
   await Promise.all(
     temporaryDirectories
       .splice(0)
@@ -52,6 +73,20 @@ describe('validateOutputPath symlink containment', () => {
   it('rejects a dangling symlink at the final output path', async () => {
     const { root, outputRoot } = await createOutputRoot();
     await symlink(join(root, 'missing.md'), join(outputRoot, 'generated.md'));
+
+    expect(validateOutputPath('generated.md', outputRoot)).toContain('cannot be verified');
+  });
+
+  it('rejects a path when filesystem metadata cannot be read', async () => {
+    const { outputRoot } = await createOutputRoot();
+    fsProbe.errorCode = 'EACCES';
+
+    expect(validateOutputPath('generated.md', outputRoot)).toContain('cannot be verified');
+  });
+
+  it('rejects a path when no existing ancestor can be verified', async () => {
+    const { outputRoot } = await createOutputRoot();
+    fsProbe.errorCode = 'ENOENT';
 
     expect(validateOutputPath('generated.md', outputRoot)).toContain('cannot be verified');
   });

--- a/packages/cli/src/utils/conflict-detector.ts
+++ b/packages/cli/src/utils/conflict-detector.ts
@@ -49,7 +49,7 @@ export function validateOutputPath(outputPath: string, outputRoot: string): stri
       return `Output path "${outputPath}" escapes the output directory ${outputRoot}`;
     }
   } catch {
-    // Filesystem probing can race with writes or fail due to permissions.
+    return `Output path "${outputPath}" cannot be verified inside the output directory ${outputRoot}`;
   }
 
   return undefined;
@@ -74,10 +74,24 @@ function resolveThroughExistingAncestor(path: string): string {
   const missingSegments: string[] = [];
   let current = path;
 
-  while (!fs.existsSync(current)) {
+  while (true) {
+    try {
+      fs.lstatSync(current);
+      break;
+    } catch (error: unknown) {
+      if (
+        typeof error !== 'object' ||
+        error === null ||
+        !('code' in error) ||
+        error.code !== 'ENOENT'
+      ) {
+        throw error;
+      }
+    }
+
     const parent = dirname(current);
     if (parent === current) {
-      return path;
+      throw new Error(`No existing ancestor for ${path}`);
     }
     missingSegments.unshift(basename(current));
     current = parent;

--- a/packages/cli/src/utils/conflict-detector.ts
+++ b/packages/cli/src/utils/conflict-detector.ts
@@ -1,6 +1,6 @@
 import type { TargetConfig } from '@promptscript/core';
 import { DEFAULT_OUTPUT_PATHS } from '@promptscript/core';
-import { resolve, relative, isAbsolute } from 'path';
+import { resolve, relative, isAbsolute, sep } from 'path';
 
 /**
  * Detect output path conflicts: multiple targets writing to the same file.
@@ -28,21 +28,15 @@ export function detectOutputConflicts(
 }
 
 /**
- * Validate that an output path is project-relative and does not contain traversal.
+ * Validate that an output path stays inside the directory it is written to.
  * Returns an error message if invalid, or undefined if valid.
  */
-export function validateOutputPath(outputPath: string, projectRoot?: string): string | undefined {
-  // Reject absolute paths that escape the project root
-  if (isAbsolute(outputPath) && projectRoot) {
-    const rel = relative(projectRoot, outputPath);
-    if (rel.startsWith('..') || isAbsolute(rel)) {
-      return `Output path "${outputPath}" escapes project root`;
-    }
-  }
+export function validateOutputPath(outputPath: string, outputRoot: string): string | undefined {
+  const resolved = resolveOutputPath(outputPath, outputRoot);
+  const rel = relative(resolve(outputRoot), resolved);
 
-  // Reject path traversal patterns
-  if (outputPath.includes('..')) {
-    return `Output path "${outputPath}" contains path traversal`;
+  if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    return `Output path "${outputPath}" escapes the output directory ${outputRoot}`;
   }
 
   return undefined;

--- a/packages/cli/src/utils/conflict-detector.ts
+++ b/packages/cli/src/utils/conflict-detector.ts
@@ -1,6 +1,7 @@
 import type { TargetConfig } from '@promptscript/core';
 import { DEFAULT_OUTPUT_PATHS } from '@promptscript/core';
-import { resolve, relative, isAbsolute, sep } from 'path';
+import * as fs from 'fs';
+import { basename, dirname, resolve, relative, isAbsolute, sep } from 'path';
 
 /**
  * Detect output path conflicts: multiple targets writing to the same file.
@@ -33,13 +34,60 @@ export function detectOutputConflicts(
  */
 export function validateOutputPath(outputPath: string, outputRoot: string): string | undefined {
   const resolved = resolveOutputPath(outputPath, outputRoot);
-  const rel = relative(resolve(outputRoot), resolved);
+  const root = resolve(outputRoot);
+  const rel = relative(root, resolved);
 
-  if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+  if (!isPathContained(rel, false)) {
     return `Output path "${outputPath}" escapes the output directory ${outputRoot}`;
   }
 
+  try {
+    // Lexical paths can cross a symlink, so compare resolved filesystem paths too.
+    const realRoot = resolveThroughExistingAncestor(root);
+    const realResolved = resolveThroughExistingAncestor(resolved);
+    if (!isPathContained(relative(realRoot, realResolved), false)) {
+      return `Output path "${outputPath}" escapes the output directory ${outputRoot}`;
+    }
+  } catch {
+    // Filesystem probing can race with writes or fail due to permissions.
+  }
+
   return undefined;
+}
+
+/**
+ * Check directory containment while allowing the directory itself.
+ */
+export function isPathInsideDir(dir: string, root: string): boolean {
+  const rel = relative(resolve(root), resolveOutputPath(dir, root));
+  return isPathContained(rel, true);
+}
+
+function isPathContained(rel: string, allowEqual: boolean): boolean {
+  return (
+    (allowEqual && rel === '') ||
+    (rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+  );
+}
+
+function resolveThroughExistingAncestor(path: string): string {
+  const missingSegments: string[] = [];
+  let current = path;
+
+  while (!fs.existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) {
+      return path;
+    }
+    missingSegments.unshift(basename(current));
+    current = parent;
+  }
+
+  const realpathSync = fs.realpathSync?.native ?? fs.realpathSync;
+  if (typeof realpathSync !== 'function') {
+    throw new Error('realpathSync is unavailable');
+  }
+  return resolve(realpathSync(current), ...missingSegments);
 }
 
 /**

--- a/packages/cli/src/utils/conflict-detector.ts
+++ b/packages/cli/src/utils/conflict-detector.ts
@@ -97,11 +97,7 @@ function resolveThroughExistingAncestor(path: string): string {
     current = parent;
   }
 
-  const realpathSync = fs.realpathSync?.native ?? fs.realpathSync;
-  if (typeof realpathSync !== 'function') {
-    throw new Error('realpathSync is unavailable');
-  }
-  return resolve(realpathSync(current), ...missingSegments);
+  return resolve(fs.realpathSync.native(current), ...missingSegments);
 }
 
 /**

--- a/packages/cli/src/utils/managed-output-cleanup.ts
+++ b/packages/cli/src/utils/managed-output-cleanup.ts
@@ -85,7 +85,7 @@ process.stdout.write('removed');
 const GUARDED_REWRITE_SCRIPT = String.raw`
 const crypto = require('node:crypto');
 const fs = require('node:fs');
-const [name, directoryDev, directoryIno, fileDev, fileIno, expectedHash] =
+const [name, directoryDev, directoryIno, fileDev, fileIno, expectedHash, requestedMode] =
   process.argv.slice(1);
 const skip = () => process.stdout.write('skipped');
 if (!name || name === '.' || name === '..' || name.includes('/') || name.includes('\\')) {
@@ -129,7 +129,7 @@ try {
   const descriptor = fs.openSync(
     temporary,
     fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
-    file.mode & 0o777
+    requestedMode === '' ? file.mode & 0o777 : Number(requestedMode) & 0o777
   );
   temporaryCreated = true;
   try {
@@ -502,7 +502,8 @@ export async function rewriteHookOutputIfUnchanged(
   file: string,
   outputRoot: string,
   expectedContent: string,
-  content: string
+  content: string,
+  mode?: number
 ): Promise<boolean> {
   const root = resolve(outputRoot);
   const candidate = resolve(file);
@@ -524,7 +525,8 @@ export async function rewriteHookOutputIfUnchanged(
       directoryStat,
       fileStat,
       expectedContent,
-      content
+      content,
+      mode
     );
   } finally {
     await closeDirectoryGuards(guards);
@@ -588,7 +590,8 @@ async function guardedRewrite(
   directoryStat: FileIdentity,
   fileStat: FileIdentity,
   expectedContent: string,
-  content: string
+  content: string,
+  mode?: number
 ): Promise<boolean> {
   const expectedHash = createHash('sha256').update(expectedContent).digest('hex');
 
@@ -605,6 +608,7 @@ async function guardedRewrite(
         String(fileStat.dev),
         String(fileStat.ino),
         expectedHash,
+        mode === undefined ? '' : String(mode),
       ],
       {
         cwd: directory,
@@ -1099,7 +1103,7 @@ export function removePromptScriptOwnedCodexHooks(
   const lines = content.split('\n');
   const remaining: string[] = [];
   let removed = false;
-  for (let index = 0; index < lines.length; ) {
+  for (let index = 0; index < lines.length;) {
     const eventMatch = lines[index]!.match(/^\s*\[\[hooks\.([A-Za-z][A-Za-z0-9_]*)\]\]\s*$/);
     if (!eventMatch) {
       remaining.push(lines[index]!);


### PR DESCRIPTION
## The problem

`prs compile` resolved each target's `output` and wrote it with no containment
check. Reproduced against `main` in a sandbox project:

```yaml
# promptscript.yaml
version: '1.0'
source: .promptscript/project.prs
targets:
  - github:
      output: ../escaped/copilot-instructions.md
```

```
$ prs compile
✔ Compiled

$ find /tmp/probe -type f
/tmp/probe/escaped/copilot-instructions.md      <- outside the project
/tmp/probe/proj/AGENTS.md
```

No warning, no error. An absolute `output` behaved the same way. Since
`promptscript.yaml` is checked in, cloning a repository and compiling it was
enough to have files written to any path the user can write - shell rc files,
`~/.ssh/`, git hooks.

`validateOutputPath()` was written for exactly this check and had no callers -
only its own unit test.

## The fix

`writeOutputs` now validates every output path against the output directory
before the first write and aborts with the full list:

```
✗ Refusing to write outside the output directory:
  - Output path "../escaped/copilot-instructions.md" escapes the output directory /tmp/probe/proj
```

Nothing is written, including in `--dry-run`, where the run would otherwise
report a plan it should not execute.

`validateOutputPath` was also tightened. It used to reject any path whose text
contained `..`, so a legitimate `weird..name.md` was refused while
`nested/../../escape.md` was not (it was caught only by the substring rule, not
by any real containment check). It now resolves the path and compares it against
the output root, so traversal that escapes only after a subdirectory is caught
and dotted filenames are accepted.

## What is intentionally still allowed

An output *base directory* outside the project. `packages/cli` has a build
profile test modelled on a real layout that compiles into a sibling directory
(`output: ../logstrip`), so this is a supported arrangement, not an accident.
It now prints:

```
⚠ Configured output directory "../logstrip" is outside the project root /repo/promptscript
```

`--output` on the command line is an explicit operator choice and is not
flagged. Per-target paths are still contained within whatever base is in effect.

## Also noticed, not changed

`detectBuildOutputCollisions` in the same module has no production callers.
Deleting it would remove intent (cross-profile collisions are not detected
anywhere else) and wiring it in is a product decision, so it is left alone -
flagging it for a maintainer call.

## Tests

- `compile-overwrite.spec.ts`: escaping relative path and absolute path each
  abort the run with nothing written and `exitCode` 1.
- `compile-utils.spec.ts`: escape after a subdirectory, the output root itself,
  and dotted filenames.
- `compile.spec.ts`: the sibling-directory build profile still writes, and now
  warns.

## Verification

Full pipeline: format, lint, typecheck, test, `prs validate --strict`,
`schema:check`, `skill:check`, `grammar:check`. `nx run-many -t test`: 12 projects
green. Docs updated in `docs/reference/config.md`.
