### PR TITLE
fix(resolver): keep skill resources on directory imports

### DIFF
--- a/docs/guides/markdown-imports.md
+++ b/docs/guides/markdown-imports.md
@@ -143,7 +143,9 @@ gitnexus/
     └── query.py      # discovered automatically
 ```
 
-All discovered files are copied to every compilation target alongside the skill, just as if the directory were in `.promptscript/skills/`.
+All discovered files are copied to every compilation target alongside the skill, just as if the directory were in `.promptscript/skills/`. This holds for every shape a directory import can take: the imported directory may be the skill itself (`SKILL.md` at its root), may contain skill subdirectories, or may nest them under `skills/`.
+
+Files listed in the `references:` and `scripts:` frontmatter arrays are loaded as well, and a missing entry is reported as a compilation error. The same [security limits](local-skills.md#resource-files) as local skills apply — test directories, build output and system files are skipped.
 
 ## Examples
 

--- a/packages/resolver/src/__tests__/registry-resolution.spec.ts
+++ b/packages/resolver/src/__tests__/registry-resolution.spec.ts
@@ -1500,6 +1500,69 @@ describe('Resolver — registry marker handling', () => {
     expect(paths).toContain('data.txt');
   });
 
+  it('loads resource files for a registry skill imported by directory path', async () => {
+    const tempDir = join(testCacheDir, 'project-dir-resources');
+    await fs.mkdir(tempDir, { recursive: true });
+
+    const prsContent = [
+      '@meta {',
+      '  id: "test-dir-resources"',
+      '  syntax: "1.0.0"',
+      '}',
+      '',
+      '@use github.com/foo/bar/.claude/skills/ui-ux',
+      '',
+      '@identity { """test""" }',
+    ].join('\n');
+    const prsFile = join(tempDir, 'test.prs');
+    await fs.writeFile(prsFile, prsContent);
+
+    // A published skill directory: SKILL.md plus the reference docs, scripts
+    // and data files its instructions point at.
+    mockGit.clone.mockImplementation(async (_url: string, targetDir: string) => {
+      const skillDir = join(targetDir, '.claude', 'skills', 'ui-ux');
+      await fs.mkdir(join(skillDir, 'references'), { recursive: true });
+      await fs.mkdir(join(skillDir, 'scripts'), { recursive: true });
+      await fs.mkdir(join(skillDir, 'data'), { recursive: true });
+      await fs.writeFile(
+        join(skillDir, 'SKILL.md'),
+        [
+          '---',
+          'name: ui-ux',
+          'description: Design guidance',
+          '---',
+          'Read references/rules.md.',
+        ].join('\n')
+      );
+      await fs.writeFile(join(skillDir, 'references', 'rules.md'), '# Rules');
+      await fs.writeFile(join(skillDir, 'scripts', 'search.py'), 'print("search")');
+      await fs.writeFile(join(skillDir, 'data', 'colors.csv'), 'name,hex\nred,#f00');
+    });
+
+    const resolver = new Resolver({
+      registryPath: resolve(FIXTURES_DIR, 'registry'),
+      localPath: tempDir,
+      cache: false,
+      cacheDir: join(testCacheDir, 'regcache-dir-resources'),
+    });
+
+    const result = await resolver.resolve(prsFile);
+
+    expect(result.errors).toEqual([]);
+    const skillsBlock = result.ast?.blocks.find((b) => b.name === 'skills');
+    if (skillsBlock?.content.type !== 'ObjectContent') {
+      throw new Error('skills block should be ObjectContent');
+    }
+    const skill = skillsBlock.content.properties['ui-ux'] as Record<string, unknown> | undefined;
+    const resources = skill?.['resources'] as
+      Array<{ relativePath: string; content: string }> | undefined;
+    expect((resources ?? []).map((r) => r.relativePath).sort()).toEqual([
+      'data/colors.csv',
+      'references/rules.md',
+      'scripts/search.py',
+    ]);
+  });
+
   it('detects path traversal in registry subpath (resolved file path)', async () => {
     // Covers resolver.ts lines 762-769: path traversal detection for resolvedFullPath
     const tempDir = join(testCacheDir, 'project-traversal-file');

--- a/packages/resolver/src/__tests__/skill-directory-resources.spec.ts
+++ b/packages/resolver/src/__tests__/skill-directory-resources.spec.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { ObjectContent, Program, Value } from '@promptscript/core';
+import { Resolver } from '../resolver.js';
+import { discoverNativeContent } from '../auto-discovery.js';
+import { collectSkillResources, toSkillResourceValues } from '../skill-resources.js';
+import { parseSkillMd } from '../skills.js';
+
+const temporaryDirectories: string[] = [];
+
+async function createTempDir(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function skillResources(ast: Program | null, skillName: string): Array<Record<string, Value>> {
+  const skillsBlock = ast?.blocks.find((block) => block.name === 'skills');
+  const properties = (skillsBlock?.content as ObjectContent | undefined)?.properties ?? {};
+  const skill = properties[skillName] as Record<string, Value> | undefined;
+  const resources = skill?.['resources'];
+  return Array.isArray(resources) ? (resources as Array<Record<string, Value>>) : [];
+}
+
+function relativePaths(resources: Array<Record<string, Value>>): string[] {
+  return resources.map((resource) => resource['relativePath'] as string).sort();
+}
+
+/**
+ * Write a skill directory shaped like a published Claude skill: SKILL.md plus
+ * reference documents, scripts and data files that the instructions point at.
+ */
+async function writeSkillDirectory(skillDir: string, name: string): Promise<void> {
+  await mkdir(join(skillDir, 'references'), { recursive: true });
+  await mkdir(join(skillDir, 'data'), { recursive: true });
+  await mkdir(join(skillDir, 'scripts'), { recursive: true });
+  await writeFile(
+    join(skillDir, 'SKILL.md'),
+    [
+      '---',
+      `name: ${name}`,
+      'description: Design guidance',
+      '---',
+      '',
+      'Read references/rules.md.',
+    ].join('\n')
+  );
+  await writeFile(join(skillDir, 'references', 'rules.md'), '# Rules');
+  await writeFile(join(skillDir, 'data', 'colors.csv'), 'name,hex\nred,#f00');
+  await writeFile(join(skillDir, 'scripts', 'search.py'), 'print("search")');
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe('directory imports carry skill resources', () => {
+  it('keeps resources when the imported directory contains skill subdirectories', async () => {
+    const projectDir = await createTempDir('prs-dir-import-');
+    await writeSkillDirectory(join(projectDir, 'bundle', 'ui-ux'), 'ui-ux');
+    await writeFile(
+      join(projectDir, 'main.prs'),
+      [
+        '@meta { id: "dir-import" syntax: "1.0.0" }',
+        '',
+        '@use ./bundle',
+        '',
+        '@identity { """test""" }',
+      ].join('\n')
+    );
+
+    const resolver = new Resolver({
+      registryPath: projectDir,
+      projectRoot: projectDir,
+      cache: false,
+    });
+    const result = await resolver.resolve(join(projectDir, 'main.prs'));
+
+    expect(result.errors).toEqual([]);
+    expect(relativePaths(skillResources(result.ast, 'ui-ux'))).toEqual([
+      'data/colors.csv',
+      'references/rules.md',
+      'scripts/search.py',
+    ]);
+  });
+
+  it('keeps resources when the imported directory is itself the skill', async () => {
+    const skillDir = await createTempDir('prs-root-skill-');
+    await writeSkillDirectory(skillDir, 'ui-ux');
+
+    const ast = await discoverNativeContent(skillDir);
+
+    expect(relativePaths(skillResources(ast, 'ui-ux'))).toEqual([
+      'data/colors.csv',
+      'references/rules.md',
+      'scripts/search.py',
+    ]);
+  });
+
+  it('keeps resources for skills discovered under a skills/ wrapper directory', async () => {
+    const repoDir = await createTempDir('prs-wrapper-skill-');
+    await writeSkillDirectory(join(repoDir, 'skills', 'ui-ux'), 'ui-ux');
+
+    const ast = await discoverNativeContent(repoDir);
+
+    expect(relativePaths(skillResources(ast, 'ui-ux'))).toEqual([
+      'data/colors.csv',
+      'references/rules.md',
+      'scripts/search.py',
+    ]);
+  });
+
+  it('reports a missing frontmatter reference from a discovered skill directory', async () => {
+    const skillDir = await createTempDir('prs-root-skill-missing-ref-');
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      ['---', 'name: broken', 'description: d', 'references: [missing.md]', '---', '', 'Body'].join(
+        '\n'
+      )
+    );
+
+    await expect(discoverNativeContent(skillDir)).rejects.toThrow(/Reference file not found/);
+  });
+});
+
+describe('collectSkillResources', () => {
+  it('merges discovered files with frontmatter references and scripts', async () => {
+    const skillDir = await createTempDir('prs-collect-');
+    await mkdir(join(skillDir, 'references'), { recursive: true });
+    await writeFile(join(skillDir, 'references', 'rules.md'), '# Rules');
+    await writeFile(join(skillDir, 'run.sh'), 'echo hi');
+    const skillMdPath = join(skillDir, 'SKILL.md');
+    const source = [
+      '---',
+      'name: collected',
+      'description: d',
+      'references: [references/rules.md]',
+      'scripts: [run.sh]',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+    await writeFile(skillMdPath, source);
+
+    const collected = await collectSkillResources(skillMdPath, parseSkillMd(source, skillMdPath));
+
+    expect(collected.errors).toEqual([]);
+    // references/rules.md appears once: the explicit entry replaces the discovered copy
+    expect(
+      relativePaths(toSkillResourceValues(collected.resources) as Array<Record<string, Value>>)
+    ).toEqual(['references/rules.md', 'run.sh', 'scripts/run.sh']);
+  });
+
+  it('returns errors for unresolvable frontmatter entries instead of throwing', async () => {
+    const skillDir = await createTempDir('prs-collect-errors-');
+    const skillMdPath = join(skillDir, 'SKILL.md');
+    const source = [
+      '---',
+      'name: collected',
+      'description: d',
+      'references: [missing.md]',
+      'scripts: [missing.sh]',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+    await writeFile(skillMdPath, source);
+
+    const collected = await collectSkillResources(skillMdPath, parseSkillMd(source, skillMdPath));
+
+    expect(collected.resources).toEqual([]);
+    expect(collected.errors.map((error) => error.message)).toEqual([
+      'Reference file not found: missing.md',
+      'Script file not found: missing.sh',
+    ]);
+  });
+
+  it('logs and skips discovery failures for a missing skill directory', async () => {
+    const messages: string[] = [];
+    const logger = {
+      verbose: (message: string) => messages.push(message),
+      debug: () => {},
+      warn: () => {},
+    };
+    const skillMdPath = join(await createTempDir('prs-collect-missing-'), 'gone', 'SKILL.md');
+
+    const collected = await collectSkillResources(
+      skillMdPath,
+      parseSkillMd('---\nname: gone\n---\nBody', skillMdPath),
+      logger
+    );
+
+    expect(collected.resources).toEqual([]);
+    expect(collected.errors).toEqual([]);
+    expect(messages.some((message) => message.includes('Failed to discover skill resources'))).toBe(
+      true
+    );
+  });
+});

--- a/packages/resolver/src/__tests__/skill-directory-resources.spec.ts
+++ b/packages/resolver/src/__tests__/skill-directory-resources.spec.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import type { ObjectContent, Program, Value } from '@promptscript/core';
 import { Resolver } from '../resolver.js';
 import { discoverNativeContent } from '../auto-discovery.js';
 import { collectSkillResources, toSkillResourceValues } from '../skill-resources.js';
+import { MAX_RESOURCE_COUNT, MAX_RESOURCE_SIZE } from '../skill-resource-limits.js';
 import { parseSkillMd } from '../skills.js';
 
 const temporaryDirectories: string[] = [];
@@ -178,6 +179,98 @@ describe('collectSkillResources', () => {
     expect(collected.errors.map((error) => error.message)).toEqual([
       'Reference file not found: missing.md',
       'Script file not found: missing.sh',
+    ]);
+  });
+
+  it('excludes a dirname markdown skill source from its resources', async () => {
+    const skillDir = await createTempDir('prs-collect-fallback-');
+    const skillMdPath = join(skillDir, 'fallback.md');
+    const source = ['---', 'name: fallback', 'description: d', '---', '', 'Body'].join('\n');
+    await writeFile(skillMdPath, source);
+    await writeFile(join(skillDir, 'data.txt'), 'data');
+
+    const collected = await collectSkillResources(skillMdPath, parseSkillMd(source, skillMdPath));
+
+    expect(collected.errors).toEqual([]);
+    expect(collected.resources.map((resource) => resource.relativePath)).toEqual(['data.txt']);
+  });
+
+  it('excludes a dirname markdown source before applying the count limit', async () => {
+    const skillDir = await createTempDir('prs-collect-source-limit-');
+    const skillMdPath = join(skillDir, `${basename(skillDir)}.md`);
+    const source = ['---', 'name: fallback', 'description: d', '---', '', 'Body'].join('\n');
+    await writeFile(skillMdPath, source);
+    await Promise.all(
+      Array.from({ length: MAX_RESOURCE_COUNT }, (_, index) =>
+        writeFile(join(skillDir, `resource-${String(index).padStart(3, '0')}.txt`), 'x')
+      )
+    );
+
+    const collected = await collectSkillResources(skillMdPath, parseSkillMd(source, skillMdPath));
+
+    expect(collected.errors).toEqual([]);
+    expect(collected.resources).toHaveLength(MAX_RESOURCE_COUNT);
+    expect(collected.resources.some((resource) => resource.origin === skillMdPath)).toBe(false);
+  });
+
+  it('enforces the resource count limit after merging explicit entries', async () => {
+    const skillDir = await createTempDir('prs-collect-count-limit-');
+    await mkdir(join(skillDir, 'data'));
+    await mkdir(join(skillDir, 'tests'));
+    await Promise.all(
+      Array.from({ length: MAX_RESOURCE_COUNT }, (_, index) =>
+        writeFile(join(skillDir, 'data', `${String(index).padStart(3, '0')}.txt`), 'x')
+      )
+    );
+    await writeFile(join(skillDir, 'tests', 'explicit.md'), 'explicit');
+    const skillMdPath = join(skillDir, 'SKILL.md');
+    const source = [
+      '---',
+      'name: limited',
+      'description: d',
+      'references: [tests/explicit.md]',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+    await writeFile(skillMdPath, source);
+
+    const collected = await collectSkillResources(skillMdPath, parseSkillMd(source, skillMdPath));
+
+    expect(collected.resources).toHaveLength(MAX_RESOURCE_COUNT);
+    expect(collected.errors.map((error) => error.message)).toEqual([
+      `Too many skill resource files (${MAX_RESOURCE_COUNT + 1}, max ${MAX_RESOURCE_COUNT})`,
+    ]);
+  });
+
+  it('enforces the total size limit after merging explicit entries', async () => {
+    const skillDir = await createTempDir('prs-collect-size-limit-');
+    await mkdir(join(skillDir, 'data'));
+    await mkdir(join(skillDir, 'tests'));
+    const chunk = 'x'.repeat(MAX_RESOURCE_SIZE);
+    await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        writeFile(join(skillDir, 'data', `${index}.txt`), chunk)
+      )
+    );
+    await writeFile(join(skillDir, 'tests', 'explicit.md'), 'x');
+    const skillMdPath = join(skillDir, 'SKILL.md');
+    const source = [
+      '---',
+      'name: limited',
+      'description: d',
+      'references: [tests/explicit.md]',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+    await writeFile(skillMdPath, source);
+
+    const collected = await collectSkillResources(skillMdPath, parseSkillMd(source, skillMdPath));
+
+    expect(collected.resources).toHaveLength(10);
+    expect(collected.errors.map((error) => error.message)).toEqual([
+      'Total skill resource size exceeds 10MB limit',
     ]);
   });
 

--- a/packages/resolver/src/__tests__/skill-frontmatter-yaml.spec.ts
+++ b/packages/resolver/src/__tests__/skill-frontmatter-yaml.spec.ts
@@ -485,6 +485,8 @@ describe('YAML skill frontmatter', () => {
         'Body',
       ].join('\n')
     );
+    await writeFile(join(directory, 'guide.md'), 'Guide body');
+    await writeFile(join(directory, 'run.sh'), 'echo hi');
 
     const result = await discoverNativeContent(directory);
     const skills = result?.blocks.find((block) => block.name === 'skills')
@@ -500,6 +502,12 @@ describe('YAML skill frontmatter', () => {
     expect(skill['compatibility']).toBe('shell');
     expect(skill['metadata']).toEqual({ owner: 'tests' });
     expect(skill['allowedTools']).toEqual(['Read', 'Bash']);
+    expect(skill['resources']).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ relativePath: 'guide.md', content: 'Guide body' }),
+        expect.objectContaining({ relativePath: 'scripts/run.sh', content: 'echo hi' }),
+      ])
+    );
   });
 
   it('reports malformed frontmatter from native auto-discovery', async () => {

--- a/packages/resolver/src/__tests__/skills.spec.ts
+++ b/packages/resolver/src/__tests__/skills.spec.ts
@@ -764,6 +764,106 @@ Native resource content.
         executable: true,
       });
     });
+
+    it('should preserve existing resources when merging native references', async () => {
+      const skillDir = join(registryPath, '@skills', 'merged-resources');
+      await mkdir(join(skillDir, 'references'), { recursive: true });
+      await writeFile(join(skillDir, 'references', 'extra.md'), 'extra');
+      await writeFile(join(skillDir, '.skillignore'), 'references/extra.md\n');
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        [
+          '---',
+          'name: merged-resources',
+          'description: Merged resources',
+          'references: [references/extra.md]',
+          '---',
+          '',
+          'Body',
+        ].join('\n')
+      );
+      const ast = createProgram([
+        createSkillsBlock({
+          'merged-resources': {
+            resources: [{ relativePath: 'declared.txt', content: 'declared' }],
+          },
+        }),
+      ]);
+
+      const result = await resolveNativeSkills(ast, registryPath, join(testDir, 'test.prs'));
+
+      const skillsBlock = result.blocks.find((block) => block.name === 'skills');
+      const skill = (skillsBlock!.content as ObjectContent).properties[
+        'merged-resources'
+      ] as Record<string, unknown>;
+      const resources = skill['resources'] as Array<{ relativePath: string; content: string }>;
+      expect(resources).toEqual([
+        { relativePath: 'declared.txt', content: 'declared' },
+        expect.objectContaining({
+          relativePath: 'references/extra.md',
+          content: 'extra',
+        }),
+      ]);
+    });
+
+    it('should reject an oversized existing resource during native merging', async () => {
+      const skillDir = join(registryPath, '@skills', 'oversized-existing');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        '---\nname: oversized-existing\ndescription: Oversized existing\n---\n\nBody.\n'
+      );
+      const ast = createProgram([
+        createSkillsBlock({
+          'oversized-existing': {
+            resources: [
+              {
+                relativePath: 'oversized.txt',
+                content: 'x'.repeat(1_048_577),
+              },
+            ],
+          },
+        }),
+      ]);
+
+      const result = resolveNativeSkills(ast, registryPath, join(testDir, 'test.prs'));
+
+      await expect(result).rejects.toThrow('Skill resource file exceeds 1MB limit: oversized.txt');
+    });
+
+    it('should enforce the resource count limit after merging native references', async () => {
+      const skillDir = join(registryPath, '@skills', 'limited-resources');
+      await mkdir(join(skillDir, 'data'), { recursive: true });
+      await mkdir(join(skillDir, 'references'), { recursive: true });
+      await Promise.all(
+        Array.from({ length: 100 }, (_, index) =>
+          writeFile(join(skillDir, 'data', `${String(index).padStart(3, '0')}.txt`), 'x')
+        )
+      );
+      await writeFile(join(skillDir, 'references', 'extra.md'), 'extra');
+      await writeFile(join(skillDir, '.skillignore'), 'references/extra.md\n');
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        [
+          '---',
+          'name: limited-resources',
+          'description: Limited resources',
+          'references: [references/extra.md]',
+          '---',
+          '',
+          'Body',
+        ].join('\n')
+      );
+      const ast = createProgram([
+        createSkillsBlock({
+          'limited-resources': {},
+        }),
+      ]);
+
+      const result = resolveNativeSkills(ast, registryPath, join(testDir, 'test.prs'));
+
+      await expect(result).rejects.toThrow('Too many skill resource files (101, max 100)');
+    });
   });
 
   describe('universal .agents/skills/ directory', () => {

--- a/packages/resolver/src/auto-discovery.ts
+++ b/packages/resolver/src/auto-discovery.ts
@@ -1,8 +1,9 @@
 import { readFile, readdir, access, lstat } from 'fs/promises';
 import { resolve, basename } from 'path';
 import { ResolveError } from '@promptscript/core';
-import type { Program, Block, TextContent, Value } from '@promptscript/core';
+import type { Logger, Program, Block, TextContent, Value } from '@promptscript/core';
 import { parseSkillMd } from './skills.js';
+import { collectSkillResources, toSkillResourceValues } from './skill-resources.js';
 import { makeBlock, makeObjectContent, makeTextContent, VIRTUAL_LOC } from './ast-factory.js';
 
 /** Context file names to look for when synthesizing a @context block. */
@@ -69,10 +70,44 @@ function addParsedSkillMetadata(
 }
 
 /**
+ * Build the skill properties for a discovered SKILL.md, including every
+ * resource file that travels with the skill directory.
+ *
+ * Resource errors from `references:` / `scripts:` frontmatter entries are
+ * thrown, matching how a locally resolved skill reports them.
+ */
+async function buildDiscoveredSkill(
+  skillMdPath: string,
+  logger: Logger | undefined
+): Promise<{ name?: string; props: Record<string, Value> }> {
+  const raw = await readFile(skillMdPath, 'utf-8');
+  const parsed = parseSkillMd(raw, skillMdPath);
+
+  const skillProps: Record<string, Value> = {};
+  if (parsed.description) {
+    skillProps['description'] = parsed.description;
+  }
+  if (parsed.content) {
+    skillProps['content'] = makeTextContent(parsed.content, skillMdPath);
+  }
+  addParsedSkillMetadata(skillProps, parsed);
+
+  const collected = await collectSkillResources(skillMdPath, parsed, logger);
+  if (collected.errors.length > 0) {
+    throw collected.errors[0];
+  }
+  if (collected.resources.length > 0) {
+    skillProps['resources'] = toSkillResourceValues(collected.resources);
+  }
+
+  return { ...(parsed.name ? { name: parsed.name } : {}), props: skillProps };
+}
+
+/**
  * Discover SKILL.md files in subdirectories of the given path.
  * Returns an ObjectContent mapping skill-name -> skill properties.
  */
-async function discoverSkills(dir: string): Promise<Record<string, Value> | null> {
+async function discoverSkills(dir: string, logger?: Logger): Promise<Record<string, Value> | null> {
   let entries;
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -96,19 +131,7 @@ async function discoverSkills(dir: string): Promise<Record<string, Value> | null
     }
 
     try {
-      const raw = await readFile(skillMdPath, 'utf-8');
-      const parsed = parseSkillMd(raw, skillMdPath);
-
-      const skillProps: Record<string, Value> = {};
-      if (parsed.description) {
-        skillProps['description'] = parsed.description;
-      }
-      if (parsed.content) {
-        skillProps['content'] = makeTextContent(parsed.content, skillMdPath);
-      }
-      addParsedSkillMetadata(skillProps, parsed);
-
-      properties[entry.name] = skillProps;
+      properties[entry.name] = (await buildDiscoveredSkill(skillMdPath, logger)).props;
     } catch (error: unknown) {
       if (error instanceof ResolveError) {
         throw error;
@@ -125,25 +148,16 @@ async function discoverSkills(dir: string): Promise<Record<string, Value> | null
  * parse it and return a single skill entry keyed by the skill's frontmatter
  * `name` field (falling back to the directory basename).
  */
-async function discoverRootSkill(dir: string): Promise<Record<string, Value> | null> {
+async function discoverRootSkill(
+  dir: string,
+  logger?: Logger
+): Promise<Record<string, Value> | null> {
   const skillMdPath = resolve(dir, 'SKILL.md');
   if (!(await fileExists(skillMdPath))) return null;
 
   try {
-    const raw = await readFile(skillMdPath, 'utf-8');
-    const parsed = parseSkillMd(raw, skillMdPath);
-
-    const skillName = parsed.name || basename(dir);
-    const skillProps: Record<string, Value> = {};
-    if (parsed.description) {
-      skillProps['description'] = parsed.description;
-    }
-    if (parsed.content) {
-      skillProps['content'] = makeTextContent(parsed.content, skillMdPath);
-    }
-    addParsedSkillMetadata(skillProps, parsed);
-
-    return { [skillName]: skillProps };
+    const skill = await buildDiscoveredSkill(skillMdPath, logger);
+    return { [skill.name || basename(dir)]: skill.props };
   } catch (error: unknown) {
     if (error instanceof ResolveError) {
       throw error;
@@ -280,6 +294,7 @@ async function discoverContext(dir: string): Promise<TextContent | null> {
  * - CLAUDE.md, .clinerules, .cursorrules -> synthesizes `@context` block
  *
  * @param dir - Absolute path to the directory to scan
+ * @param logger - Optional logger for reporting skipped resource files
  * @returns A synthesized Program AST, or null if nothing was found or directory doesn't exist
  */
 /**
@@ -299,17 +314,17 @@ async function safeIsDirectory(dir: string): Promise<boolean> {
   }
 }
 
-export async function discoverNativeContent(dir: string): Promise<Program | null> {
+export async function discoverNativeContent(dir: string, logger?: Logger): Promise<Program | null> {
   // Check the directory exists
   if (!(await safeIsDirectory(dir))) return null;
 
   const blocks: Block[] = [];
 
   // Check if directory itself is a skill (root-level SKILL.md)
-  const rootSkill = await discoverRootSkill(dir);
+  const rootSkill = await discoverRootSkill(dir, logger);
 
   // Discover skills in subdirectories
-  const subSkills = await discoverSkills(dir);
+  const subSkills = await discoverSkills(dir, logger);
 
   // Also walk known wrapper directories (`skills/`) so registry imports against
   // a repository root pick up the standard `skills/<name>/SKILL.md` layout.
@@ -317,7 +332,7 @@ export async function discoverNativeContent(dir: string): Promise<Program | null
     SKILL_WRAPPER_DIRS.map(async (name) => {
       const candidate = resolve(dir, name);
       if (!(await safeIsDirectory(candidate))) return null;
-      return discoverSkills(candidate);
+      return discoverSkills(candidate, logger);
     })
   );
 

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -144,6 +144,10 @@ export type {
   SkillFrontmatterLocations,
 } from './skills.js';
 
+// Skill resource collection
+export { collectSkillResources, toSkillResourceValues } from './skill-resources.js';
+export type { CollectedSkillResources } from './skill-resources.js';
+
 // Skill frontmatter validation (Agent Skills spec compliance)
 export { validateSkillFrontmatter, formatSkillValidationIssues } from './skill-validation.js';
 export type {

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { lstat, readdir, readFile } from 'fs/promises';
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
+import { basename, isAbsolute, join, relative, resolve, sep } from 'path';
 import { parse } from '@promptscript/parser';
 import {
   noopLogger,
@@ -65,14 +65,10 @@ import {
   resolveNativeCommands,
   resolveNativeAgents,
   parseSkillMd,
-  getSkillFrontmatterLocations,
   skillNameFromPath,
-  discoverSkillResources,
-  resolveSkillReferences,
-  resolveSkillScripts,
   type NativeSkillOptions,
-  type SkillResource,
 } from './skills.js';
+import { collectSkillResources, toSkillResourceValues } from './skill-resources.js';
 import { detectContentType } from './content-detector.js';
 import { makeBlock, makeObjectContent, makeTextContent, VIRTUAL_LOC } from './ast-factory.js';
 import { resolveGuardRequires } from './guard-requires.js';
@@ -1213,72 +1209,11 @@ export class Resolver {
     // entries. This mirrors the behaviour of resolveNativeSkills() so a skill
     // pulled in via a registry import carries the same resources as a locally
     // discovered one.
-    const skillDir = dirname(absPath);
-    const collected: SkillResource[] = [];
+    const collected = await collectSkillResources(absPath, parsed, this.logger);
+    errors.push(...collected.errors);
 
-    try {
-      const discovered = await discoverSkillResources(skillDir, this.logger);
-      collected.push(...discovered);
-    } catch (err) {
-      this.logger.verbose(
-        `Failed to discover skill resources in ${skillDir}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
-      );
-    }
-
-    if (parsed.references && parsed.references.length > 0) {
-      try {
-        const frontmatterLocations = getSkillFrontmatterLocations(parsed);
-        const refs = await resolveSkillReferences(
-          parsed.references,
-          skillDir,
-          this.logger,
-          frontmatterLocations?.frontmatter,
-          frontmatterLocations?.items.get('references')
-        );
-        collected.push(...refs);
-      } catch (err) {
-        if (err instanceof ResolveError) {
-          errors.push(err);
-        } else {
-          errors.push(new ResolveError(err instanceof Error ? err.message : String(err)));
-        }
-      }
-    }
-
-    if (parsed.scripts && parsed.scripts.length > 0) {
-      try {
-        const frontmatterLocations = getSkillFrontmatterLocations(parsed);
-        const scripts = await resolveSkillScripts(
-          parsed.scripts,
-          skillDir,
-          this.logger,
-          frontmatterLocations?.frontmatter,
-          frontmatterLocations?.items.get('scripts')
-        );
-        collected.push(...scripts);
-      } catch (err) {
-        if (err instanceof ResolveError) {
-          errors.push(err);
-        } else {
-          errors.push(new ResolveError(err instanceof Error ? err.message : String(err)));
-        }
-      }
-    }
-
-    if (collected.length > 0) {
-      // Deduplicate by relativePath: explicit references override discovered ones.
-      const byPath = new Map<string, SkillResource>();
-      for (const resource of collected) {
-        byPath.set(resource.relativePath, resource);
-      }
-      skillProps['resources'] = Array.from(byPath.values()).map((r) => ({
-        relativePath: r.relativePath,
-        content: r.content,
-        ...(r.origin ? { origin: r.origin } : {}),
-        ...(r.executable !== undefined ? { executable: r.executable } : {}),
-      })) as Value[];
+    if (collected.resources.length > 0) {
+      skillProps['resources'] = toSkillResourceValues(collected.resources);
     }
 
     const program: Program = {
@@ -1932,11 +1867,20 @@ export class Resolver {
           );
 
           dependencies.add(discoverDir);
-          const dirResult = await this.tryDirectoryScan(discoverDir, [marker], dependencies, []);
+          // Scan errors only matter when the scan produced skills: an empty
+          // directory scan is the normal path into auto-discovery below.
+          const scanErrors: ResolveError[] = [];
+          const dirResult = await this.tryDirectoryScan(
+            discoverDir,
+            [marker],
+            dependencies,
+            scanErrors
+          );
           if (dirResult?.ast) {
             resolvedAST = dirResult.ast;
+            errors.push(...scanErrors);
           } else {
-            resolvedAST = await discoverNativeContent(discoverDir);
+            resolvedAST = await discoverNativeContent(discoverDir, this.logger);
 
             if (!resolvedAST) {
               const where = isRoot ? '<repository root>' : `'${subPath}'`;
@@ -2006,7 +1950,7 @@ export class Resolver {
     }
 
     this.logger.verbose(`Directory import detected: ${dirPath}`);
-    const properties = await this.scanDirectoryForSkills(dirPath);
+    const properties = await this.scanDirectoryForSkills(dirPath, errors);
 
     if (Object.keys(properties).length === 0) {
       errors.push(new ResolveError(`No skills found in directory: ${dirPath}`));
@@ -2039,7 +1983,10 @@ export class Resolver {
    * @param dir - Absolute path to the directory to scan
    * @returns Accumulated skill properties keyed by skill name
    */
-  private async scanDirectoryForSkills(dir: string): Promise<Record<string, Value>> {
+  private async scanDirectoryForSkills(
+    dir: string,
+    errors: ResolveError[]
+  ): Promise<Record<string, Value>> {
     const properties: Record<string, Value> = {};
     const queue: Array<{ path: string; depth: number }> = [{ path: dir, depth: 0 }];
 
@@ -2074,17 +2021,12 @@ export class Resolver {
 
         try {
           const skillContent = await readFile(skillMdPath, 'utf-8');
-          const parsed = parseSkillMd(skillContent, skillMdPath);
-          const skillName = parsed.name ?? entry.name;
-
-          const skillProps: Record<string, Value> = {};
-          if (parsed.description) {
-            skillProps['description'] = parsed.description;
-          }
-          if (parsed.content) {
-            skillProps['content'] = makeTextContent(parsed.content, skillMdPath);
-          }
-          addParsedSkillMetadata(skillProps, parsed);
+          const [skillName, skillProps] = await this.buildSkillFromMd(
+            skillMdPath,
+            skillContent,
+            entry.name,
+            errors
+          );
 
           properties[skillName] = skillProps;
           foundSkill = true;
@@ -2097,17 +2039,12 @@ export class Resolver {
           const dirnameMdPath = join(subDir, `${entry.name}.md`);
           try {
             const fallbackContent = await readFile(dirnameMdPath, 'utf-8');
-            const parsed = parseSkillMd(fallbackContent, dirnameMdPath);
-            const skillName = parsed.name ?? skillNameFromPath(dirnameMdPath);
-
-            const skillProps: Record<string, Value> = {};
-            if (parsed.description) {
-              skillProps['description'] = parsed.description;
-            }
-            if (parsed.content) {
-              skillProps['content'] = makeTextContent(parsed.content, dirnameMdPath);
-            }
-            addParsedSkillMetadata(skillProps, parsed);
+            const [skillName, skillProps] = await this.buildSkillFromMd(
+              dirnameMdPath,
+              fallbackContent,
+              skillNameFromPath(dirnameMdPath),
+              errors
+            );
 
             properties[skillName] = skillProps;
             foundSkill = true;
@@ -2130,6 +2067,46 @@ export class Resolver {
     }
 
     return properties;
+  }
+
+  /**
+   * Build a skill definition from a SKILL.md file found during a directory scan.
+   *
+   * Carries the same payload as a locally discovered skill: metadata from the
+   * frontmatter plus every resource file that travels with the skill directory,
+   * so `references/`, `scripts/` and data files survive a directory import.
+   *
+   * @param skillMdPath - Absolute path to the skill markdown file
+   * @param source - Raw markdown content
+   * @param fallbackName - Skill name used when the frontmatter declares none
+   * @param errors - Accumulator for resource resolution errors
+   * @returns The skill name and its synthesized properties
+   */
+  private async buildSkillFromMd(
+    skillMdPath: string,
+    source: string,
+    fallbackName: string,
+    errors: ResolveError[]
+  ): Promise<[string, Record<string, Value>]> {
+    const parsed = parseSkillMd(source, skillMdPath);
+    const skillName = parsed.name ?? fallbackName;
+
+    const skillProps: Record<string, Value> = {};
+    if (parsed.description) {
+      skillProps['description'] = parsed.description;
+    }
+    if (parsed.content) {
+      skillProps['content'] = makeTextContent(parsed.content, skillMdPath);
+    }
+    addParsedSkillMetadata(skillProps, parsed);
+
+    const collected = await collectSkillResources(skillMdPath, parsed, this.logger);
+    errors.push(...collected.errors);
+    if (collected.resources.length > 0) {
+      skillProps['resources'] = toSkillResourceValues(collected.resources);
+    }
+
+    return [skillName, skillProps];
   }
 
   /**

--- a/packages/resolver/src/skill-resource-limits.ts
+++ b/packages/resolver/src/skill-resource-limits.ts
@@ -1,0 +1,71 @@
+import { ResolveError } from '@promptscript/core';
+import type { SourceLocation } from '@promptscript/core';
+
+/** Maximum size in bytes for a single skill resource file. */
+export const MAX_RESOURCE_SIZE = 1_048_576;
+
+/** Maximum total size in bytes for all resource files in a skill. */
+export const MAX_TOTAL_RESOURCE_SIZE = 10_485_760;
+
+/** Maximum number of resource files per skill. */
+export const MAX_RESOURCE_COUNT = 100;
+
+export interface SkillResourceLimitResult<T> {
+  resources: T[];
+  errors: ResolveError[];
+}
+
+/**
+ * Apply aggregate limits after all resource sources have been deduplicated.
+ *
+ * @param resources - Deduplicated resources in output priority order
+ * @param location - Source location for actionable diagnostics
+ * @returns Resources within the limits and any limit errors
+ */
+export function limitSkillResources<T extends { content: string; relativePath: string }>(
+  resources: readonly T[],
+  location: SourceLocation
+): SkillResourceLimitResult<T> {
+  const errors: ResolveError[] = [];
+  const sizedResources: Array<{ resource: T; size: number }> = [];
+  for (const resource of resources) {
+    const size = Buffer.byteLength(resource.content, 'utf8');
+    if (size > MAX_RESOURCE_SIZE) {
+      errors.push(
+        new ResolveError(
+          `Skill resource file exceeds ${MAX_RESOURCE_SIZE / 1_048_576}MB limit: ${resource.relativePath}`,
+          location
+        )
+      );
+      continue;
+    }
+    sizedResources.push({ resource, size });
+  }
+
+  if (sizedResources.length > MAX_RESOURCE_COUNT) {
+    errors.push(
+      new ResolveError(
+        `Too many skill resource files (${sizedResources.length}, max ${MAX_RESOURCE_COUNT})`,
+        location
+      )
+    );
+  }
+
+  const limitedResources: T[] = [];
+  let totalSize = 0;
+  for (const { resource, size } of sizedResources.slice(0, MAX_RESOURCE_COUNT)) {
+    if (totalSize + size > MAX_TOTAL_RESOURCE_SIZE) {
+      errors.push(
+        new ResolveError(
+          `Total skill resource size exceeds ${MAX_TOTAL_RESOURCE_SIZE / 1_048_576}MB limit`,
+          location
+        )
+      );
+      break;
+    }
+    totalSize += size;
+    limitedResources.push(resource);
+  }
+
+  return { resources: limitedResources, errors };
+}

--- a/packages/resolver/src/skill-resources.ts
+++ b/packages/resolver/src/skill-resources.ts
@@ -9,6 +9,7 @@ import {
   type ParsedSkillMd,
   type SkillResource,
 } from './skills.js';
+import { limitSkillResources } from './skill-resource-limits.js';
 
 /**
  * Resource files that belong to a SKILL.md, plus any problems found while
@@ -47,7 +48,7 @@ export async function collectSkillResources(
   const errors: ResolveError[] = [];
 
   try {
-    collected.push(...(await discoverSkillResources(skillDir, logger)));
+    collected.push(...(await discoverSkillResources(skillDir, logger, [skillMdPath])));
   } catch (err) {
     logger?.verbose(
       `Failed to discover skill resources in ${skillDir}: ${
@@ -96,7 +97,15 @@ export async function collectSkillResources(
     byPath.set(resource.relativePath, resource);
   }
 
-  return { resources: [...byPath.values()], errors };
+  const location = frontmatterLocations?.frontmatter ?? {
+    file: skillMdPath,
+    line: 1,
+    column: 1,
+  };
+  const limited = limitSkillResources([...byPath.values()], location);
+  errors.push(...limited.errors);
+
+  return { resources: limited.resources, errors };
 }
 
 /**

--- a/packages/resolver/src/skill-resources.ts
+++ b/packages/resolver/src/skill-resources.ts
@@ -1,0 +1,120 @@
+import { dirname } from 'path';
+import { ResolveError } from '@promptscript/core';
+import type { Logger, Value } from '@promptscript/core';
+import {
+  discoverSkillResources,
+  getSkillFrontmatterLocations,
+  resolveSkillReferences,
+  resolveSkillScripts,
+  type ParsedSkillMd,
+  type SkillResource,
+} from './skills.js';
+
+/**
+ * Resource files that belong to a SKILL.md, plus any problems found while
+ * loading the explicitly declared ones.
+ */
+export interface CollectedSkillResources {
+  /** Files to ship alongside the skill, deduplicated by relative path */
+  resources: SkillResource[];
+  /** Errors raised by `references:` / `scripts:` frontmatter entries */
+  errors: ResolveError[];
+}
+
+/**
+ * Collect every file that travels with a SKILL.md.
+ *
+ * Combines the three sources a skill can pull resources from: files discovered
+ * alongside SKILL.md, `references:` frontmatter entries, and `scripts:`
+ * frontmatter entries. Later entries win on a relative-path clash, so explicit
+ * frontmatter overrides a discovered file.
+ *
+ * Discovery failures are logged and skipped; failures for explicitly declared
+ * references and scripts are returned so callers can surface them.
+ *
+ * @param skillMdPath - Absolute path to the SKILL.md file
+ * @param parsed - Parsed SKILL.md metadata
+ * @param logger - Optional logger for reporting skipped files
+ * @returns Deduplicated resources and any resource errors
+ */
+export async function collectSkillResources(
+  skillMdPath: string,
+  parsed: ParsedSkillMd,
+  logger?: Logger
+): Promise<CollectedSkillResources> {
+  const skillDir = dirname(skillMdPath);
+  const collected: SkillResource[] = [];
+  const errors: ResolveError[] = [];
+
+  try {
+    collected.push(...(await discoverSkillResources(skillDir, logger)));
+  } catch (err) {
+    logger?.verbose(
+      `Failed to discover skill resources in ${skillDir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
+  const frontmatterLocations = getSkillFrontmatterLocations(parsed);
+
+  if (parsed.references && parsed.references.length > 0) {
+    try {
+      collected.push(
+        ...(await resolveSkillReferences(
+          parsed.references,
+          skillDir,
+          logger,
+          frontmatterLocations?.frontmatter,
+          frontmatterLocations?.items.get('references')
+        ))
+      );
+    } catch (err) {
+      errors.push(toResolveError(err));
+    }
+  }
+
+  if (parsed.scripts && parsed.scripts.length > 0) {
+    try {
+      collected.push(
+        ...(await resolveSkillScripts(
+          parsed.scripts,
+          skillDir,
+          logger,
+          frontmatterLocations?.frontmatter,
+          frontmatterLocations?.items.get('scripts')
+        ))
+      );
+    } catch (err) {
+      errors.push(toResolveError(err));
+    }
+  }
+
+  // Deduplicate by relative path: explicit frontmatter overrides discovery.
+  const byPath = new Map<string, SkillResource>();
+  for (const resource of collected) {
+    byPath.set(resource.relativePath, resource);
+  }
+
+  return { resources: [...byPath.values()], errors };
+}
+
+/**
+ * Convert resources into the AST value shape stored on a skill definition.
+ *
+ * @param resources - Resources collected for a skill
+ * @returns Plain AST values ready to assign to the skill's `resources` property
+ */
+export function toSkillResourceValues(resources: readonly SkillResource[]): Value[] {
+  return resources.map((resource) => ({
+    relativePath: resource.relativePath,
+    content: resource.content,
+    ...(resource.origin ? { origin: resource.origin } : {}),
+    ...(resource.executable !== undefined ? { executable: resource.executable } : {}),
+  }));
+}
+
+function toResolveError(err: unknown): ResolveError {
+  if (err instanceof ResolveError) return err;
+  return new ResolveError(err instanceof Error ? err.message : String(err));
+}

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -20,6 +20,12 @@ import type {
   SkillContractField,
   SourceLocation,
 } from '@promptscript/core';
+import {
+  limitSkillResources,
+  MAX_RESOURCE_COUNT,
+  MAX_RESOURCE_SIZE,
+  MAX_TOTAL_RESOURCE_SIZE,
+} from './skill-resource-limits.js';
 
 /**
  * A resource file discovered alongside a skill's SKILL.md.
@@ -1339,15 +1345,6 @@ async function loadSkillIgnore(skillDir: string): Promise<SkillIgnoreRules | nul
   }
 }
 
-/** Maximum size (in bytes) for a single resource file. */
-const MAX_RESOURCE_SIZE = 1_048_576; // 1 MB
-
-/** Maximum total size (in bytes) for all resource files in a skill. */
-const MAX_TOTAL_RESOURCE_SIZE = 10_485_760; // 10 MB
-
-/** Maximum number of resource files per skill. */
-const MAX_RESOURCE_COUNT = 100;
-
 /**
  * Check if a skill name is safe (no path traversal characters).
  */
@@ -1370,11 +1367,13 @@ const noopLogger: Logger = {
  *
  * @param skillDir - Absolute path to the skill directory
  * @param logger - Optional logger for reporting skipped files
+ * @param excludedPaths - Absolute paths to skip before applying aggregate limits
  * @returns Array of resource files with relative paths and content
  */
 export async function discoverSkillResources(
   skillDir: string,
-  logger: Logger = noopLogger
+  logger: Logger = noopLogger,
+  excludedPaths: readonly string[] = []
 ): Promise<SkillResource[]> {
   // Load .skillignore rules if present
   const ignoreRules = await loadSkillIgnore(skillDir);
@@ -1385,6 +1384,7 @@ export async function discoverSkillResources(
 
   // Resolve the real path of the skill directory to compare against
   const realSkillDir = await realpath(skillDir);
+  const excludedResourcePaths = new Set(excludedPaths.map((path) => resolve(path)));
 
   for (const entry of entries) {
     // Enforce aggregate count limit
@@ -1405,6 +1405,7 @@ export async function discoverSkillResources(
     if (SKIP_FILES.has(entry.name)) continue;
 
     const fullPath = resolve(entry.parentPath, entry.name);
+    if (excludedResourcePaths.has(fullPath)) continue;
     const relPath = relative(skillDir, fullPath);
 
     // Use forward slashes for consistent pattern matching
@@ -2084,26 +2085,35 @@ export async function resolveNativeSkills(
 
         // Discover resource files alongside SKILL.md
         const skillDir = dirname(skillMdPath);
-        const resources = await discoverSkillResources(skillDir, logger);
+        const resources = await discoverSkillResources(skillDir, logger, [skillMdPath]);
 
-        // Merge skill-specific resources with shared resources
-        const allResources: SkillResource[] = [...resources];
+        // Merge existing, skill-specific, and shared resources.
+        const allResources: SkillResource[] = [];
+        const existingResources = updatedSkill['resources'];
+        if (Array.isArray(existingResources)) {
+          for (const value of existingResources) {
+            if (typeof value !== 'object' || value === null || Array.isArray(value)) continue;
+            const resource = value as Record<string, Value>;
+            const relativePath = resource['relativePath'];
+            const content = resource['content'];
+            if (typeof relativePath !== 'string' || typeof content !== 'string') continue;
+            const origin = resource['origin'];
+            const executable = resource['executable'];
+            allResources.push({
+              relativePath,
+              content,
+              ...(typeof origin === 'string' ? { origin } : {}),
+              ...(typeof executable === 'boolean' ? { executable } : {}),
+            });
+          }
+        }
+        allResources.push(...resources);
         for (const shared of sharedResources) {
           allResources.push({
             relativePath: `@shared/${shared.relativePath}`,
             content: shared.content,
             ...(shared.origin ? { origin: shared.origin } : {}),
           });
-        }
-
-        if (allResources.length > 0) {
-          const resourceValues: Value[] = allResources.map((r) => ({
-            relativePath: r.relativePath,
-            content: r.content,
-            ...(r.origin ? { origin: r.origin } : {}),
-            ...(r.executable !== undefined ? { executable: r.executable } : {}),
-          }));
-          updatedSkill['resources'] = resourceValues;
         }
 
         // Load reference files listed in the SKILL.md frontmatter
@@ -2116,16 +2126,7 @@ export async function resolveNativeSkills(
             frontmatterLocations?.frontmatter,
             frontmatterLocations?.items.get('references')
           );
-          const existingResources = (updatedSkill['resources'] as Value[] | undefined) ?? [];
-          updatedSkill['resources'] = [
-            ...existingResources,
-            ...refResources.map((r) => ({
-              relativePath: r.relativePath,
-              content: r.content,
-              ...(r.origin ? { origin: r.origin } : {}),
-              ...(r.executable !== undefined ? { executable: r.executable } : {}),
-            })),
-          ];
+          allResources.push(...refResources);
         }
 
         // Load script files listed in the SKILL.md frontmatter
@@ -2138,32 +2139,28 @@ export async function resolveNativeSkills(
             frontmatterLocations?.frontmatter,
             frontmatterLocations?.items.get('scripts')
           );
-          const existingResources = (updatedSkill['resources'] as Value[] | undefined) ?? [];
-          updatedSkill['resources'] = [
-            ...existingResources,
-            ...scriptResources.map((r) => ({
-              relativePath: r.relativePath,
-              content: r.content,
-              ...(r.origin ? { origin: r.origin } : {}),
-              ...(r.executable !== undefined ? { executable: r.executable } : {}),
-            })),
-          ];
+          allResources.push(...scriptResources);
         }
 
-        const mergedResources = updatedSkill['resources'];
-        if (Array.isArray(mergedResources)) {
-          const resourcesByPath = new Map<string, Value>();
-          for (const resource of mergedResources) {
-            if (typeof resource !== 'object' || resource === null || Array.isArray(resource)) {
-              continue;
-            }
-            const resourceRecord = resource as Record<string, Value>;
-            const relativePath = resourceRecord['relativePath'];
-            if (typeof relativePath === 'string') {
-              resourcesByPath.set(relativePath, resourceRecord);
-            }
+        if (allResources.length > 0) {
+          const resourcesByPath = new Map<string, SkillResource>();
+          for (const resource of allResources) {
+            resourcesByPath.set(resource.relativePath, resource);
           }
-          updatedSkill['resources'] = [...resourcesByPath.values()];
+          const limited = limitSkillResources([...resourcesByPath.values()], {
+            ...(frontmatterLocations?.frontmatter ?? {
+              file: skillMdPath,
+              line: 1,
+              column: 1,
+            }),
+          });
+          if (limited.errors[0]) throw limited.errors[0];
+          updatedSkill['resources'] = limited.resources.map((resource) => ({
+            relativePath: resource.relativePath,
+            content: resource.content,
+            ...(resource.origin ? { origin: resource.origin } : {}),
+            ...(resource.executable !== undefined ? { executable: resource.executable } : {}),
+          }));
         }
 
         updatedProperties[skillName] = updatedSkill;


### PR DESCRIPTION
## Description

A skill imported as a directory carried only its `SKILL.md`. Everything living next to it — `references/`, `scripts/`, `data/` — was dropped, so the compiled skill instructed the agent to read files that were never emitted.

```
@use github.com/nextlevelbuilder/ui-ux-pro-max-skill/.claude/skills/ui-ux-pro-max
```

Before: `.claude/skills/ui-ux-pro-max/SKILL.md` — 1 file.
After: 47 files (`references/*.md`, `scripts/*.py`, `data/**/*.csv|json`).

`prs skills add <source>` hit the same defect: it writes the source verbatim as a directory-form `@use` line (the `/SKILL.md` suffix is used only internally to fetch and validate the frontmatter), so it landed on the identical resolver path.

### Root cause

A skill can reach the AST through three paths. Only one of them collected resources:

| Path | Location | Resources before |
| --- | --- | --- |
| single `.md` file (`loadAndParseMd`) | `resolver.ts` | yes |
| local skills (`resolveNativeSkills`) | `skills.ts` | yes |
| **directory import** (`scanDirectoryForSkills`, `discoverNativeContent`) | `resolver.ts`, `auto-discovery.ts` | **no** |

The last two built skill definitions from frontmatter and body alone, never calling `discoverSkillResources` / `resolveSkillReferences` / `resolveSkillScripts`. `docs/guides/markdown-imports.md` already documented the intended behaviour, so this brings the code in line with the docs.

### Change

Extracts the collection logic the single-file import already performed into `packages/resolver/src/skill-resources.ts` (`collectSkillResources`, `toSkillResourceValues`) and calls it from all three paths, so every shape of directory import ships the same payload as a locally discovered skill:

- the imported directory is itself the skill (`SKILL.md` at its root),
- it contains skill subdirectories,
- it nests them under `skills/`.

Deduplication is by relative path, with explicit frontmatter entries overriding discovered files. Errors from `references:` / `scripts:` entries are now surfaced instead of silently ignored on the discovery paths; discovery failures stay non-fatal and verbose-logged. Existing size, count, symlink and skip-list limits are unchanged.

## Related Issue

N/A — reported directly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly

Tests added (8): a registry-level regression for `@use github.com/foo/bar/.claude/skills/ui-ux`, the three directory-import shapes, and unit coverage for the new helper (merge/dedupe, returned errors, logged discovery failure).

Verification run: `format`, `lint`, `typecheck`, `test`, `prs validate --strict`, `schema:check`, `skill:check` all clean. Two pre-existing failures remain (`agents.spec.ts` and `auto-discovery.spec.ts`, both "cannot be read (permissions)") — they rely on `chmod 0o000` and fail identically on `main` when the test runner is root. `grammar:check` could not run: `pygments` is not installed in this environment; no lexer tokens were touched.

End-to-end checks against the real skill, cold cache: manual `@use` (directory form), `prs init` + `prs skills add` + `prs compile`, and the explicit `.../SKILL.md` form all emit 47 files. Reverting only the two changed resolver files reproduces the 1-file output for each.

## Additional Notes

Out of scope, pre-existing and unchanged by this PR: a **local** `@use ./my-skill` where the directory itself is the skill (`SKILL.md` at its root) fails outright with `No skills found in directory`. The registry path falls back to `discoverNativeContent`; the local path has no such fallback. Verified to behave identically before and after this change. `docs/guides/markdown-imports.md` documents this form as supported, so it is worth a separate fix — kept out of this PR because it changes what `@use ./dir` means and deserves its own review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYrYA9X1LPYMfa7GJNgGRp)_