### PR TITLE
fix(cli): handle builds-only compile

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -270,6 +270,11 @@ prs compile [options]
 
 `--all-builds` and `--build` are mutually exclusive. `--all-builds` compiles every named profile in `config.builds` in sorted key order, reports failures per profile, and uses one watcher for the full build set when combined with `--watch`.
 
+Compilation fails with exit code 1 when the run resolves zero targets: `config.targets` is missing or
+empty, the selected build profile lists no targets, or every matching target is `enabled: false`. The
+error names the config key to change and, for builds-only projects, lists the profiles that can be
+compiled with `--build` or `--all-builds`.
+
 Paths passed through `--config`, `--registry`, and `--output` are resolved relative to `--cwd` (or the current project directory). Watch mode honors the configured `watch.include`, `watch.exclude`, `watch.debounce`, and `watch.clearScreen` settings. Added, changed, and removed matching files all trigger compilation, and rebuilds are serialized.
 
 Watch mode also tracks resolved dependencies - imported files, local skills, and the loaded

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -193,7 +193,7 @@ includePromptScriptSkill: true # default: true
 | -------------------------- | ----------------------- | -------- | ----------------------------------------------- |
 | `id`                       | string                  | Yes      | Project identifier                              |
 | `syntax`                   | string                  | Yes      | PromptScript syntax version                     |
-| `targets`                  | `TargetEntry[]`         | Yes      | Output targets and target-specific options      |
+| `targets`                  | `TargetEntry[]`         | Yes\*    | Output targets and target-specific options      |
 | `description`              | string                  | No       | Project description                             |
 | `telemetry`                | boolean                 | No       | Enable anonymous aggregate usage telemetry      |
 | `extends`                  | string                  | No       | Base configuration file to merge                |
@@ -212,8 +212,14 @@ includePromptScriptSkill: true # default: true
 | `validation`               | object                  | No       | Guard and validation rule settings              |
 | `policies`                 | array                   | No       | Extension compliance policies                   |
 
-`id`, `syntax`, and `targets` are required even when `input.entry` uses its default. See the
-[Policy Engine guide](../guides/policy-engine.md) for `policies` syntax.
+`id` and `syntax` are required even when `input.entry` uses its default.
+
+\* `targets` is required unless every target is declared inside a named [build
+profile](#builds). Such builds-only projects compile with `prs compile --build <name>` or
+`prs compile --all-builds`; a bare `prs compile` fails with the list of available profiles because
+there is no default target list to use.
+
+See the [Policy Engine guide](../guides/policy-engine.md) for `policies` syntax.
 
 ### telemetry
 
@@ -829,6 +835,11 @@ prs build logstrip-factory
 # Compile all named build profiles in deterministic order
 prs compile --all-builds
 ```
+
+A profile without its own `targets` key falls back to the top-level `targets` list. When a project
+keeps every target inside profiles and omits top-level `targets`, a bare `prs compile` fails and
+lists the available profiles instead of compiling nothing. `prs diff` reads only top-level `targets`,
+so builds-only projects need `prs diff --target <name>`.
 
 **Nested AGENTS.md via Build Profiles:**
 

--- a/packages/cli/src/__tests__/check-command.spec.ts
+++ b/packages/cli/src/__tests__/check-command.spec.ts
@@ -234,6 +234,42 @@ describe('commands/check', () => {
       expect(process.exitCode === 0 || process.exitCode === undefined).toBe(true);
     });
 
+    it('should accept targets defined only in named build profiles', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        builds: { docs: { targets: ['claude'] } },
+      });
+      mockExistsSync.mockReturnValue(true);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      const output = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(output).toContain('1 target(s) configured in build profiles');
+      expect(output).not.toContain('No targets configured');
+      logSpy.mockRestore();
+    });
+
+    it('should fail when a build profile configures an unknown target', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        builds: { docs: { targets: ['not-a-target'] } },
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
     it('should handle registry path configuration', async () => {
       mockFindConfigFile.mockReturnValue('promptscript.yaml');
       mockLoadConfig.mockResolvedValue({

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -1133,6 +1133,23 @@ describe('compile command - createCliLogger warn path', () => {
     );
   });
 
+  it('should fail cleanly when only named build profiles define targets', async () => {
+    mockLoadConfig.mockResolvedValue({
+      builds: {
+        docs: { targets: ['claude'] },
+      },
+    });
+
+    await compileCommand({}, mockServices);
+
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(mockError).toHaveBeenCalledWith(
+      'No enabled compilation targets configured. Available build profiles: docs. Select a build profile with --build <name> or use --all-builds.'
+    );
+    expect(mockError).not.toHaveBeenCalledWith(expect.stringContaining('Cannot read properties'));
+  });
+
   it('should not warn when output directory is the project root', async () => {
     mockLoadConfig.mockResolvedValue({
       targets: ['claude'],

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -1150,6 +1150,18 @@ describe('compile command - createCliLogger warn path', () => {
     expect(mockError).not.toHaveBeenCalledWith(expect.stringContaining('Cannot read properties'));
   });
 
+  it('should fail cleanly when no targets or named build profiles are configured', async () => {
+    mockLoadConfig.mockResolvedValue({});
+
+    await compileCommand({}, mockServices);
+
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(mockError).toHaveBeenCalledWith(
+      'No enabled compilation targets configured. Select a build profile with --build <name> or use --all-builds.'
+    );
+  });
+
   it('should not warn when output directory is the project root', async () => {
     mockLoadConfig.mockResolvedValue({
       targets: ['claude'],

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -1133,33 +1133,115 @@ describe('compile command - createCliLogger warn path', () => {
     );
   });
 
-  it('should fail cleanly when only named build profiles define targets', async () => {
-    mockLoadConfig.mockResolvedValue({
-      builds: {
-        docs: { targets: ['claude'] },
-      },
+  describe('empty target resolution', () => {
+    it('should point at named build profiles when only they define targets', async () => {
+      mockLoadConfig.mockResolvedValue({
+        builds: {
+          docs: { targets: ['claude'] },
+        },
+      });
+
+      await compileCommand({}, mockServices);
+
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockSpinner.fail).toHaveBeenCalledWith('No compilation targets');
+      expect(mockError).toHaveBeenCalledWith(
+        'No compilation targets configured in config.targets. Compile a named build profile with --build <name> (available: docs) or use --all-builds.'
+      );
     });
 
-    await compileCommand({}, mockServices);
+    it('should point at prs init when nothing configures targets', async () => {
+      mockLoadConfig.mockResolvedValue({});
 
-    expect(mockCompile).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
-    expect(mockError).toHaveBeenCalledWith(
-      'No enabled compilation targets configured. Available build profiles: docs. Select a build profile with --build <name> or use --all-builds.'
-    );
-    expect(mockError).not.toHaveBeenCalledWith(expect.stringContaining('Cannot read properties'));
-  });
+      await compileCommand({}, mockServices);
 
-  it('should fail cleanly when no targets or named build profiles are configured', async () => {
-    mockLoadConfig.mockResolvedValue({});
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        'No compilation targets configured. Add a "targets" list to promptscript.yaml or run: prs init'
+      );
+    });
 
-    await compileCommand({}, mockServices);
+    it('should report top-level targets that are all disabled', async () => {
+      mockLoadConfig.mockResolvedValue({
+        targets: [{ claude: { enabled: false } }],
+      });
 
-    expect(mockCompile).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
-    expect(mockError).toHaveBeenCalledWith(
-      'No enabled compilation targets configured. Select a build profile with --build <name> or use --all-builds.'
-    );
+      await compileCommand({}, mockServices);
+
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        'All compilation targets are disabled. promptscript.yaml lists only targets with "enabled: false" - enable at least one in config.targets.'
+      );
+    });
+
+    it('should report build profile targets that are all disabled', async () => {
+      mockLoadConfig.mockResolvedValue({
+        builds: {
+          docs: { targets: [{ claude: { enabled: false } }] },
+        },
+      });
+
+      await compileCommand({ build: 'docs' }, mockServices);
+
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        'All compilation targets are disabled. Build profile "docs" lists only targets with "enabled: false" - enable at least one in config.builds.docs.targets.'
+      );
+    });
+
+    it('should report a build profile with an empty target list', async () => {
+      mockLoadConfig.mockResolvedValue({
+        targets: ['claude'],
+        builds: {
+          docs: { targets: [] },
+        },
+      });
+
+      await compileCommand({ build: 'docs' }, mockServices);
+
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        'Build profile "docs" lists no compilation targets. Add them to config.builds.docs.targets.'
+      );
+    });
+
+    it('should report a build profile that inherits empty top-level targets', async () => {
+      mockLoadConfig.mockResolvedValue({
+        builds: {
+          docs: { entry: '.promptscript/docs.prs' },
+        },
+      });
+
+      await compileCommand({ build: 'docs' }, mockServices);
+
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        'Build profile "docs" inherits targets from config.targets, which is empty. Add targets to config.builds.docs.targets or config.targets.'
+      );
+    });
+
+    it('should report the failing profile during --all-builds', async () => {
+      mockLoadConfig.mockResolvedValue({
+        builds: {
+          docs: { targets: [{ claude: { enabled: false } }] },
+        },
+      });
+
+      await compileCommand({ allBuilds: true }, mockServices);
+
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        'All compilation targets are disabled. Build profile "docs" lists only targets with "enabled: false" - enable at least one in config.builds.docs.targets.'
+      );
+      expect(mockError).toHaveBeenCalledWith('Build profile "docs" failed');
+    });
   });
 
   it('should not warn when output directory is the project root', async () => {

--- a/packages/cli/src/commands/__tests__/diff.spec.ts
+++ b/packages/cli/src/commands/__tests__/diff.spec.ts
@@ -221,6 +221,53 @@ describe('diffCommand', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('should fail cleanly when only named build profiles define targets', async () => {
+    mockLoadConfig.mockResolvedValue({
+      builds: { docs: { targets: ['claude'] } },
+      validation: {},
+    });
+    mockResolveRegistryPath.mockResolvedValue({
+      path: './registry',
+      isRemote: false,
+      source: 'local',
+    });
+
+    await diffCommand({ noPager: true });
+
+    expect(mockFail).toHaveBeenCalledWith('No compilation targets');
+    expect(ConsoleOutput.error).toHaveBeenCalledWith(
+      'No compilation targets configured in config.targets. prs diff reads only top-level targets - pass --target <name> or add targets to promptscript.yaml (build profiles found: docs).'
+    );
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should emit a machine-readable error when no targets are configured', async () => {
+    mockLoadConfig.mockResolvedValue({ validation: {} });
+    mockResolveRegistryPath.mockResolvedValue({
+      path: './registry',
+      isRemote: false,
+      source: 'local',
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await diffCommand({ format: 'json' });
+
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    const report: unknown = JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+    expect(report).toMatchObject({
+      errors: [
+        {
+          code: 'DIFF0003',
+          message:
+            'No compilation targets configured. Add a "targets" list to promptscript.yaml or run: prs init',
+        },
+      ],
+    });
+    logSpy.mockRestore();
+  });
+
   it('should compile an explicitly requested target not present in config', async () => {
     mockLoadConfig.mockResolvedValue({
       targets: ['github'],

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -179,7 +179,13 @@ export async function checkCommand(_options: CheckOptions): Promise<void> {
     }
 
     // Check 7: Targets configured
-    if (!config.targets || config.targets.length === 0) {
+    // Builds-only projects keep every target inside config.builds, so the
+    // top-level list being empty is not by itself a misconfiguration.
+    const buildTargets = Object.values(config.builds ?? {}).flatMap(
+      (profile) => profile.targets ?? []
+    );
+    const rootTargets = config.targets ?? [];
+    if (rootTargets.length === 0 && buildTargets.length === 0) {
       results.push({
         name: 'Targets',
         status: 'warning',
@@ -187,13 +193,17 @@ export async function checkCommand(_options: CheckOptions): Promise<void> {
       });
       hasWarnings = true;
     } else {
-      const targetNames = config.targets.flatMap((target) => {
-        if (typeof target === 'string') return [target];
-        if (typeof target !== 'object' || target === null || Array.isArray(target)) {
-          return ['<invalid>'];
-        }
-        return Object.keys(target);
-      });
+      const targetNames = [
+        ...new Set(
+          [...rootTargets, ...buildTargets].flatMap((target) => {
+            if (typeof target === 'string') return [target];
+            if (typeof target !== 'object' || target === null || Array.isArray(target)) {
+              return ['<invalid>'];
+            }
+            return Object.keys(target);
+          })
+        ),
+      ];
       const invalidTargets = targetNames.filter((target) => !isKnownTarget(target));
       if (invalidTargets.length > 0 || targetNames.length === 0) {
         results.push({
@@ -209,7 +219,10 @@ export async function checkCommand(_options: CheckOptions): Promise<void> {
         results.push({
           name: 'Targets',
           status: 'ok',
-          message: `${targetNames.length} target(s) configured`,
+          message:
+            rootTargets.length === 0
+              ? `${targetNames.length} target(s) configured in build profiles`
+              : `${targetNames.length} target(s) configured`,
         });
       }
     }

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -127,6 +127,45 @@ function parseTargets(
     .filter((target) => target.config?.enabled !== false);
 }
 
+interface EmptyTargetsContext {
+  /** Profile passed via --build, also set for each profile of --all-builds */
+  buildName: string | undefined;
+  /** True when the entries came from the profile instead of the top-level list */
+  fromBuildProfile: boolean;
+  /** Entries before the enabled filter, used to separate "disabled" from "absent" */
+  entries: TargetEntry[] | undefined;
+  availableBuilds: string[];
+}
+
+/**
+ * Describe why a compile run resolved zero targets.
+ * The hint names the config key that has to change, so a run that already
+ * passed --build or --all-builds is never told to pass it again.
+ */
+function describeEmptyTargets(context: EmptyTargetsContext): string {
+  const { buildName, fromBuildProfile, entries, availableBuilds } = context;
+  const location =
+    fromBuildProfile && buildName ? `config.builds.${buildName}.targets` : 'config.targets';
+
+  if (entries && entries.length > 0) {
+    const source =
+      fromBuildProfile && buildName ? `Build profile "${buildName}"` : 'promptscript.yaml';
+    return `All compilation targets are disabled. ${source} lists only targets with "enabled: false" - enable at least one in ${location}.`;
+  }
+
+  if (buildName) {
+    return fromBuildProfile
+      ? `Build profile "${buildName}" lists no compilation targets. Add them to ${location}.`
+      : `Build profile "${buildName}" inherits targets from config.targets, which is empty. Add targets to config.builds.${buildName}.targets or config.targets.`;
+  }
+
+  if (availableBuilds.length > 0) {
+    return `No compilation targets configured in config.targets. Compile a named build profile with --build <name> (available: ${availableBuilds.join(', ')}) or use --all-builds.`;
+  }
+
+  return 'No compilation targets configured. Add a "targets" list to promptscript.yaml or run: prs init';
+}
+
 function getBuildProfile(
   config: PromptScriptConfig,
   buildName: string | undefined
@@ -787,14 +826,17 @@ async function compileCommandWithResult(
     }
 
     if (targets.length === 0) {
-      const availableBuilds = Object.keys(config.builds ?? {});
-      const buildHint =
-        availableBuilds.length > 0
-          ? ` Available build profiles: ${availableBuilds.join(', ')}.`
-          : '';
-      throw new Error(
-        `No enabled compilation targets configured.${buildHint} Select a build profile with --build <name> or use --all-builds.`
+      spinner.fail('No compilation targets');
+      ConsoleOutput.error(
+        describeEmptyTargets({
+          buildName: options.build,
+          fromBuildProfile: buildProfile?.targets !== undefined,
+          entries: targetEntries,
+          availableBuilds: Object.keys(config.builds ?? {}),
+        })
       );
+      process.exitCode = 1;
+      return false;
     }
 
     // Detect output path conflicts before doing any work

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -108,8 +108,10 @@ function createCliLogger(): Logger {
  * Parse target entries into compiler format.
  * Filters out targets with enabled: false.
  */
-function parseTargets(targets: TargetEntry[]): { name: string; config?: TargetConfig }[] {
-  return targets
+function parseTargets(
+  targets: TargetEntry[] | undefined
+): { name: string; config?: TargetConfig }[] {
+  return (targets ?? [])
     .map((entry) => {
       if (typeof entry === 'string') {
         return { name: entry };
@@ -782,6 +784,17 @@ async function compileCommandWithResult(
       targets = matched ? [matched] : [{ name: selectedTarget }];
     } else {
       targets = parsedTargets;
+    }
+
+    if (targets.length === 0) {
+      const availableBuilds = Object.keys(config.builds ?? {});
+      const buildHint =
+        availableBuilds.length > 0
+          ? ` Available build profiles: ${availableBuilds.join(', ')}.`
+          : '';
+      throw new Error(
+        `No enabled compilation targets configured.${buildHint} Select a build profile with --build <name> or use --all-builds.`
+      );
     }
 
     // Detect output path conflicts before doing any work

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -75,8 +75,10 @@ export function createDiffLogger(machineReadable = false): Logger {
 /**
  * Parse target entries into compiler format.
  */
-function parseTargets(targets: TargetEntry[]): { name: string; config?: TargetConfig }[] {
-  return targets
+function parseTargets(
+  targets: TargetEntry[] | undefined
+): { name: string; config?: TargetConfig }[] {
+  return (targets ?? [])
     .map((entry) => {
       if (typeof entry === 'string') {
         return { name: entry };
@@ -212,6 +214,35 @@ export async function diffCommand(options: DiffOptions): Promise<void> {
     const targets = options.target
       ? [parsedTargets.find((target) => target.name === options.target) ?? { name: options.target }]
       : parsedTargets;
+
+    if (targets.length === 0) {
+      // Named build profiles are compile-only, so a builds-only project has
+      // nothing for diff to compare unless a target is passed explicitly.
+      const availableBuilds = Object.keys(config.builds ?? {});
+      const message =
+        availableBuilds.length > 0
+          ? `No compilation targets configured in config.targets. prs diff reads only top-level targets - pass --target <name> or add targets to promptscript.yaml (build profiles found: ${availableBuilds.join(', ')}).`
+          : 'No compilation targets configured. Add a "targets" list to promptscript.yaml or run: prs init';
+      if (isJsonFormat) {
+        console.log(
+          JSON.stringify(
+            createCompilationDiffErrorReport(
+              [{ name: 'TargetError', code: 'DIFF0003', message }],
+              [],
+              projectRoot,
+              options.includeContent
+            ),
+            null,
+            2
+          )
+        );
+      } else {
+        spinner.fail('No compilation targets');
+        ConsoleOutput.error(message);
+      }
+      process.exitCode = 1;
+      return;
+    }
     const logger = createDiffLogger(isJsonFormat);
     const prettierOptions = await resolvePrettierOptions(config, projectRoot);
     const skillContent =

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -225,7 +225,7 @@ function selectRequestedCandidates(
 async function readProjectConfig(
   configPath: string,
   services: CliServices
-): Promise<PromptScriptConfig> {
+): Promise<PromptScriptConfig & { targets: TargetEntry[] }> {
   const content = interpolateEnvVars(await services.fs.readFile(configPath, 'utf-8'));
   const config = parseYaml(content) as PromptScriptConfig | null;
   if (
@@ -248,7 +248,7 @@ async function readProjectConfig(
   ) {
     throw new Error(`${configPath} must contain id, syntax, and targets before migration`);
   }
-  return config;
+  return config as PromptScriptConfig & { targets: TargetEntry[] };
 }
 
 function extractTargetNames(targets: TargetEntry[]): AIToolTarget[] {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -365,6 +365,9 @@ export interface PromptScriptConfig {
   /**
    * Output targets.
    *
+   * Optional only when every target lives in a named build profile: such
+   * builds-only projects compile through `--build <name>` or `--all-builds`.
+   *
    * Can be simple names or objects with configuration:
    * @example
    * targets:
@@ -373,7 +376,7 @@ export interface PromptScriptConfig {
    *       convention: markdown
    *       output: custom/CLAUDE.md
    */
-  targets: TargetEntry[];
+  targets?: TargetEntry[];
 
   /**
    * Custom convention definitions.

--- a/schema/config.json
+++ b/schema/config.json
@@ -251,7 +251,7 @@
       "items": {
         "$ref": "#/definitions/TargetEntry"
       },
-      "description": "Output targets.\n\nCan be simple names or objects with configuration:",
+      "description": "Output targets.\n\nOptional only when every target lives in a named build profile: such builds-only projects compile through `--build <name>` or `--all-builds`.\n\nCan be simple names or objects with configuration:",
       "example": "targets:\n  - github\n  - claude:\n      convention: markdown\n      output: custom/CLAUDE.md"
     },
     "customConventions": {
@@ -313,8 +313,7 @@
   },
   "required": [
     "id",
-    "syntax",
-    "targets"
+    "syntax"
   ],
   "additionalProperties": false,
   "definitions": {


### PR DESCRIPTION
## Summary

- Handle configs with named builds but no top-level targets without raw TypeError
- Return actionable guidance for `--build` and `--all-builds`
- Add regression coverage

## Tests

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` - 1747 passed
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`

Closes #440