### PR TITLE
feat(playground): surface compiler warnings

### DIFF
--- a/packages/browser-compiler/src/compiler.ts
+++ b/packages/browser-compiler/src/compiler.ts
@@ -99,6 +99,11 @@ export interface CompileError {
 }
 
 /**
+ * Compilation warning reported by validation or by a formatter.
+ */
+export type CompileWarning = ValidationMessage;
+
+/**
  * Statistics about the compilation process.
  */
 export interface CompileStats {

--- a/packages/browser-compiler/src/index.ts
+++ b/packages/browser-compiler/src/index.ts
@@ -53,6 +53,7 @@ export {
   type CompileError,
   type CompileResult,
   type CompileStats,
+  type CompileWarning,
   type TargetConfig,
 } from './compiler.js';
 

--- a/packages/playground/src/__tests__/store.spec.ts
+++ b/packages/playground/src/__tests__/store.spec.ts
@@ -9,6 +9,8 @@ import {
   selectOutputForFormatter,
   selectErrors,
   selectHasErrors,
+  selectWarnings,
+  selectHasWarnings,
   DEFAULT_FILE,
   type PlaygroundConfig,
 } from '../store';
@@ -767,6 +769,34 @@ describe('PlaygroundStore', () => {
 
     it('selectHasErrors should return false when no compile result', () => {
       expect(selectHasErrors(usePlaygroundStore.getState())).toBe(false);
+    });
+
+    it('selectWarnings should return warnings array', () => {
+      const { setCompileResult } = usePlaygroundStore.getState();
+      setCompileResult({
+        success: true,
+        outputs: new Map(),
+        errors: [],
+        warnings: [
+          {
+            ruleId: 'PS4001',
+            ruleName: 'output-path-collision',
+            severity: 'warning',
+            message: 'Test warning',
+          },
+        ],
+        stats: { resolveTime: 0, validateTime: 0, formatTime: 0, totalTime: 0 },
+      });
+
+      const warnings = selectWarnings(usePlaygroundStore.getState());
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].ruleId).toBe('PS4001');
+      expect(selectHasWarnings(usePlaygroundStore.getState())).toBe(true);
+    });
+
+    it('selectWarnings should return empty array when no compile result', () => {
+      expect(selectWarnings(usePlaygroundStore.getState())).toEqual([]);
+      expect(selectHasWarnings(usePlaygroundStore.getState())).toBe(false);
     });
   });
 

--- a/packages/playground/src/components/ExampleGallery.tsx
+++ b/packages/playground/src/components/ExampleGallery.tsx
@@ -1145,6 +1145,77 @@ export const EXAMPLES: Example[] = [
     ],
   },
   {
+    id: 'namespaced-agents',
+    name: 'Namespaced Agents',
+    description: 'Two teams contribute a reviewer without overwriting each other',
+    complexity: 'advanced',
+    files: [
+      {
+        path: 'project.prs',
+        content: `@meta {
+  id: "namespaced-agents"
+  syntax: "1.5.0"
+}
+
+@identity {
+  """
+  You coordinate the frontend and backend review teams.
+  Each team keeps its own reviewer agent.
+  """
+}
+
+# An alias qualifies every agent the fragment defines.
+# Both files declare "reviewer" and neither one is lost.
+@use ./frontend-team as frontend
+@use ./backend-team as backend
+
+@shortcuts {
+  "/review-ui": "Ask frontend.reviewer for a component review"
+  "/review-api": "Ask backend.reviewer for an endpoint review"
+}
+`,
+      },
+      {
+        path: 'frontend-team.prs',
+        content: `@meta {
+  id: "frontend-team"
+  syntax: "1.5.0"
+}
+
+@agents {
+  reviewer: {
+    description: "Review React components and accessibility"
+    tools: ["Read", "Grep", "Glob"]
+    content: """
+    Review component structure, state handling, and accessibility.
+    Flag re-render risks and missing keyboard support.
+    """
+  }
+}
+`,
+      },
+      {
+        path: 'backend-team.prs',
+        content: `@meta {
+  id: "backend-team"
+  syntax: "1.5.0"
+}
+
+@agents {
+  reviewer: {
+    description: "Review API endpoints and data access"
+    tools: ["Read", "Grep", "Bash"]
+    content: """
+    Review request validation, error handling, and query cost.
+    Flag missing authorization checks.
+    """
+  }
+}
+`,
+      },
+    ],
+  },
+  {
     id: 'agent-platform',
     name: 'Complete Agent Platform',
     description: 'Skills, agents, MCP servers, hooks, workflows, and plugins in one source',

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -21,6 +21,7 @@ export function Header() {
 
   const hasErrors = compileResult && !compileResult.success;
   const stats = compileResult?.stats;
+  const warningCount = compileResult?.warnings.length ?? 0;
 
   const onShare = async () => {
     const success = await handleShare();
@@ -62,6 +63,11 @@ export function Header() {
               <span className="text-green-400">Compiled in {stats?.totalTime}ms</span>
             </>
           ) : null}
+          {!isCompiling && warningCount > 0 && (
+            <span className="text-yellow-400">
+              {warningCount} warning{warningCount === 1 ? '' : 's'}
+            </span>
+          )}
         </div>
 
         {/* Config button */}

--- a/packages/playground/src/components/OutputPanel.tsx
+++ b/packages/playground/src/components/OutputPanel.tsx
@@ -4,8 +4,10 @@ import {
   usePlaygroundStore,
   selectOutputsForFormatter,
   selectEnabledTargets,
+  selectWarnings,
   type FormatterName,
 } from '../store';
+import type { CompileWarning } from '@promptscript/browser-compiler';
 
 const FORMATTERS: { name: FormatterName; label: string; icon: string }[] = [
   { name: 'github', label: 'GitHub', icon: '🐙' },
@@ -129,6 +131,42 @@ function OutputFileTree({
   );
 }
 
+function WarningPanel({ warnings }: { warnings: CompileWarning[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const label = `${warnings.length} warning${warnings.length === 1 ? '' : 's'}`;
+
+  return (
+    <div className="border-b border-ps-border bg-ps-bg">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        className="w-full px-3 py-1.5 text-xs flex items-center gap-2 text-yellow-400 hover:bg-ps-surface/50 cursor-pointer"
+      >
+        <span aria-hidden="true">⚠</span>
+        <span>{label}</span>
+        <span className="text-gray-500 ml-auto">{expanded ? 'Hide' : 'Show'}</span>
+      </button>
+      {expanded && (
+        <ul className="px-3 pb-2 space-y-1.5 max-h-40 overflow-auto">
+          {warnings.map((warning, index) => (
+            <li key={`${warning.ruleId}-${index}`} className="text-xs text-gray-300">
+              <div>
+                {warning.location?.file && (
+                  <span className="text-gray-500">
+                    {warning.location.file}:{warning.location.line}:{warning.location.column}{' '}
+                  </span>
+                )}
+                <span className="text-yellow-400">[{warning.ruleId}]</span> {warning.message}
+              </div>
+              {warning.suggestion && <div className="text-gray-500 pl-4">{warning.suggestion}</div>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 type OutputViewMode = 'tree' | 'tabs';
 
 export function OutputPanel() {
@@ -137,6 +175,7 @@ export function OutputPanel() {
   const compileResult = usePlaygroundStore((s) => s.compileResult);
   const isCompiling = usePlaygroundStore((s) => s.isCompiling);
   const enabledTargets = usePlaygroundStore(useShallow(selectEnabledTargets));
+  const warnings = usePlaygroundStore(useShallow(selectWarnings));
   const [outputViewMode, setOutputViewMode] = useState<OutputViewMode>('tree');
 
   const outputs = usePlaygroundStore(
@@ -189,6 +228,8 @@ export function OutputPanel() {
           }
         )}
       </div>
+
+      {!isCompiling && warnings.length > 0 && <WarningPanel warnings={warnings} />}
 
       {/* Output content */}
       <div className="flex-1 flex flex-col overflow-hidden bg-ps-surface">

--- a/packages/playground/src/components/__tests__/ExampleGallery.spec.tsx
+++ b/packages/playground/src/components/__tests__/ExampleGallery.spec.tsx
@@ -62,6 +62,21 @@ describe('ExampleGallery — gallery examples compile', () => {
     expect(output).toContain('Require integration tests');
   });
 
+  it('qualifies imported agents with their import alias', async () => {
+    const example = EXAMPLES.find((candidate) => candidate.id === 'namespaced-agents');
+    expect(example).toBeDefined();
+    const files = Object.fromEntries(example!.files.map((file) => [file.path, file.content]));
+
+    const result = await compile(files, example!.files[0]!.path, {
+      formatters: [{ name: 'claude', config: { version: 'full' } }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.has('.claude/agents/frontend-reviewer.md')).toBe(true);
+    expect(result.outputs.has('.claude/agents/backend-reviewer.md')).toBe(true);
+    expect(result.outputs.has('.claude/agents/reviewer.md')).toBe(false);
+  });
+
   it('renders contextual section headers in generated output', async () => {
     const example = EXAMPLES.find((candidate) => candidate.id === 'custom-section-headers');
     expect(example).toBeDefined();

--- a/packages/playground/src/components/__tests__/Header.spec.tsx
+++ b/packages/playground/src/components/__tests__/Header.spec.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CompileResult, CompileWarning } from '@promptscript/browser-compiler';
+import { Header } from '../Header';
+import { usePlaygroundStore } from '../../store';
+
+function buildResult(warnings: CompileWarning[]): CompileResult {
+  return {
+    success: true,
+    outputs: new Map(),
+    outputOwners: new Map(),
+    errors: [],
+    warnings,
+    stats: { resolveTime: 1, validateTime: 1, formatTime: 1, totalTime: 3 },
+  };
+}
+
+const warning: CompileWarning = {
+  ruleId: 'PS4001',
+  ruleName: 'output-path-collision',
+  severity: 'warning',
+  message: "Output path 'AGENTS.md' is written by both 'github' and 'factory'.",
+};
+
+describe('Header compilation status', () => {
+  beforeEach(() => {
+    usePlaygroundStore.setState({ isCompiling: false, compileResult: buildResult([]) });
+  });
+
+  it('reports success without a warning count when there are none', () => {
+    render(<Header />);
+
+    expect(screen.getByText(/Compiled in/)).toBeInTheDocument();
+    expect(screen.queryByText(/warning/)).toBeNull();
+  });
+
+  it('counts warnings alongside a successful compilation', () => {
+    usePlaygroundStore.setState({ compileResult: buildResult([warning, warning]) });
+
+    render(<Header />);
+
+    expect(screen.getByText(/Compiled in/)).toBeInTheDocument();
+    expect(screen.getByText('2 warnings')).toBeInTheDocument();
+  });
+
+  it('uses the singular form for one warning', () => {
+    usePlaygroundStore.setState({ compileResult: buildResult([warning]) });
+
+    render(<Header />);
+
+    expect(screen.getByText('1 warning')).toBeInTheDocument();
+  });
+
+  it('omits the count while a compilation is running', () => {
+    usePlaygroundStore.setState({ isCompiling: true, compileResult: buildResult([warning]) });
+
+    render(<Header />);
+
+    expect(screen.getByText('Compiling...')).toBeInTheDocument();
+    expect(screen.queryByText('1 warning')).toBeNull();
+  });
+});

--- a/packages/playground/src/components/__tests__/OutputPanel.spec.tsx
+++ b/packages/playground/src/components/__tests__/OutputPanel.spec.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { CompileResult, CompileWarning } from '@promptscript/browser-compiler';
+import { OutputPanel } from '../OutputPanel';
+import { usePlaygroundStore } from '../../store';
+
+function buildResult(warnings: CompileWarning[]): CompileResult {
+  return {
+    success: true,
+    outputs: new Map([
+      ['CLAUDE.md', { path: 'CLAUDE.md', content: '# CLAUDE.md', formatter: 'claude' }],
+    ]),
+    outputOwners: new Map([['CLAUDE.md', 'claude']]),
+    errors: [],
+    warnings,
+    stats: { resolveTime: 1, validateTime: 1, formatTime: 1, totalTime: 3 },
+  };
+}
+
+const collisionWarning: CompileWarning = {
+  ruleId: 'PS4001',
+  ruleName: 'output-path-collision',
+  severity: 'warning',
+  message: "Output path 'AGENTS.md' is written by both 'github' and 'factory'.",
+  suggestion: 'Configure distinct output paths for these formatters.',
+};
+
+describe('OutputPanel warnings', () => {
+  beforeEach(() => {
+    usePlaygroundStore.setState({
+      activeFormatter: 'claude',
+      isCompiling: false,
+      compileResult: buildResult([]),
+    });
+  });
+
+  it('renders no warning summary when compilation reports none', () => {
+    render(<OutputPanel />);
+
+    expect(screen.queryByText(/warning/)).toBeNull();
+  });
+
+  it('summarizes warnings and reveals details on demand', () => {
+    usePlaygroundStore.setState({ compileResult: buildResult([collisionWarning]) });
+
+    render(<OutputPanel />);
+    const summary = screen.getByRole('button', { name: /1 warning/ });
+
+    expect(summary).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('[PS4001]')).toBeNull();
+
+    fireEvent.click(summary);
+
+    expect(summary).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('[PS4001]')).toBeInTheDocument();
+    expect(screen.getByText(/written by both/)).toBeInTheDocument();
+    expect(screen.getByText(/Configure distinct output paths/)).toBeInTheDocument();
+  });
+
+  it('reports the source location of a located warning', () => {
+    const locatedWarning: CompileWarning = {
+      ruleId: 'PS018',
+      ruleName: 'syntax-version-compat',
+      severity: 'warning',
+      message: 'Resolved blocks require syntax 1.5.0.',
+      location: { file: 'project.prs', line: 3, column: 5, offset: 42 },
+    };
+    usePlaygroundStore.setState({ compileResult: buildResult([locatedWarning]) });
+
+    render(<OutputPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /1 warning/ }));
+
+    expect(screen.getByText('project.prs:3:5')).toBeInTheDocument();
+  });
+
+  it('hides the summary while a compilation is running', () => {
+    usePlaygroundStore.setState({
+      isCompiling: true,
+      compileResult: buildResult([collisionWarning]),
+    });
+
+    render(<OutputPanel />);
+
+    expect(screen.queryByRole('button', { name: /1 warning/ })).toBeNull();
+  });
+});

--- a/packages/playground/src/store.ts
+++ b/packages/playground/src/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { CompileResult, CompileError } from '@promptscript/browser-compiler';
+import type { CompileResult, CompileError, CompileWarning } from '@promptscript/browser-compiler';
 import type { FormatterOutput } from '@promptscript/formatters';
 import type { KnownTarget } from '@promptscript/core';
 import { TARGET_DEFINITIONS } from '@promptscript/core';
@@ -581,6 +581,12 @@ export const selectErrors = (state: PlaygroundState): CompileError[] =>
 
 export const selectHasErrors = (state: PlaygroundState): boolean =>
   (state.compileResult?.errors?.length ?? 0) > 0;
+
+export const selectWarnings = (state: PlaygroundState): CompileWarning[] =>
+  state.compileResult?.warnings ?? [];
+
+export const selectHasWarnings = (state: PlaygroundState): boolean =>
+  (state.compileResult?.warnings?.length ?? 0) > 0;
 
 export const selectEnabledTargets = (state: PlaygroundState): FormatterName[] =>
   (Object.entries(state.config.targets) as [FormatterName, TargetSettings][])


### PR DESCRIPTION
## Summary

Follow-up to the post-1.17 documentation audit (#433). Two playground gaps found during that audit.

### Warnings were invisible

`compile()` returns validator warnings (PS018 syntax version, PS038 block shape, PS039 agent namespaces) and formatter warnings (PS4001 output path collisions, PS4002 unsupported features), but the UI rendered `compileResult.errors` only. A user could hit a collision that silently drops an output and see nothing. `git log -S "warnings.map"` shows they were never rendered, so this is long-standing, not a regression.

- `OutputPanel` gains a collapsed warning summary above the output area; expanding it lists rule id, source location, message, and suggestion.
- `Header` shows the warning count next to the compile status.
- `store` exports `selectWarnings` and `selectHasWarnings`, mirroring the existing error selectors.
- `browser-compiler` exports `CompileWarning`, the type already used by `CompileResult.warnings` but not nameable by consumers.

### No example for namespaced agents

The headline feature of the last two merged PRs had no gallery entry. `namespaced-agents` imports two team fragments that each define `reviewer`, and the new gallery test asserts both survive as `.claude/agents/frontend-reviewer.md` and `.claude/agents/backend-reviewer.md`.

## Verification

`nx lint`, `nx typecheck`, playground (313) and browser-compiler (364) suites, `knip -W 'packages/*'`, `grammar:check`, `skill:check`, and patch coverage on the changed lines (`missed=0`).
