### PR TITLE
fix(cli): align text diff with merged outputs

### DIFF
--- a/packages/cli/src/commands/__tests__/diff.spec.ts
+++ b/packages/cli/src/commands/__tests__/diff.spec.ts
@@ -281,6 +281,54 @@ describe('diffCommand', () => {
     );
   });
 
+  it('should report no changes when existing hook settings include user configuration', async () => {
+    const generatedHook = {
+      type: 'command',
+      command: 'prs compile --hook # promptscript-generated:abc123',
+    };
+    const generatedContent =
+      JSON.stringify({ hooks: { PreToolUse: [generatedHook] } }, null, 2) + '\n';
+    const existingContent =
+      JSON.stringify(
+        {
+          permissions: { allow: ['Read'] },
+          hooks: { PreToolUse: [{ type: 'command', command: 'user command' }, generatedHook] },
+        },
+        null,
+        2
+      ) + '\n';
+    mockLoadConfig.mockResolvedValue({
+      targets: ['claude'],
+      validation: {},
+      includePromptScriptSkill: false,
+    });
+    mockResolveRegistryPath.mockResolvedValue({
+      path: './registry',
+      isRemote: false,
+      source: 'local',
+    });
+    mockExistsSync.mockImplementation((path) => !String(path).endsWith('promptscript.lock'));
+    mockCompile.mockResolvedValue({
+      success: true,
+      errors: [],
+      warnings: [],
+      outputs: new Map([['claude', { path: '.claude/settings.json', content: generatedContent }]]),
+    });
+    mockReadFile.mockResolvedValue(existingContent);
+
+    await diffCommand({ noPager: true });
+
+    expect(mockPagerWrite).toHaveBeenCalledWith(
+      expect.stringContaining('.claude/settings.json (no changes)')
+    );
+    expect(mockPagerWrite).toHaveBeenCalledWith(
+      expect.stringContaining('All files are up to date')
+    );
+    expect(mockPagerWrite).not.toHaveBeenCalledWith(
+      expect.stringContaining('.claude/settings.json (modified)')
+    );
+  });
+
   it('should read a valid lockfile and configure complete repository roots', async () => {
     mockLoadConfig.mockResolvedValue({
       targets: ['github'],

--- a/packages/cli/src/commands/__tests__/diff.spec.ts
+++ b/packages/cli/src/commands/__tests__/diff.spec.ts
@@ -329,6 +329,119 @@ describe('diffCommand', () => {
     );
   });
 
+  it('should preview changed hooks after merging user settings', async () => {
+    const generatedContent =
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: 'Edit|Write',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: '/new/prs hook pre-edit # promptscript-generated:new',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      ) + '\n';
+    const existingContent =
+      JSON.stringify(
+        {
+          permissions: { allow: ['Read'] },
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: 'Bash',
+                hooks: [{ type: 'command', command: 'echo user' }],
+              },
+              {
+                matcher: 'Edit|Write',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: '/old/prs hook pre-edit # promptscript-generated:old',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      ) + '\n';
+    mockLoadConfig.mockResolvedValue({
+      targets: ['claude'],
+      validation: {},
+      includePromptScriptSkill: false,
+    });
+    mockResolveRegistryPath.mockResolvedValue({
+      path: './registry',
+      isRemote: false,
+      source: 'local',
+    });
+    mockExistsSync.mockImplementation((path) => !String(path).endsWith('promptscript.lock'));
+    mockCompile.mockResolvedValue({
+      success: true,
+      errors: [],
+      warnings: [],
+      outputs: new Map([['claude', { path: '.claude/settings.json', content: generatedContent }]]),
+    });
+    mockReadFile.mockResolvedValue(existingContent);
+
+    await diffCommand({ noPager: true, full: true });
+
+    expect(mockPagerWrite).toHaveBeenCalledWith(
+      expect.stringContaining('.claude/settings.json (modified)')
+    );
+    expect(mockPagerWrite).toHaveBeenCalledWith(expect.stringContaining('/new/prs hook pre-edit'));
+    expect(mockPagerWrite).not.toHaveBeenCalledWith(expect.stringContaining('echo user'));
+    expect(mockPagerWrite).not.toHaveBeenCalledWith(expect.stringContaining('"permissions"'));
+  });
+
+  it('should preview a merged Codex config without removing user settings', async () => {
+    const existingContent = `max_threads = 4
+
+model = "gpt-5"
+
+[[hooks.PreToolUse]]
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "echo old # promptscript-generated:owned"
+`;
+    mockLoadConfig.mockResolvedValue({
+      targets: ['codex'],
+      validation: {},
+      includePromptScriptSkill: false,
+    });
+    mockResolveRegistryPath.mockResolvedValue({
+      path: './registry',
+      isRemote: false,
+      source: 'local',
+    });
+    mockExistsSync.mockImplementation((path) => !String(path).endsWith('promptscript.lock'));
+    mockCompile.mockResolvedValue({
+      success: true,
+      errors: [],
+      warnings: [],
+      outputs: new Map([['codex', { path: '.codex/config.toml', content: 'max_threads = 8\n' }]]),
+    });
+    mockReadFile.mockResolvedValue(existingContent);
+
+    await diffCommand({ noPager: true, full: true });
+
+    expect(mockPagerWrite).toHaveBeenCalledWith(
+      expect.stringContaining('.codex/config.toml (modified)')
+    );
+    expect(mockPagerWrite).toHaveBeenCalledWith(expect.stringContaining('max_threads = 8'));
+    expect(mockPagerWrite).not.toHaveBeenCalledWith(expect.stringContaining('model = "gpt-5"'));
+  });
+
   it('should read a valid lockfile and configure complete repository roots', async () => {
     mockLoadConfig.mockResolvedValue({
       targets: ['github'],

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -17,7 +17,11 @@ import { Compiler } from '@promptscript/compiler';
 import { resolveRegistryPath } from '../utils/registry-resolver.js';
 import { stripMarkers } from '../utils/markers.js';
 import { resolvePrettierOptions } from '../prettier/loader.js';
-import { buildCompilationDiff, createCompilationDiffErrorReport } from '../utils/diff-report.js';
+import {
+  buildCompilationDiff,
+  createCompilationDiffErrorReport,
+  getPlannedContent,
+} from '../utils/diff-report.js';
 import { loadBundledSkillContent } from '../utils/bundled-skill.js';
 import { prepareLegacyFactoryMigration } from '../utils/legacy-factory-hooks.js';
 import { finalizeOutputPlan } from '../utils/output-plan.js';
@@ -152,7 +156,8 @@ async function compareOutput(
   // File exists - compare content (strip markers to ignore timestamp-only changes)
   const existingContent = await readFile(outputPath, 'utf-8');
   const existingStripped = stripMarkers(existingContent);
-  const newStripped = stripMarkers(newContent);
+  const plannedContent = getPlannedContent(output, existingContent).content;
+  const newStripped = stripMarkers(plannedContent);
 
   if (existingStripped === newStripped) {
     pager.write(chalk.gray(`  ${outputPath} (no changes)`));

--- a/packages/cli/src/utils/diff-report.ts
+++ b/packages/cli/src/utils/diff-report.ts
@@ -219,7 +219,7 @@ function isOwnedOutput(path: string, content: string): boolean {
  * still being safely updated by `prs compile`. Diff must compare that merged
  * candidate, not the formatter's generated fragment.
  */
-function getPlannedContent(
+export function getPlannedContent(
   output: FormatterOutput,
   existingContent: string | undefined
 ): { content: string; safelyWritable: boolean } {


### PR DESCRIPTION
## Summary

- Reuse merge-preview content in textual `prs diff` comparisons.
- Keep Claude settings with user-owned configuration from reporting false modifications.
- Add regression coverage for `.claude/settings.json`.

## Verification

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`