### PR TITLE
docs(cli): close post-1.17 documentation gaps

### DIFF
--- a/.claude/skills/promptscript/SKILL.md
+++ b/.claude/skills/promptscript/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# promptscript-generated: 2026-08-05T11:01:45.244Z | source: .promptscript/project.prs | target: claude
+# promptscript-generated: 2026-08-16T08:50:28.851Z | source: .promptscript/project.prs | target: claude
 name: promptscript
 description: >-
   PromptScript language expert for reading, writing, modifying, and
@@ -293,6 +293,10 @@ Review the code using {{language}} conventions following {{standard}}.
 The `references` field in SKILL.md frontmatter lists files to attach to the skill's context.
 Paths are relative to the SKILL.md file.
 
+Imported SKILL.md frontmatter is bounded: 256 KiB per document, 10,000 YAML nodes, 32 nesting
+levels, 2,000 entries per mapping or sequence, and 64 KiB per string value. Documents over any
+limit are rejected before their YAML values are converted.
+
 Pass values in `@skills` block:
 
 ```
@@ -391,6 +395,19 @@ Custom subagent definitions. Compiles to `.claude/agents/` for Claude Code,
   }
 }
 ```
+
+Imported agent definitions are qualified by an aliased `@use`:
+
+```
+@use ./frontend-team as frontend
+@use ./backend-team as backend
+```
+
+If both imports define `reviewer`, the resolved names are `frontend.reviewer` and
+`backend.reviewer`. Unique unaliased imports keep their original names. Conflicting unaliased
+definitions stop compilation with source and import diagnostics instead of silently overwriting
+one another. Native targets map dots to hyphens, so `frontend.reviewer` becomes
+`frontend-reviewer`.
 
 Supports mixed models per agent: `specModel` sets a different model for
 Specification/planning mode (GitHub, Factory), `specReasoningEffort` sets reasoning
@@ -1093,6 +1110,7 @@ sections without changing filenames, frontmatter, XML tags, or structured keys:
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
 - **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS038 (`valid-block-shape`)**: rejects unsupported built-in block shapes and warns about formatter-sensitive legacy shapes or multiline shortcut scalars.
+- **PS039 (`agent-namespaces`)**: validates qualified agent name segments and checks them against recorded import provenance.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).
@@ -1140,6 +1158,8 @@ prs import CLAUDE.md        # Import existing AI instructions
 prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
+prs explain <path>          # Explain source and composition provenance
+prs explain <path> --format json # Machine-readable provenance history
 prs hooks install           # Install auto-compilation hooks for AI tools
 prs hooks install claude    # Install hooks for a specific tool
 prs hooks uninstall         # Remove installed auto-compilation hooks
@@ -1152,6 +1172,8 @@ prs skills list             # List all imported skills
 prs skills update           # Re-resolve markdown-imported skills (re-validates + re-hashes)
 prs pull                    # Update registry
 prs diff --target claude    # Show compilation diff
+prs diff --all --format json # Machine-readable diff report for CI
+prs diff --format json --include-content # Include generated content in the report
 prs lock                    # Generate/update promptscript.lock
 prs lock --dry-run          # Preview lockfile changes
 prs update                  # Re-resolve all remote imports to latest
@@ -1186,8 +1208,14 @@ writes when no candidates are detected.
 | Roo Code    | .roorules                       | -------------------------------------------------- |
 | Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
 | Continue    | .continue/rules/project.md      | -------------------------------------------------- |
-| Hermes      | AGENTS.md                       | -                                                  |
+| Hermes      | AGENTS.md                       | -------------------------------------------------- |
 | + 36 more   |                                 | See full list in documentation                     |
+
+Targets that share an output path (for example Factory, Codex, and every AGENTS.md target) are
+reconciled in one output plan before anything is written. Identical content merges silently;
+differing content reports `PS4001`, where a formatter output replaces an earlier one and a
+resource or the auto-injected PromptScript skill keeps the file already planned. Paths are compared
+case-insensitively and NFC-normalized on every platform.
 
 ### Formatter Documentation
 

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
-# promptscript-generated: 2026-07-23T16:03:24.538Z | source: .promptscript/project.prs | target: claude
-name: 'skill-creator'
-description: "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy."
+# promptscript-generated: 2026-08-16T08:50:28.851Z | source: .promptscript/project.prs | target: claude
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
 ---
 
 # Skill Creator

--- a/.factory/skills/promptscript/SKILL.md
+++ b/.factory/skills/promptscript/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# promptscript-generated: 2026-08-05T11:01:45.252Z | source: .promptscript/project.prs | target: factory
+# promptscript-generated: 2026-08-16T08:50:28.851Z | source: .promptscript/project.prs | target: factory
 name: promptscript
 description: >-
   PromptScript language expert for reading, writing, modifying, and
@@ -264,6 +264,10 @@ Review the code using {{language}} conventions following {{standard}}.
 The `references` field in SKILL.md frontmatter lists files to attach to the skill's context.
 Paths are relative to the SKILL.md file.
 
+Imported SKILL.md frontmatter is bounded: 256 KiB per document, 10,000 YAML nodes, 32 nesting
+levels, 2,000 entries per mapping or sequence, and 64 KiB per string value. Documents over any
+limit are rejected before their YAML values are converted.
+
 Pass values in `@skills` block:
 
 ```
@@ -362,6 +366,19 @@ Custom subagent definitions. Compiles to `.claude/agents/` for Claude Code,
   }
 }
 ```
+
+Imported agent definitions are qualified by an aliased `@use`:
+
+```
+@use ./frontend-team as frontend
+@use ./backend-team as backend
+```
+
+If both imports define `reviewer`, the resolved names are `frontend.reviewer` and
+`backend.reviewer`. Unique unaliased imports keep their original names. Conflicting unaliased
+definitions stop compilation with source and import diagnostics instead of silently overwriting
+one another. Native targets map dots to hyphens, so `frontend.reviewer` becomes
+`frontend-reviewer`.
 
 Supports mixed models per agent: `specModel` sets a different model for
 Specification/planning mode (GitHub, Factory), `specReasoningEffort` sets reasoning
@@ -1060,6 +1077,7 @@ sections without changing filenames, frontmatter, XML tags, or structured keys:
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
 - **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS038 (`valid-block-shape`)**: rejects unsupported built-in block shapes and warns about formatter-sensitive legacy shapes or multiline shortcut scalars.
+- **PS039 (`agent-namespaces`)**: validates qualified agent name segments and checks them against recorded import provenance.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).
@@ -1107,6 +1125,8 @@ prs import CLAUDE.md        # Import existing AI instructions
 prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
+prs explain <path>          # Explain source and composition provenance
+prs explain <path> --format json # Machine-readable provenance history
 prs hooks install           # Install auto-compilation hooks for AI tools
 prs hooks install claude    # Install hooks for a specific tool
 prs hooks uninstall         # Remove installed auto-compilation hooks
@@ -1119,6 +1139,8 @@ prs skills list             # List all imported skills
 prs skills update           # Re-resolve markdown-imported skills (re-validates + re-hashes)
 prs pull                    # Update registry
 prs diff --target claude    # Show compilation diff
+prs diff --all --format json # Machine-readable diff report for CI
+prs diff --format json --include-content # Include generated content in the report
 prs lock                    # Generate/update promptscript.lock
 prs lock --dry-run          # Preview lockfile changes
 prs update                  # Re-resolve all remote imports to latest
@@ -1155,6 +1177,12 @@ writes when no candidates are detected.
 | Continue    | .continue/rules/project.md      | -                                                  |
 | Hermes      | AGENTS.md                       | -                                                  |
 | + 36 more   |                                 | See full list in documentation                     |
+
+Targets that share an output path (for example Factory, Codex, and every AGENTS.md target) are
+reconciled in one output plan before anything is written. Identical content merges silently;
+differing content reports `PS4001`, where a formatter output replaces an earlier one and a
+resource or the auto-injected PromptScript skill keeps the file already planned. Paths are compared
+case-insensitively and NFC-normalized on every platform.
 
 ### Formatter Documentation
 

--- a/.factory/skills/skill-creator/SKILL.md
+++ b/.factory/skills/skill-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
-# promptscript-generated: 2026-05-30T23:22:42.936Z | source: .promptscript/project.prs | target: factory
+# promptscript-generated: 2026-08-16T08:50:28.851Z | source: .promptscript/project.prs | target: factory
 name: skill-creator
-description: "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy."
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
 ---
 
 # Skill Creator

--- a/.github/skills/promptscript/SKILL.md
+++ b/.github/skills/promptscript/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# promptscript-generated: 2026-08-05T11:01:45.248Z | source: .promptscript/project.prs | target: github
+# promptscript-generated: 2026-08-16T08:50:28.852Z | source: .promptscript/project.prs | target: github
 name: promptscript
 description: >-
   PromptScript language expert for reading, writing, modifying, and
@@ -293,6 +293,10 @@ Review the code using {{language}} conventions following {{standard}}.
 The `references` field in SKILL.md frontmatter lists files to attach to the skill's context.
 Paths are relative to the SKILL.md file.
 
+Imported SKILL.md frontmatter is bounded: 256 KiB per document, 10,000 YAML nodes, 32 nesting
+levels, 2,000 entries per mapping or sequence, and 64 KiB per string value. Documents over any
+limit are rejected before their YAML values are converted.
+
 Pass values in `@skills` block:
 
 ```
@@ -391,6 +395,19 @@ Custom subagent definitions. Compiles to `.claude/agents/` for Claude Code,
   }
 }
 ```
+
+Imported agent definitions are qualified by an aliased `@use`:
+
+```
+@use ./frontend-team as frontend
+@use ./backend-team as backend
+```
+
+If both imports define `reviewer`, the resolved names are `frontend.reviewer` and
+`backend.reviewer`. Unique unaliased imports keep their original names. Conflicting unaliased
+definitions stop compilation with source and import diagnostics instead of silently overwriting
+one another. Native targets map dots to hyphens, so `frontend.reviewer` becomes
+`frontend-reviewer`.
 
 Supports mixed models per agent: `specModel` sets a different model for
 Specification/planning mode (GitHub, Factory), `specReasoningEffort` sets reasoning
@@ -1093,6 +1110,7 @@ sections without changing filenames, frontmatter, XML tags, or structured keys:
 - **PS019 (`unknown-block-name`)**: warns when a block name is not a known PromptScript type, with fuzzy-match suggestions for typos.
 - **PS037 (`valid-section-headers`)**: rejects invalid titles, unknown or unowned section keys, duplicate overrides, and nested extension overrides.
 - **PS038 (`valid-block-shape`)**: rejects unsupported built-in block shapes and warns about formatter-sensitive legacy shapes or multiline shortcut scalars.
+- **PS039 (`agent-namespaces`)**: validates qualified agent name segments and checks them against recorded import provenance.
 - **PS021 (`use-block-filter`)**: errors when `only` and `exclude` are both specified in `@use` parameters.
 - **PS025 (`valid-skill-references`)**: errors when a `references` entry points to a file with a disallowed extension or a path that cannot be resolved.
 - **PS026 (`safe-reference-content`)**: warns when a referenced file contains potentially sensitive content (e.g., secrets, credentials).
@@ -1140,6 +1158,8 @@ prs import CLAUDE.md        # Import existing AI instructions
 prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
+prs explain <path>          # Explain source and composition provenance
+prs explain <path> --format json # Machine-readable provenance history
 prs hooks install           # Install auto-compilation hooks for AI tools
 prs hooks install claude    # Install hooks for a specific tool
 prs hooks uninstall         # Remove installed auto-compilation hooks
@@ -1152,6 +1172,8 @@ prs skills list             # List all imported skills
 prs skills update           # Re-resolve markdown-imported skills (re-validates + re-hashes)
 prs pull                    # Update registry
 prs diff --target claude    # Show compilation diff
+prs diff --all --format json # Machine-readable diff report for CI
+prs diff --format json --include-content # Include generated content in the report
 prs lock                    # Generate/update promptscript.lock
 prs lock --dry-run          # Preview lockfile changes
 prs update                  # Re-resolve all remote imports to latest
@@ -1186,8 +1208,14 @@ writes when no candidates are detected.
 | Roo Code    | .roorules                       | -------------------------------------------------- |
 | Codex       | AGENTS.md                       | .agents/skills/\*/SKILL.md                         |
 | Continue    | .continue/rules/project.md      | -------------------------------------------------- |
-| Hermes      | AGENTS.md                       | -                                                  |
+| Hermes      | AGENTS.md                       | -------------------------------------------------- |
 | + 36 more   |                                 | See full list in documentation                     |
+
+Targets that share an output path (for example Factory, Codex, and every AGENTS.md target) are
+reconciled in one output plan before anything is written. Identical content merges silently;
+differing content reports `PS4001`, where a formatter output replaces an earlier one and a
+resource or the auto-injected PromptScript skill keeps the file already planned. Paths are compared
+case-insensitively and NFC-normalized on every platform.
 
 ### Formatter Documentation
 

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
-# promptscript-generated: 2026-07-23T16:03:24.544Z | source: .promptscript/project.prs | target: github
+# promptscript-generated: 2026-08-16T08:50:28.852Z | source: .promptscript/project.prs | target: github
 name: skill-creator
-description: "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy."
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
 ---
 
 # Skill Creator

--- a/.promptscript/skills/promptscript/SKILL.md
+++ b/.promptscript/skills/promptscript/SKILL.md
@@ -292,6 +292,10 @@ Review the code using {{language}} conventions following {{standard}}.
 The `references` field in SKILL.md frontmatter lists files to attach to the skill's context.
 Paths are relative to the SKILL.md file.
 
+Imported SKILL.md frontmatter is bounded: 256 KiB per document, 10,000 YAML nodes, 32 nesting
+levels, 2,000 entries per mapping or sequence, and 64 KiB per string value. Documents over any
+limit are rejected before their YAML values are converted.
+
 Pass values in `@skills` block:
 
 ```
@@ -1150,6 +1154,7 @@ prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
 prs explain <path>          # Explain source and composition provenance
+prs explain <path> --format json # Machine-readable provenance history
 prs hooks install           # Install auto-compilation hooks for AI tools
 prs hooks install claude    # Install hooks for a specific tool
 prs hooks uninstall         # Remove installed auto-compilation hooks
@@ -1162,6 +1167,8 @@ prs skills list             # List all imported skills
 prs skills update           # Re-resolve markdown-imported skills (re-validates + re-hashes)
 prs pull                    # Update registry
 prs diff --target claude    # Show compilation diff
+prs diff --all --format json # Machine-readable diff report for CI
+prs diff --format json --include-content # Include generated content in the report
 prs lock                    # Generate/update promptscript.lock
 prs lock --dry-run          # Preview lockfile changes
 prs update                  # Re-resolve all remote imports to latest
@@ -1198,6 +1205,12 @@ writes when no candidates are detected.
 | Continue    | .continue/rules/project.md      | -                                                  |
 | Hermes      | AGENTS.md                       | -                                                  |
 | + 36 more   |                                 | See full list in documentation                     |
+
+Targets that share an output path (for example Factory, Codex, and every AGENTS.md target) are
+reconciled in one output plan before anything is written. Identical content merges silently;
+differing content reports `PS4001`, where a formatter output replaces an earlier one and a
+resource or the auto-injected PromptScript skill keeps the file already planned. Paths are compared
+case-insensitively and NFC-normalized on every platform.
 
 ### Formatter Documentation
 

--- a/docs/guides/ci.md
+++ b/docs/guides/ci.md
@@ -44,6 +44,7 @@ flowchart LR
 | `prs compile --dry-run`      | Preview without writing       | 0=success, 1=error                           |
 | `prs check`                  | Check config and dependencies | 0=healthy, 1=issues                          |
 | `prs diff --all`             | Show uncommitted changes      | Always 0                                     |
+| `prs diff --format json`     | Machine-readable diff report  | 0=report produced, 1=error                   |
 
 ## GitHub Actions
 
@@ -127,6 +128,32 @@ jobs:
           fi
           echo "✅ All compiled files are in sync"
 ```
+
+### Drift Check Without Writing Files
+
+`prs diff --format json` reports the same drift without touching the working tree, which suits
+required checks on protected branches and jobs that post their findings elsewhere:
+
+```yaml
+- name: Check for drift
+  run: |
+    prs diff --all --format json > diff.json
+    if [ "$(jq -r '.success' diff.json)" != "true" ]; then
+      jq -r '.errors[].message' diff.json
+      exit 1
+    fi
+    if [ "$(jq -r '.hasChanges' diff.json)" = "true" ]; then
+      echo "::error::Compiled files are out of sync with source."
+      jq -r '.changes[] | "\(.kind) \(.path) (\(.target))"' diff.json
+      exit 1
+    fi
+```
+
+The command exits 0 for any valid report, including one with changes, so the job decides what counts
+as a failure. Reports follow the versioned
+[diff schema](https://getpromptscript.dev/schema/diff/v1.json): `changes[]` carries target, output
+path, change kind, ownership, and a `sha256-<hex>` content hash, `unsupported[]` repeats entries
+that the target cannot represent, and `--include-content` adds the generated content itself.
 
 ### With Private Registry
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ meta:
   - property: og:title
     content: PromptScript - Define Once, Compile Everywhere
   - property: og:description
-    content: One validated source for your complete AI agent platform. Native output for 48 coding agents.
+    content: One validated source for your complete AI agent platform. Native output for 49 coding agents.
   - property: og:type
     content: website
   - name: twitter:card
@@ -87,7 +87,7 @@ hide:
 <span>Cursor</span>
 <code>.cursor/rules/project.mdc</code>
 </div>
-<div class="home-output-more">+ 44 targets</div>
+<div class="home-output-more">+ 45 targets</div>
 </div>
 </section>
 <div class="home-platforms" aria-label="Supported platforms">

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -272,6 +272,12 @@ prs compile [options]
 
 Paths passed through `--config`, `--registry`, and `--output` are resolved relative to `--cwd` (or the current project directory). Watch mode honors the configured `watch.include`, `watch.exclude`, `watch.debounce`, and `watch.clearScreen` settings. Added, changed, and removed matching files all trigger compilation, and rebuilds are serialized.
 
+Watch mode also tracks resolved dependencies - imported files, local skills, and the loaded
+configuration - even when they sit outside `watch.include`. The dependency set is refreshed after
+every rebuild: newly resolved files start being watched, and files that are no longer dependencies
+stop being watched unless `watch.include` covers them explicitly. Removing an `@use` therefore stops
+rebuilds triggered by the dropped file, and adding one starts them without a restart.
+
 The `output.overwrite` setting provides the configuration equivalent of `--force`. A configured `output.header` is added to generated Markdown after PromptScript metadata (and after YAML frontmatter when present) so generated-file detection and frontmatter remain valid.
 
 In non-interactive mode without `--force`, `prs compile` preflights every
@@ -281,6 +287,20 @@ partially updated. Interactive mode processes outputs in order and prompts on
 conflicts, so accepted earlier writes can remain when a later path is skipped.
 Use `--dry-run` to inspect the full plan. Use `--force` or
 `output.overwrite: true` only after reviewing every conflicting path.
+
+Before anything is written, every enabled target contributes its files to a single output plan, so
+two targets that resolve to the same path are reconciled once instead of racing on disk:
+
+- Identical content and write settings are merged silently and reported only under `--debug`.
+- Differing content reports `PS4001`. A formatter output replaces an earlier one; a resource or the
+  auto-injected PromptScript skill preserves the file that is already planned, so a hand-written
+  skill always wins over the bundled one.
+- Paths are compared case-insensitively and Unicode-normalized (NFC) on every platform, so
+  `.agents/skills/Review/SKILL.md` and `.agents/skills/review/SKILL.md` collide on Linux too, and
+  the plan stays identical across macOS, Windows, and Linux.
+
+`--strict` is a separate and earlier check: it fails the run when two configured targets declare the
+same main output path, before any compilation happens.
 
 When compiling the Factory target and `.factory/hooks.json` is absent,
 `prs compile` migrates unambiguous hooks from `.factory/settings.json` before
@@ -500,19 +520,49 @@ JSON output has this shape:
 ```json
 {
   "version": 1,
-  "path": "standards.code.frameworks[0]",
+  "path": "standards.code.frameworks[1]",
   "entries": [
     {
-      "path": "standards.code.frameworks[0]",
+      "path": "standards.code.frameworks[1]",
       "kind": "list",
-      "source": { "file": ".promptscript/project.prs", "line": 4, "column": 3 },
-      "history": [],
-      "value": "React"
+      "source": { "file": ".promptscript/project.prs", "line": 15, "column": 18 },
+      "history": [
+        {
+          "operation": "declaration",
+          "action": "selected",
+          "source": { "file": ".promptscript/project.prs", "line": 15, "column": 18 },
+          "chain": []
+        },
+        {
+          "operation": "extend",
+          "action": "appended",
+          "source": { "file": ".promptscript/project.prs", "line": 15, "column": 18 },
+          "strategy": "merge",
+          "target": "standards",
+          "chain": []
+        }
+      ],
+      "value": "Vue"
     }
   ],
   "diagnostics": []
 }
 ```
+
+Each entry reports `kind` as `block`, `field`, `value`, `list`, `text`, or `inline-use`, and
+`history` lists the operations that produced the final value in application order:
+
+| Field       | Description                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| `operation` | `declaration`, `inherit`, `use`, `extend`, `override`, `compose`, or `generated`            |
+| `action`    | `declared`, `selected`, `merged`, `appended`, `replaced`, `removed`, or `composed`          |
+| `source`    | Location of the statement that performed the operation                                      |
+| `strategy`  | Merge strategy applied to this value, such as `merge`, `append`, or `replace`               |
+| `target`    | Resolved target of the operation, such as the extended block or the imported file           |
+| `reference` | Reference as written in the source, such as `./context` or `@company/platform`              |
+| `alias`     | Namespace alias from `@use <reference> as <alias>`                                          |
+| `chain`     | Import links traversed to reach the source, outermost first                                 |
+| `trace`     | Nested provenance of a composed value, such as a skill body pulled in by a composition step |
 
 `prs explain` exits with status 0 when the path resolves and diagnostics are
 warnings only. It exits nonzero for a missing path, configuration failure,

--- a/docs/reference/language/composition.md
+++ b/docs/reference/language/composition.md
@@ -23,6 +23,11 @@ Composition uses two layers of rules:
 For multiple `@use` declarations, each later import becomes the new source.
 Its same-shape values win against the accumulated target.
 
+A field keeps the position of its first declaration. Later operations change its
+value, not its place, and fields that a later layer introduces are appended in
+declaration order. Resolved output therefore stays stable when an inherited or
+imported field is redefined.
+
 The operation mode comes from the effective composed graph. A `1.5.0` source
 or ordered operation in inherited, imported, inline-composed, or
 extension-carried content enables declaration order for the whole graph.

--- a/packages/cli/skills/promptscript/SKILL.md
+++ b/packages/cli/skills/promptscript/SKILL.md
@@ -292,6 +292,10 @@ Review the code using {{language}} conventions following {{standard}}.
 The `references` field in SKILL.md frontmatter lists files to attach to the skill's context.
 Paths are relative to the SKILL.md file.
 
+Imported SKILL.md frontmatter is bounded: 256 KiB per document, 10,000 YAML nodes, 32 nesting
+levels, 2,000 entries per mapping or sequence, and 64 KiB per string value. Documents over any
+limit are rejected before their YAML values are converted.
+
 Pass values in `@skills` block:
 
 ```
@@ -1150,6 +1154,7 @@ prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
 prs explain <path>          # Explain source and composition provenance
+prs explain <path> --format json # Machine-readable provenance history
 prs hooks install           # Install auto-compilation hooks for AI tools
 prs hooks install claude    # Install hooks for a specific tool
 prs hooks uninstall         # Remove installed auto-compilation hooks
@@ -1162,6 +1167,8 @@ prs skills list             # List all imported skills
 prs skills update           # Re-resolve markdown-imported skills (re-validates + re-hashes)
 prs pull                    # Update registry
 prs diff --target claude    # Show compilation diff
+prs diff --all --format json # Machine-readable diff report for CI
+prs diff --format json --include-content # Include generated content in the report
 prs lock                    # Generate/update promptscript.lock
 prs lock --dry-run          # Preview lockfile changes
 prs update                  # Re-resolve all remote imports to latest
@@ -1198,6 +1205,12 @@ writes when no candidates are detected.
 | Continue    | .continue/rules/project.md      | -                                                  |
 | Hermes      | AGENTS.md                       | -                                                  |
 | + 36 more   |                                 | See full list in documentation                     |
+
+Targets that share an output path (for example Factory, Codex, and every AGENTS.md target) are
+reconciled in one output plan before anything is written. Identical content merges silently;
+differing content reports `PS4001`, where a formatter output replaces an earlier one and a
+resource or the auto-injected PromptScript skill keeps the file already planned. Paths are compared
+case-insensitively and NFC-normalized on every platform.
 
 ### Formatter Documentation
 

--- a/skills/promptscript/SKILL.md
+++ b/skills/promptscript/SKILL.md
@@ -292,6 +292,10 @@ Review the code using {{language}} conventions following {{standard}}.
 The `references` field in SKILL.md frontmatter lists files to attach to the skill's context.
 Paths are relative to the SKILL.md file.
 
+Imported SKILL.md frontmatter is bounded: 256 KiB per document, 10,000 YAML nodes, 32 nesting
+levels, 2,000 entries per mapping or sequence, and 64 KiB per string value. Documents over any
+limit are rejected before their YAML values are converted.
+
 Pass values in `@skills` block:
 
 ```
@@ -1150,6 +1154,7 @@ prs import CLAUDE.md --dry-run # Preview import conversion
 prs inspect <skill>         # Show skill composition provenance
 prs inspect <skill> --layers # Show layer-level breakdown
 prs explain <path>          # Explain source and composition provenance
+prs explain <path> --format json # Machine-readable provenance history
 prs hooks install           # Install auto-compilation hooks for AI tools
 prs hooks install claude    # Install hooks for a specific tool
 prs hooks uninstall         # Remove installed auto-compilation hooks
@@ -1162,6 +1167,8 @@ prs skills list             # List all imported skills
 prs skills update           # Re-resolve markdown-imported skills (re-validates + re-hashes)
 prs pull                    # Update registry
 prs diff --target claude    # Show compilation diff
+prs diff --all --format json # Machine-readable diff report for CI
+prs diff --format json --include-content # Include generated content in the report
 prs lock                    # Generate/update promptscript.lock
 prs lock --dry-run          # Preview lockfile changes
 prs update                  # Re-resolve all remote imports to latest
@@ -1198,6 +1205,12 @@ writes when no candidates are detected.
 | Continue    | .continue/rules/project.md      | -                                                  |
 | Hermes      | AGENTS.md                       | -                                                  |
 | + 36 more   |                                 | See full list in documentation                     |
+
+Targets that share an output path (for example Factory, Codex, and every AGENTS.md target) are
+reconciled in one output plan before anything is written. Identical content merges silently;
+differing content reports `PS4001`, where a formatter output replaces an earlier one and a
+resource or the auto-injected PromptScript skill keeps the file already planned. Paths are compared
+case-insensitively and NFC-normalized on every platform.
 
 ### Formatter Documentation
 


### PR DESCRIPTION
## Summary

Documentation audit of everything merged between `v1.17.1` and current `main` (39 commits, issues #412-#421). Four surfaces were checked: mkdocs `docs/`, the playground, `skills/promptscript/SKILL.md`, and the root + CLI READMEs.

## Gaps closed

- `docs/index.md`: `og:description` said 48 coding agents, the hero card said `+ 44 targets` next to 4 named output cards. Both now total 49.
- `docs/reference/cli.md` (`prs explain`): the JSON example showed `"history": []` and never described a step. Replaced with real output from an `@extend` merge and added a field table for `operation`, `action`, `source`, `strategy`, `target`, `reference`, `alias`, `chain`, and the nested `trace`.
- `docs/reference/cli.md` (`prs compile`): watch mode now documents dependency tracking across rebuilds - newly resolved imports start being watched, dropped ones stop unless `watch.include` covers them.
- `docs/reference/cli.md` (`prs compile`): output plan collision resolution was undocumented outside a design doc. Documents identical-merge, `PS4001` for differing content, primary-replaces vs resource/injected-preserves, and case- plus NFC-folded path comparison on every platform. Clarifies that `--strict` is the earlier configured-path check, not a promotion of these warnings.
- `docs/guides/ci.md`: added `prs diff --format json` to the command table plus a drift-check job that consumes the report without writing files.
- `docs/reference/language/composition.md`: stated the field ordering guarantee - a field keeps the position of its first declaration, later layers append.
- `skills/promptscript/SKILL.md`: added `prs diff --all --format json`, `--include-content`, `prs explain --format json`, the SKILL.md frontmatter limits, and collision behavior.
- Recompiled `.claude`, `.factory`, and `.github` skill copies: they were two releases behind their source and still carried pre-YAML-parser frontmatter quoting.

## Verified correct, no change needed

- 49 `KNOWN_TARGETS` matches both READMEs, `mkdocs.yml`, `SKILL.md`, and `docs/features/*`; the playground `TARGET_META` has exactly 49 entries.
- `check-grammar.mts` passes, so the Monaco language, Pygments lexer, and TextMate grammar all cover the lexer tokens and block directives.
- Namespaced agents, including nested aliases and reference rewriting, are already covered in `docs/features/agents.md`.
- `prs diff --format json`, `--include-content`, the diff schema URL, `prs explain`, and `--absolute-paths` are already in both READMEs.
- `docs/guides/building-skills.md` already documents the new frontmatter fields and YAML limits.

## Known gap, follow-up

The playground renders `compileResult.errors` only. Validator warnings (PS018, PS038, PS039) and formatter warnings (PS4001, PS4002) are returned by the browser compiler and never shown. Pre-existing, handled in a separate PR together with a namespaced-agents gallery example.

## Verification

`nx format:check`, `docs:validate:check`, `docs:highlight:check`, `grammar:check`, `skill:check`, schema regeneration, `prs validate --strict`, `mkdocs build --strict`, plus the compiler and CLI init suites that assert bundled skill content.
