### PR TITLE
fix(parser): isolate parser state per request

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -53,11 +53,16 @@ the legacy parse functions.
 
 ### Parser & Visitor
 
-| Export               | Description                 |
-| :------------------- | :-------------------------- |
-| `PromptScriptParser` | Chevrotain parser class     |
-| `parser`             | Singleton parser instance   |
-| `visitor`            | CST-to-AST visitor instance |
+| Export               | Description                                  |
+| :------------------- | :------------------------------------------- |
+| `PromptScriptParser` | Chevrotain parser class                      |
+| `createParser`       | Create an isolated parser instance           |
+| `parser`             | Legacy parser instance for direct consumers  |
+| `createVisitor`      | Create an isolated CST-to-AST visitor        |
+| `visitor`            | Legacy visitor instance for direct consumers |
+
+Parse helpers create parser and visitor instances per request. The legacy
+`parser` and `visitor` exports remain available for direct consumers.
 
 ### Types
 

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -53,16 +53,23 @@ the legacy parse functions.
 
 ### Parser & Visitor
 
-| Export               | Description                                  |
-| :------------------- | :------------------------------------------- |
-| `PromptScriptParser` | Chevrotain parser class                      |
-| `createParser`       | Create an isolated parser instance           |
-| `parser`             | Legacy parser instance for direct consumers  |
-| `createVisitor`      | Create an isolated CST-to-AST visitor        |
-| `visitor`            | Legacy visitor instance for direct consumers |
+| Export               | Description                           |
+| :------------------- | :------------------------------------ |
+| `PromptScriptParser` | Chevrotain parser class               |
+| `createParser`       | Create an isolated parser instance    |
+| `parser`             | Deprecated shared parser instance     |
+| `createVisitor`      | Create an isolated CST-to-AST visitor |
+| `visitor`            | Deprecated shared visitor instance    |
 
-Parse helpers create parser and visitor instances per request. The legacy
-`parser` and `visitor` exports remain available for direct consumers.
+Parse helpers give every request exclusive ownership of a parser and a fresh
+visitor, so concurrent and reentrant parses cannot observe each other's tokens,
+diagnostics, or environment providers. Parser instances are pooled and reset on
+release, which keeps Chevrotain's grammar analysis cost out of the parse path.
+
+The `parser` and `visitor` exports remain for backward compatibility but are
+deprecated: both accumulate request state, so sharing them across concurrent or
+reentrant calls cross-contaminates results. Use `createParser` and
+`createVisitor` instead.
 
 ### Types
 

--- a/packages/parser/src/__tests__/isolation.spec.ts
+++ b/packages/parser/src/__tests__/isolation.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import {
+  createParser,
+  createVisitor,
+  parse,
+  parseCanonical,
+  parseCanonicalFile,
+  parseFile,
+} from '../index.js';
+import type { CanonicalParseResult } from '../index.js';
+
+function readCanonicalField(result: CanonicalParseResult, name: string): string {
+  const block = result.ast?.blocks[0];
+  const entry = block?.body.entries.find(
+    (candidate) => candidate.type === 'FieldEntry' && candidate.name === name
+  );
+  if (!entry || entry.type !== 'FieldEntry' || entry.value.type !== 'ScalarValueNode') {
+    throw new Error(`Expected scalar field ${name}`);
+  }
+  if (typeof entry.value.value !== 'string') {
+    throw new Error(`Expected string field ${name}`);
+  }
+  return entry.value.value;
+}
+
+describe('parser request isolation', () => {
+  it('creates independent parser and visitor instances', () => {
+    expect(createParser()).not.toBe(createParser());
+    expect(createVisitor()).not.toBe(createVisitor());
+  });
+
+  it('isolates reentrant providers and diagnostics', () => {
+    let nestedResult: CanonicalParseResult | undefined;
+    const outerResult = parseCanonical(
+      '@context { invalid!: "outer" = "default" first: "${OUTER}" second: "${OUTER_SECOND}" }',
+      {
+        filename: 'outer.prs',
+        recovery: true,
+        interpolateEnv: true,
+        envProvider: (name) => {
+          if (name === 'OUTER') {
+            nestedResult = parseCanonical(
+              '@context { invalid!: "${INNER}" = "default" value: "${INNER_VALUE}" }',
+              {
+                filename: 'inner.prs',
+                recovery: true,
+                interpolateEnv: true,
+                envProvider: () => 'inner',
+              }
+            );
+          }
+          return 'outer';
+        },
+      }
+    );
+
+    expect(nestedResult).toBeDefined();
+    expect(readCanonicalField(outerResult, 'first')).toBe('outer');
+    expect(readCanonicalField(outerResult, 'second')).toBe('outer');
+    expect(outerResult.errors).toHaveLength(1);
+    expect(outerResult.errors[0]?.location).toMatchObject({ file: 'outer.prs' });
+    expect(readCanonicalField(nestedResult!, 'value')).toBe('inner');
+    expect(nestedResult?.errors).toHaveLength(1);
+    expect(nestedResult?.errors[0]?.location).toMatchObject({ file: 'inner.prs' });
+  });
+
+  it('isolates concurrent source and file helper calls', async () => {
+    const fixturePath = fileURLToPath(new URL('./__fixtures__/minimal.prs', import.meta.url));
+    const [legacy, canonical, legacyFile, canonicalFile] = await Promise.all([
+      Promise.resolve().then(() =>
+        parse('@context { value: "${SOURCE_A}" }', {
+          interpolateEnv: true,
+          envProvider: () => 'source-a',
+        })
+      ),
+      Promise.resolve().then(() =>
+        parseCanonical('@context { value: "${SOURCE_B}" }', {
+          interpolateEnv: true,
+          envProvider: () => 'source-b',
+        })
+      ),
+      Promise.resolve().then(() =>
+        parseFile(fixturePath, {
+          interpolateEnv: true,
+          envProvider: () => 'file-a',
+        })
+      ),
+      Promise.resolve().then(() =>
+        parseCanonicalFile(fixturePath, {
+          interpolateEnv: true,
+          envProvider: () => 'file-b',
+        })
+      ),
+    ]);
+
+    expect(legacy.errors).toEqual([]);
+    expect(legacy.ast?.blocks[0]?.content).toMatchObject({
+      properties: { value: 'source-a' },
+    });
+    expect(canonical.errors).toEqual([]);
+    expect(readCanonicalField(canonical, 'value')).toBe('source-b');
+    expect(legacyFile.errors).toEqual([]);
+    expect(canonicalFile.errors).toEqual([]);
+  });
+});

--- a/packages/parser/src/__tests__/isolation.spec.ts
+++ b/packages/parser/src/__tests__/isolation.spec.ts
@@ -140,6 +140,16 @@ describe('parser request isolation', () => {
     expect(acquireParser()).toBe(first);
   });
 
+  it('caps the pool so a burst of parses cannot retain instances forever', () => {
+    clearParserPool();
+    const burst = Array.from({ length: 12 }, () => acquireParser());
+    for (const instance of burst) {
+      releaseParser(instance);
+    }
+
+    expect(pooledParserCount()).toBe(8);
+  });
+
   it('clears request state when an instance returns to the pool', () => {
     clearParserPool();
     const instance = acquireParser();

--- a/packages/parser/src/__tests__/isolation.spec.ts
+++ b/packages/parser/src/__tests__/isolation.spec.ts
@@ -7,7 +7,14 @@ import {
   parseCanonical,
   parseCanonicalFile,
   parseFile,
+  PSLexer,
 } from '../index.js';
+import {
+  acquireParser,
+  clearParserPool,
+  pooledParserCount,
+  releaseParser,
+} from '../grammar/parser-pool.js';
 import type { CanonicalParseResult } from '../index.js';
 
 function readCanonicalField(result: CanonicalParseResult, name: string): string {
@@ -102,5 +109,67 @@ describe('parser request isolation', () => {
     expect(readCanonicalField(canonical, 'value')).toBe('source-b');
     expect(legacyFile.errors).toEqual([]);
     expect(canonicalFile.errors).toEqual([]);
+  });
+
+  it('does not leak parser errors between pooled requests', () => {
+    const failing = parseCanonical('@context { value: }', { filename: 'broken.prs' });
+    expect(failing.errors.length).toBeGreaterThan(0);
+
+    const succeeding = parseCanonical('@context { value: "ok" }', { filename: 'clean.prs' });
+    expect(succeeding.errors).toEqual([]);
+    expect(readCanonicalField(succeeding, 'value')).toBe('ok');
+  });
+
+  it('hands out distinct instances while a parse is in flight', () => {
+    clearParserPool();
+    const inFlight = acquireParser();
+    const nested = acquireParser();
+
+    expect(nested).not.toBe(inFlight);
+
+    releaseParser(nested);
+    releaseParser(inFlight);
+    expect(pooledParserCount()).toBe(2);
+  });
+
+  it('reuses released instances instead of rebuilding the grammar', () => {
+    clearParserPool();
+    const first = acquireParser();
+    releaseParser(first);
+
+    expect(acquireParser()).toBe(first);
+  });
+
+  it('clears request state when an instance returns to the pool', () => {
+    clearParserPool();
+    const instance = acquireParser();
+    instance.input = PSLexer.tokenize('@context { value: }').tokens;
+    instance.program();
+    expect(instance.errors.length).toBeGreaterThan(0);
+
+    releaseParser(instance);
+
+    const reused = acquireParser();
+    expect(reused).toBe(instance);
+    expect(reused.errors).toEqual([]);
+    expect(reused.input).toEqual([]);
+  });
+
+  it('keeps nested parses independent while the outer parser is checked out', () => {
+    clearParserPool();
+    let nested: CanonicalParseResult | undefined;
+    const outer = parseCanonical('@context { value: "${OUTER}" }', {
+      filename: 'outer.prs',
+      interpolateEnv: true,
+      envProvider: () => {
+        nested ??= parseCanonical('@context { value: }', { filename: 'nested.prs' });
+        return 'outer-value';
+      },
+    });
+
+    expect(nested?.errors.length).toBeGreaterThan(0);
+    expect(nested?.errors[0]?.location).toMatchObject({ file: 'nested.prs' });
+    expect(outer.errors).toEqual([]);
+    expect(readCanonicalField(outer, 'value')).toBe('outer-value');
   });
 });

--- a/packages/parser/src/grammar/parser-pool.ts
+++ b/packages/parser/src/grammar/parser-pool.ts
@@ -1,0 +1,49 @@
+import { createParser, type PromptScriptParser } from './parser.js';
+
+/**
+ * Chevrotain runs grammar recording, validation, and lookahead compilation in
+ * the parser constructor, so building one instance per parse call dominates the
+ * cost of parsing small files. Pooled instances keep that cost amortized while
+ * still guaranteeing exclusive ownership for the duration of a parse.
+ */
+const MAX_POOLED_PARSERS = 8;
+
+const available: PromptScriptParser[] = [];
+
+/**
+ * Take exclusive ownership of a parser instance.
+ *
+ * Parsing is synchronous, so an instance handed out here cannot be observed by
+ * another parse until it is released. Callers must release in a `finally` block.
+ */
+export function acquireParser(): PromptScriptParser {
+  return available.pop() ?? createParser();
+}
+
+/**
+ * Return a parser instance to the pool.
+ *
+ * Assigning `input` invokes Chevrotain's `reset()`, clearing tokens, errors,
+ * and rule stacks so the next acquirer never observes prior request state.
+ */
+export function releaseParser(instance: PromptScriptParser): void {
+  instance.input = [];
+  if (available.length >= MAX_POOLED_PARSERS) {
+    return;
+  }
+  available.push(instance);
+}
+
+/**
+ * Drop every pooled instance. Intended for tests that assert pool behavior.
+ */
+export function clearParserPool(): void {
+  available.length = 0;
+}
+
+/**
+ * Number of idle instances currently pooled. Intended for tests.
+ */
+export function pooledParserCount(): number {
+  return available.length;
+}

--- a/packages/parser/src/grammar/parser.ts
+++ b/packages/parser/src/grammar/parser.ts
@@ -570,6 +570,10 @@ export function createParser(): PromptScriptParser {
 /**
  * Legacy parser instance kept for direct consumers of the parser API.
  *
- * Parse helpers use createParser() so request state never leaks between calls.
+ * Parse helpers use pooled instances so request state never leaks between calls.
+ *
+ * @deprecated Shared instance: Chevrotain stores input, errors, and rule stacks
+ * on the parser, so concurrent or reentrant use cross-contaminates results. Call
+ * {@link createParser} to obtain an instance scoped to one parse request.
  */
 export const parser = createParser();

--- a/packages/parser/src/grammar/parser.ts
+++ b/packages/parser/src/grammar/parser.ts
@@ -558,7 +558,18 @@ export class PromptScriptParser extends CstParser {
 }
 
 /**
- * Singleton parser instance.
- * Reuse this instance to avoid repeated grammar analysis.
+ * Create an isolated parser instance for one parse request.
+ *
+ * Chevrotain stores input and diagnostics on the parser instance, so callers
+ * must not share an instance across parse requests.
  */
-export const parser = new PromptScriptParser();
+export function createParser(): PromptScriptParser {
+  return new PromptScriptParser();
+}
+
+/**
+ * Legacy parser instance kept for direct consumers of the parser API.
+ *
+ * Parse helpers use createParser() so request state never leaks between calls.
+ */
+export const parser = createParser();

--- a/packages/parser/src/grammar/visitor.ts
+++ b/packages/parser/src/grammar/visitor.ts
@@ -1356,6 +1356,18 @@ function splitOnce(value: string, separator: string): [string, string?] {
 }
 
 /**
- * Singleton visitor instance.
+ * Create an isolated visitor instance for one parse request.
+ *
+ * The visitor stores interpolation settings, environment providers,
+ * diagnostics, and transformation caches on the instance.
  */
-export const visitor = new PromptScriptVisitor();
+export function createVisitor(): PromptScriptVisitor {
+  return new PromptScriptVisitor();
+}
+
+/**
+ * Legacy visitor instance kept for direct consumers of the parser API.
+ *
+ * Parse helpers use createVisitor() so request state never leaks between calls.
+ */
+export const visitor = createVisitor();

--- a/packages/parser/src/grammar/visitor.ts
+++ b/packages/parser/src/grammar/visitor.ts
@@ -1369,5 +1369,10 @@ export function createVisitor(): PromptScriptVisitor {
  * Legacy visitor instance kept for direct consumers of the parser API.
  *
  * Parse helpers use createVisitor() so request state never leaks between calls.
+ *
+ * @deprecated Shared instance: interpolation settings, environment providers, and
+ * diagnostics accumulate on the visitor, so concurrent or reentrant use
+ * cross-contaminates results. Call {@link createVisitor} to obtain an instance
+ * scoped to one parse request.
  */
 export const visitor = createVisitor();

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -26,5 +26,10 @@ export { PSLexer, tokenize } from './lexer/index.js';
 export * from './lexer/tokens.js';
 
 // Parser components
-export { PromptScriptParser, parser } from './grammar/parser.js';
-export { visitor, type EnvProvider, type VisitorDiagnostic } from './grammar/visitor.js';
+export { PromptScriptParser, createParser, parser } from './grammar/parser.js';
+export {
+  createVisitor,
+  visitor,
+  type EnvProvider,
+  type VisitorDiagnostic,
+} from './grammar/visitor.js';

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { PSLexer } from './lexer/lexer.js';
-import { createParser } from './grammar/parser.js';
+import { acquireParser, releaseParser } from './grammar/parser-pool.js';
 import { createVisitor, type EnvProvider } from './grammar/visitor.js';
 import type { CanonicalProgram, Program } from '@promptscript/core';
 import { ParseError, toLegacyProgram } from '@promptscript/core';
@@ -123,19 +123,25 @@ export function parseCanonical(source: string, options: ParseOptions = {}): Cano
   }
 
   // Parsing phase
-  const requestParser = createParser();
-  requestParser.input = lexResult.tokens;
-  const cst = requestParser.program();
+  const requestParser = acquireParser();
+  let cst;
+  try {
+    requestParser.input = lexResult.tokens;
+    cst = requestParser.program();
 
-  for (const err of requestParser.errors) {
-    errors.push(
-      new ParseError(err.message, {
-        file: filename,
-        // Chevrotain parser tokens always have startLine/startColumn
-        line: err.token.startLine!,
-        column: err.token.startColumn!,
-      })
-    );
+    // Errors must be drained before release because releasing resets the instance
+    for (const err of requestParser.errors) {
+      errors.push(
+        new ParseError(err.message, {
+          file: filename,
+          // Chevrotain parser tokens always have startLine/startColumn
+          line: err.token.startLine!,
+          column: err.token.startColumn!,
+        })
+      );
+    }
+  } finally {
+    releaseParser(requestParser);
   }
 
   if (errors.length > 0 && !isRecoveryMode) {

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -152,7 +152,6 @@ export function parseCanonical(source: string, options: ParseOptions = {}): Cano
     } else {
       requestVisitor.resetEnvProvider();
     }
-    requestVisitor.resetDiagnostics();
     const ast = requestVisitor.visit(cst, filename) as CanonicalProgram;
     for (const diagnostic of requestVisitor.takeDiagnostics()) {
       errors.push(new ParseError(diagnostic.message, diagnostic.loc));

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { PSLexer } from './lexer/lexer.js';
-import { parser } from './grammar/parser.js';
-import { visitor, type EnvProvider } from './grammar/visitor.js';
+import { createParser } from './grammar/parser.js';
+import { createVisitor, type EnvProvider } from './grammar/visitor.js';
 import type { CanonicalProgram, Program } from '@promptscript/core';
 import { ParseError, toLegacyProgram } from '@promptscript/core';
 
@@ -123,10 +123,11 @@ export function parseCanonical(source: string, options: ParseOptions = {}): Cano
   }
 
   // Parsing phase
-  parser.input = lexResult.tokens;
-  const cst = parser.program();
+  const requestParser = createParser();
+  requestParser.input = lexResult.tokens;
+  const cst = requestParser.program();
 
-  for (const err of parser.errors) {
+  for (const err of requestParser.errors) {
     errors.push(
       new ParseError(err.message, {
         file: filename,
@@ -144,15 +145,16 @@ export function parseCanonical(source: string, options: ParseOptions = {}): Cano
   // AST transformation phase
   try {
     // Configure visitor with interpolation setting
-    visitor.setInterpolateEnv(interpolateEnv);
+    const requestVisitor = createVisitor();
+    requestVisitor.setInterpolateEnv(interpolateEnv);
     if (envProvider) {
-      visitor.setEnvProvider(envProvider);
+      requestVisitor.setEnvProvider(envProvider);
     } else {
-      visitor.resetEnvProvider();
+      requestVisitor.resetEnvProvider();
     }
-    visitor.resetDiagnostics();
-    const ast = visitor.visit(cst, filename) as CanonicalProgram;
-    for (const diagnostic of visitor.takeDiagnostics()) {
+    requestVisitor.resetDiagnostics();
+    const ast = requestVisitor.visit(cst, filename) as CanonicalProgram;
+    for (const diagnostic of requestVisitor.takeDiagnostics()) {
       errors.push(new ParseError(diagnostic.message, diagnostic.loc));
     }
     if (errors.length > 0 && !isRecoveryMode) {


### PR DESCRIPTION
## Summary
- create request-scoped Chevrotain parser and visitor instances
- preserve legacy parser and visitor exports for direct consumers
- add reentrant provider, diagnostics, source, and file-helper isolation regressions

Closes #412

## Tests
- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm run test
- pnpm prs validate --strict
- pnpm schema:check
- pnpm skill:check
- pnpm grammar:check