### PR TITLE
test(resolver): allow time for the frontmatter node limit test

### DIFF
--- a/packages/resolver/src/__tests__/skill-frontmatter-yaml.spec.ts
+++ b/packages/resolver/src/__tests__/skill-frontmatter-yaml.spec.ts
@@ -785,6 +785,8 @@ describe('YAML skill frontmatter', () => {
     }
   });
 
+  // Tripping the node limit requires parsing more than 10000 YAML nodes, which
+  // outruns the default timeout on loaded CI runners with coverage enabled.
   it('counts null mapping values when enforcing the node limit', () => {
     const yaml = Array.from({ length: 3 }, (_, groupIndex) =>
       [
@@ -796,7 +798,7 @@ describe('YAML skill frontmatter', () => {
     expect(() => parseSkillMd(`---\n${yaml}\n---\nBody`)).toThrow(
       /frontmatter contains more than 10000 values/
     );
-  });
+  }, 30_000);
 
   it('reports non-Error YAML value resolution failures', () => {
     const toJsSpy = vi.spyOn(Document.prototype, 'toJS').mockImplementation(() => {


### PR DESCRIPTION
## Problem

`main` is red: `counts null mapping values when enforcing the node limit` times out.

Reaching the frontmatter node limit requires parsing more than 10000 YAML nodes.
That takes ~0.5s locally with coverage and over 5s on a loaded CI runner, so the
test exceeds Vitest's default five second timeout. Every open pull request
inherits the failure once it merges main.

## Fix

Give that single test a 30s budget and record why it is slow. No production code
changes, no weakening of the assertion: the limit is still proven to count null
mapping values.

## Verification

- `nx run resolver:lint` pass
- `nx run resolver:typecheck` pass
- `vitest run --root packages/resolver` pass (full package suite)