### PR TITLE
fix(cli): harden builds-only workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ See exact output paths and feature support in the
 - **Reproducible builds** - lockfile hashes, version pins, vendor mode, and strict validation.
 - **Safe automation** - lifecycle hook commands use arrays, while generated-file protection keeps
   agents pointed at `.prs` source.
-- **Scoped monorepo builds** - compile one package with `prs build <name>` or every profile with
-  `prs compile --all-builds`.
+- **Scoped monorepo builds** - compile one package with `prs build <name>`, inspect it with
+  `prs diff --build <name>`, or compile every profile with `prs compile --all-builds`.
 - **CI-ready output** - use `prs validate --strict --format json`, `prs compile --dry-run`, and
   `prs diff --format json` for deterministic machine-readable changes without generated-file
   writes.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -332,9 +332,9 @@ This creates:
 Your existing AI instruction files remain untouched.
 
 When `promptscript.yaml` already exists, static migration preserves it byte-for-byte, writes
-imported modules under `.promptscript/migrated/`, and adds one idempotent `@use` to the configured
-entry file. No candidates means no writes. Run `prs migrate --static --dry-run` to preview every
-path first.
+imported modules under `.promptscript/migrated/`, and adds one idempotent `@use` to every effective
+top-level or build-profile entry. No candidates means no writes. Run
+`prs migrate --static --dry-run` to preview every path first.
 
 For AI-assisted migration, generate a migration prompt and install the PromptScript skill:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,7 +191,8 @@ For an initialized project:
 
 - `promptscript.yaml` remains byte-for-byte unchanged.
 - Static output is written under `.promptscript/migrated/`.
-- Existing entry file gains one idempotent `@use` for the migrated project.
+- Every effective top-level or build-profile entry gains one idempotent `@use` for the migrated
+  project.
 - AI-assisted mode writes `.promptscript/migration-prompt.md` and installs the PromptScript skill.
 - Existing instruction files remain unchanged.
 - No hooks are installed.
@@ -587,6 +588,7 @@ prs diff [options]
 
 | Option                  | Description                       |
 | ----------------------- | --------------------------------- |
+| `-b, --build <name>`    | Show diff for named build profile |
 | `-t, --target <target>` | Show diff for specific target     |
 | `--format <format>`     | Output format (`text`, `json`)    |
 | `-a, --all`             | Show diff for all targets         |
@@ -605,6 +607,9 @@ prs diff --all
 # Show diff for specific target
 prs diff --target github
 
+# Show diff for a named build profile
+prs diff --build docs
+
 # Emit a machine-readable report with hashes
 prs diff --format json
 
@@ -621,12 +626,13 @@ direct automation. `success: false` with `errors` means compilation or report ge
 `success: true` with `hasChanges: true` is a valid diff report. The command exits 1 for errors and
 0 for valid reports, including reports with changes.
 
-Generated output paths are compared under the configured `output.baseDir`. The JSON report uses the
-same formatter output, configured header, and Prettier post-format pass as `prs compile`; `prs diff`
-uses the complete configured target for `--target`, including version, convention, output path, and
-skill settings. It never writes generated files, registry checkouts, cache metadata, lockfiles, or
-temporary files. Git registries must already be available through vendor mode or a valid local
-cache; otherwise diff fails with an actionable error instead of fetching them.
+Generated output paths use `builds.<name>.output` for `--build`, with `output.baseDir` as the
+fallback. The JSON report uses the same formatter output, configured header, and Prettier
+post-format pass as `prs compile`; `prs diff` uses the complete configured target for `--target`,
+including version, convention, output path, and skill settings. It never writes generated files,
+registry checkouts, cache metadata, lockfiles, or temporary files. Git registries must already be
+available through vendor mode or a valid local cache; otherwise diff fails with an actionable error
+instead of fetching them.
 
 ---
 
@@ -683,9 +689,9 @@ For local or HTTP registries, these options are ignored.
 
 ### prs check
 
-Check the effective configuration, entry file, lockfile, registry, imports,
-inheritance, and PromptScript validation without generating output. Configuration
-and validation warnings do not fail the command, while health-check errors exit
+Check the effective configuration, every top-level or build-profile entry file, lockfile, registry,
+imports, inheritance, and PromptScript validation without generating output. Configuration and
+validation warnings do not fail the command, while health-check errors exit
 with status 1.
 
 ```bash

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -838,8 +838,8 @@ prs compile --all-builds
 
 A profile without its own `targets` key falls back to the top-level `targets` list. When a project
 keeps every target inside profiles and omits top-level `targets`, a bare `prs compile` fails and
-lists the available profiles instead of compiling nothing. `prs diff` reads only top-level `targets`,
-so builds-only projects need `prs diff --target <name>`.
+lists the available profiles instead of compiling nothing. Inspect profile output with
+`prs diff --build <name>`.
 
 **Nested AGENTS.md via Build Profiles:**
 

--- a/packages/cli/src/__tests__/check-command.spec.ts
+++ b/packages/cli/src/__tests__/check-command.spec.ts
@@ -254,6 +254,70 @@ describe('commands/check', () => {
       logSpy.mockRestore();
     });
 
+    it('should check and resolve every effective build profile entry', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        builds: {
+          docs: { entry: './docs.prs', targets: ['claude'] },
+          api: { entry: './api.prs', targets: ['github'] },
+        },
+      });
+      mockExistsSync.mockImplementation(
+        (path: string) => path.endsWith('docs.prs') || path.endsWith('api.prs')
+      );
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBeUndefined();
+      expect(mockCompile).toHaveBeenCalledTimes(2);
+      expect(mockCompile).toHaveBeenCalledWith(expect.stringMatching(/docs\.prs$/));
+      expect(mockCompile).toHaveBeenCalledWith(expect.stringMatching(/api\.prs$/));
+      expect(mockCompile).not.toHaveBeenCalledWith(expect.stringMatching(/project\.prs$/));
+    });
+
+    it('should fail when an effective build profile entry is missing', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        builds: {
+          docs: { entry: './docs.prs', targets: ['claude'] },
+          api: { entry: './missing.prs', targets: ['github'] },
+        },
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('docs.prs'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+      expect(mockCompile).toHaveBeenCalledOnce();
+      expect(mockCompile).toHaveBeenCalledWith(expect.stringMatching(/docs\.prs$/));
+    });
+
+    it('should fail when a build profile entry is not a string', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        builds: {
+          docs: { entry: 42, targets: ['claude'] },
+        },
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
     it('should fail when a build profile configures an unknown target', async () => {
       mockFindConfigFile.mockReturnValue('promptscript.yaml');
       mockLoadConfig.mockResolvedValue({
@@ -261,6 +325,44 @@ describe('commands/check', () => {
         syntax: '1.0.0',
         input: { entry: './project.prs' },
         builds: { docs: { targets: ['not-a-target'] } },
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should fail when one build profile inherits missing top-level targets', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        builds: {
+          docs: { targets: ['claude'] },
+          broken: {},
+        },
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should fail when a build profile has no enabled targets', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        targets: ['github'],
+        builds: {
+          docs: { targets: [{ claude: { enabled: false } }] },
+        },
       });
       mockExistsSync.mockReturnValue(true);
 
@@ -365,6 +467,22 @@ describe('commands/check', () => {
       expect(process.exitCode).toBe(1);
     });
 
+    it('should fail when targets is not an array', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        targets: 'github',
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
     it.each([
       ['non-object', 42],
       ['null', null],
@@ -399,6 +517,38 @@ describe('commands/check', () => {
       await checkCommand({} as CheckOptions);
 
       expect(process.exitCode).toBe(1);
+    });
+
+    it('should fail when a target configuration is not an object', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        targets: [{ github: [] }],
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should accept multiple targets configured in one object', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        targets: [{ github: {}, claude: {} }],
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBeUndefined();
     });
 
     it('should handle inherit configuration', async () => {

--- a/packages/cli/src/__tests__/check-command.spec.ts
+++ b/packages/cli/src/__tests__/check-command.spec.ts
@@ -318,6 +318,74 @@ describe('commands/check', () => {
       expect(process.exitCode).toBe(1);
     });
 
+    it.each([
+      [
+        'input collection',
+        {
+          id: 'test',
+          syntax: '1.0.0',
+          input: [],
+          targets: ['github'],
+        },
+      ],
+      [
+        'input entry',
+        {
+          id: 'test',
+          syntax: '1.0.0',
+          input: { entry: '' },
+          targets: ['github'],
+        },
+      ],
+      [
+        'build collection',
+        {
+          id: 'test',
+          syntax: '1.0.0',
+          input: { entry: './project.prs' },
+          targets: ['github'],
+          builds: [],
+        },
+      ],
+      [
+        'build profile',
+        {
+          id: 'test',
+          syntax: '1.0.0',
+          input: { entry: './project.prs' },
+          targets: ['github'],
+          builds: { docs: null },
+        },
+      ],
+      [
+        'build profile target list',
+        {
+          id: 'test',
+          syntax: '1.0.0',
+          input: { entry: './project.prs' },
+          builds: { docs: { targets: 'claude' } },
+        },
+      ],
+      [
+        'empty build profile target list',
+        {
+          id: 'test',
+          syntax: '1.0.0',
+          input: { entry: './project.prs' },
+          builds: { docs: { targets: [] } },
+        },
+      ],
+    ])('should fail when %s is malformed', async (_case, config) => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue(config);
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
     it('should fail when a build profile configures an unknown target', async () => {
       mockFindConfigFile.mockReturnValue('promptscript.yaml');
       mockLoadConfig.mockResolvedValue({
@@ -458,6 +526,22 @@ describe('commands/check', () => {
         syntax: '1.0.0',
         input: { entry: './project.prs' },
         targets: ['unknown-target'],
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should fail when an unknown object-form target is configured', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        targets: [{ 'not-a-target': {} }],
       });
       mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
 
@@ -695,6 +779,23 @@ describe('commands/check', () => {
       });
       mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
       mockResolveRegistryPath.mockRejectedValue(new Error('Registry unavailable'));
+
+      const { checkCommand } = await import('../commands/check.js');
+      await checkCommand({} as CheckOptions);
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should handle non-error project resolution failures', async () => {
+      mockFindConfigFile.mockReturnValue('promptscript.yaml');
+      mockLoadConfig.mockResolvedValue({
+        id: 'test',
+        syntax: '1.0.0',
+        input: { entry: './project.prs' },
+        targets: ['github'],
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('project.prs'));
+      mockCompile.mockRejectedValue('Resolution failed');
 
       const { checkCommand } = await import('../commands/check.js');
       await checkCommand({} as CheckOptions);

--- a/packages/cli/src/__tests__/compile-utils.spec.ts
+++ b/packages/cli/src/__tests__/compile-utils.spec.ts
@@ -1,36 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { TargetEntry, TargetConfig } from '@promptscript/core';
+import type { TargetEntry } from '@promptscript/core';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
-
-/**
- * Parse target entries into compiler format.
- * Filters out targets with enabled: false.
- *
- * Note: This is a copy of the function from compile.ts for testing purposes.
- * The actual function is private to the module.
- */
-function parseTargets(targets: TargetEntry[]): { name: string; config?: TargetConfig }[] {
-  return targets
-    .map((entry) => {
-      if (typeof entry === 'string') {
-        return { name: entry };
-      }
-      // Object format: { github: { convention: 'xml' } }
-      const entries = Object.entries(entry);
-      if (entries.length === 0) {
-        throw new Error('Empty target configuration');
-      }
-      const [name, config] = entries[0] as [string, TargetConfig | undefined];
-      return { name, config };
-    })
-    .filter((target) => target.config?.enabled !== false);
-}
+import { parseTargetEntries } from '../utils/target-config.js';
 
 describe('parseTargets', () => {
   it('should parse string targets', () => {
     const targets: TargetEntry[] = ['github', 'claude'];
-    const result = parseTargets(targets);
+    const result = parseTargetEntries(targets);
     expect(result).toEqual([{ name: 'github' }, { name: 'claude' }]);
   });
 
@@ -39,7 +16,7 @@ describe('parseTargets', () => {
       { github: { convention: 'xml' } },
       { claude: { output: 'custom/CLAUDE.md' } },
     ];
-    const result = parseTargets(targets);
+    const result = parseTargetEntries(targets);
     expect(result).toEqual([
       { name: 'github', config: { convention: 'xml' } },
       { name: 'claude', config: { output: 'custom/CLAUDE.md' } },
@@ -52,7 +29,7 @@ describe('parseTargets', () => {
       { claude: { enabled: false } },
       { cursor: { convention: 'markdown' } },
     ];
-    const result = parseTargets(targets);
+    const result = parseTargetEntries(targets);
     expect(result).toEqual([
       { name: 'github', config: { enabled: true } },
       { name: 'cursor', config: { convention: 'markdown' } },
@@ -61,7 +38,7 @@ describe('parseTargets', () => {
 
   it('should include targets with enabled: true', () => {
     const targets: TargetEntry[] = [{ github: { enabled: true, convention: 'xml' } }];
-    const result = parseTargets(targets);
+    const result = parseTargetEntries(targets);
     expect(result).toEqual([{ name: 'github', config: { enabled: true, convention: 'xml' } }]);
   });
 
@@ -71,7 +48,7 @@ describe('parseTargets', () => {
       { claude: { output: 'CLAUDE.md' } },
       { cursor: { enabled: false } },
     ];
-    const result = parseTargets(targets);
+    const result = parseTargetEntries(targets);
     expect(result).toEqual([
       { name: 'github' },
       { name: 'claude', config: { output: 'CLAUDE.md' } },
@@ -80,7 +57,34 @@ describe('parseTargets', () => {
 
   it('should throw on empty target configuration', () => {
     const targets: TargetEntry[] = [{}];
-    expect(() => parseTargets(targets)).toThrow('Empty target configuration');
+    expect(() => parseTargetEntries(targets)).toThrow('Empty target configuration');
+  });
+
+  it('should throw on a malformed target configuration', () => {
+    const targets = [{ github: [] }] as unknown as TargetEntry[];
+
+    expect(() => parseTargetEntries(targets)).toThrow(
+      'Target "github" configuration must be an object'
+    );
+  });
+
+  it('should throw when targets is not an array', () => {
+    expect(() => parseTargetEntries('github')).toThrow('Compilation targets must be an array');
+  });
+
+  it.each([null, '', 42, []])('should throw on malformed target entry %j', (entry) => {
+    expect(() => parseTargetEntries([entry])).toThrow(
+      'Target entries must be non-empty names or configuration objects'
+    );
+  });
+
+  it('should parse every target from a multi-target object', () => {
+    const targets = [{ github: {}, claude: {} }] as unknown as TargetEntry[];
+
+    expect(parseTargetEntries(targets)).toEqual([
+      { name: 'github', config: {} },
+      { name: 'claude', config: {} },
+    ]);
   });
 
   it('should handle mixed string and object targets', () => {
@@ -90,7 +94,7 @@ describe('parseTargets', () => {
       'cursor',
       { antigravity: { enabled: true } },
     ];
-    const result = parseTargets(targets);
+    const result = parseTargetEntries(targets);
     expect(result).toEqual([
       { name: 'github' },
       { name: 'cursor' },

--- a/packages/cli/src/__tests__/config-schema.spec.ts
+++ b/packages/cli/src/__tests__/config-schema.spec.ts
@@ -1,0 +1,61 @@
+import { readFile } from 'node:fs/promises';
+import { Ajv, type ValidateFunction } from 'ajv';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+async function loadConfigSchema(): Promise<Record<string, unknown>> {
+  return JSON.parse(
+    await readFile(new URL('../../../../schema/config.json', import.meta.url), 'utf8')
+  ) as Record<string, unknown>;
+}
+
+describe('config schema target sources', () => {
+  let validate: ValidateFunction;
+
+  beforeAll(async () => {
+    validate = new Ajv({ strict: false }).compile(await loadConfigSchema());
+  });
+
+  it.each([
+    ['top-level targets', { id: 'test', syntax: '1.5.0', targets: ['claude'] }],
+    [
+      'build profile targets',
+      {
+        id: 'test',
+        syntax: '1.5.0',
+        builds: { docs: { targets: ['claude'] } },
+      },
+    ],
+    [
+      'build profile targets with an empty top-level list',
+      {
+        id: 'test',
+        syntax: '1.5.0',
+        targets: [],
+        builds: { docs: { targets: ['claude'] } },
+      },
+    ],
+  ])('accepts %s', (_case, config) => {
+    expect(validate(config), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it.each([
+    ['no target source', { id: 'test', syntax: '1.5.0' }],
+    ['empty top-level targets', { id: 'test', syntax: '1.5.0', targets: [] }],
+    ['targetless build profile', { id: 'test', syntax: '1.5.0', builds: { docs: {} } }],
+    [
+      'empty build profile targets',
+      { id: 'test', syntax: '1.5.0', builds: { docs: { targets: [] } } },
+    ],
+    [
+      'empty build profile targets with top-level fallback',
+      {
+        id: 'test',
+        syntax: '1.5.0',
+        targets: ['claude'],
+        builds: { docs: { targets: [] } },
+      },
+    ],
+  ])('rejects %s', (_case, config) => {
+    expect(validate(config)).toBe(false);
+  });
+});

--- a/packages/cli/src/__tests__/migrate-command.spec.ts
+++ b/packages/cli/src/__tests__/migrate-command.spec.ts
@@ -137,6 +137,140 @@ describe('migrateCommand', () => {
     expect(mockGetSkillWrites).not.toHaveBeenCalled();
   });
 
+  it('accepts builds-only config during static migration', async () => {
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'builds:',
+          '  docs:',
+          '    targets:',
+          '      - claude',
+          '',
+        ].join('\n');
+      }
+      if (path === '.promptscript/project.prs') {
+        return '@meta { id: "preserved" syntax: "1.4.0" }\n';
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(mockImportMultipleFiles).toHaveBeenCalled();
+    expect(mockFs.writeFile).not.toHaveBeenCalledWith(
+      'promptscript.yaml',
+      expect.anything(),
+      'utf-8'
+    );
+  });
+
+  it('updates every effective build profile entry during static migration', async () => {
+    mockFs.existsSync.mockImplementation((path: string) =>
+      ['promptscript.yaml', 'docs/project.prs', 'apps/api/project.prs', 'CLAUDE.md'].includes(path)
+    );
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'builds:',
+          '  docs:',
+          '    entry: docs/project.prs',
+          '    targets:',
+          '      - claude',
+          '  api:',
+          '    entry: apps/api/project.prs',
+          '    targets:',
+          '      - github',
+          '',
+        ].join('\n');
+      }
+      if (path === 'docs/project.prs' || path === 'apps/api/project.prs') {
+        return '@meta { id: "preserved" syntax: "1.4.0" }\n';
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      'docs/project.prs',
+      expect.stringContaining('@use ../.promptscript/migrated/project'),
+      'utf-8'
+    );
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      'apps/api/project.prs',
+      expect.stringContaining('@use ../../.promptscript/migrated/project'),
+      'utf-8'
+    );
+    expect(mockFs.writeFile).not.toHaveBeenCalledWith(
+      '.promptscript/project.prs',
+      expect.anything(),
+      'utf-8'
+    );
+  });
+
+  it('prefixes migration imports for a root-level entry', async () => {
+    mockFs.existsSync.mockImplementation((path: string) =>
+      ['promptscript.yaml', 'project.prs', 'CLAUDE.md'].includes(path)
+    );
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'targets:',
+          '  - claude',
+          'input:',
+          '  entry: project.prs',
+          '',
+        ].join('\n');
+      }
+      if (path === 'project.prs') {
+        return '@meta { id: "preserved" syntax: "1.4.0" }\n';
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      'project.prs',
+      expect.stringContaining('@use ./.promptscript/migrated/project'),
+      'utf-8'
+    );
+  });
+
+  it('accepts empty top-level targets when profiles define targets', async () => {
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'targets: []',
+          'builds:',
+          '  docs:',
+          '    targets:',
+          '      - claude',
+          '',
+        ].join('\n');
+      }
+      if (path === '.promptscript/project.prs') {
+        return '@meta { id: "preserved" syntax: "1.4.0" }\n';
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(mockImportMultipleFiles).toHaveBeenCalled();
+  });
+
   it('creates a stable entry shell when the configured entry is missing', async () => {
     mockFs.existsSync.mockImplementation((path: string) =>
       ['promptscript.yaml', 'CLAUDE.md'].includes(path)
@@ -525,5 +659,84 @@ describe('migrateCommand', () => {
     await migrateCommand({ llm: true }, services);
 
     expect(mockGetSkillWrites).toHaveBeenCalledWith(['claude']);
+  });
+
+  it('uses enabled build profile targets for LLM skill writes', async () => {
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'builds:',
+          '  docs:',
+          '    targets:',
+          '      - claude:',
+          '          enabled: true',
+          '      - cursor:',
+          '          enabled: false',
+          '',
+        ].join('\n');
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ llm: true }, services);
+
+    expect(mockGetSkillWrites).toHaveBeenCalledWith(['claude']);
+  });
+
+  it('lists every effective build profile entry in the LLM prompt', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'builds:',
+          '  docs:',
+          '    entry: docs/project.prs',
+          '    targets:',
+          '      - claude',
+          '  api:',
+          '    entry: apps/api/project.prs',
+          '    targets:',
+          '      - github',
+          '',
+        ].join('\n');
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ llm: true }, services);
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '.promptscript/migration-prompt.md',
+      expect.stringMatching(/- docs\/project\.prs[\s\S]*- apps\/api\/project\.prs/),
+      'utf-8'
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('rejects malformed profile targets even with valid top-level targets', async () => {
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'targets:',
+          '  - claude',
+          'builds:',
+          '  docs:',
+          '    targets: []',
+          '',
+        ].join('\n');
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(process.exitCode).toBe(1);
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/__tests__/migrate-command.spec.ts
+++ b/packages/cli/src/__tests__/migrate-command.spec.ts
@@ -456,6 +456,86 @@ describe('migrateCommand', () => {
     expect(mockFs.writeFile).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['missing target source', 'id: preserved\nsyntax: "1.4.0"\n'],
+    ['scalar target list', 'id: preserved\nsyntax: "1.4.0"\ntargets: claude\n'],
+    ['primitive target entry', 'id: preserved\nsyntax: "1.4.0"\ntargets:\n  - 42\n'],
+    ['empty target object', 'id: preserved\nsyntax: "1.4.0"\ntargets:\n  - {}\n'],
+    ['array build collection', 'id: preserved\nsyntax: "1.4.0"\nbuilds: []\n'],
+    ['scalar build profile', 'id: preserved\nsyntax: "1.4.0"\nbuilds:\n  docs: invalid\n'],
+    [
+      'profile without targets',
+      'id: preserved\nsyntax: "1.4.0"\nbuilds:\n  docs:\n    entry: docs.prs\n',
+    ],
+    [
+      'profile with empty targets',
+      'id: preserved\nsyntax: "1.4.0"\nbuilds:\n  docs:\n    targets: []\n',
+    ],
+  ])('rejects malformed target source: %s', async (_case, configContent) => {
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return configContent;
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(process.exitCode).toBe(1);
+    expect(mockImportMultipleFiles).not.toHaveBeenCalled();
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['input collection', 'id: preserved\nsyntax: "1.4.0"\ntargets:\n  - claude\ninput: []\n'],
+    [
+      'empty input entry',
+      'id: preserved\nsyntax: "1.4.0"\ntargets:\n  - claude\ninput:\n  entry: ""\n',
+    ],
+    [
+      'non-string profile entry',
+      'id: preserved\nsyntax: "1.4.0"\nbuilds:\n  docs:\n    entry: 42\n    targets:\n      - claude\n',
+    ],
+  ])('rejects malformed entry configuration: %s', async (_case, configContent) => {
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return configContent;
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(process.exitCode).toBe(1);
+    expect(mockImportMultipleFiles).not.toHaveBeenCalled();
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('accepts profiles that inherit valid top-level targets', async () => {
+    mockFs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'promptscript.yaml') {
+        return [
+          'id: preserved',
+          'syntax: "1.4.0"',
+          'targets:',
+          '  - claude',
+          'builds:',
+          '  docs: {}',
+          '',
+        ].join('\n');
+      }
+      if (path === '.promptscript/project.prs') {
+        return '@meta { id: "preserved" syntax: "1.4.0" }\n';
+      }
+      return '# Existing instructions';
+    });
+
+    await migrateCommand({ static: true }, services);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(mockImportMultipleFiles).toHaveBeenCalled();
+  });
+
   it('rejects an entry inside the reserved migration output directory', async () => {
     mockFs.readFile.mockImplementation(async (path: string) => {
       if (path === 'promptscript.yaml') {

--- a/packages/cli/src/__tests__/types.spec.ts
+++ b/packages/cli/src/__tests__/types.spec.ts
@@ -101,5 +101,10 @@ describe('types', () => {
       const options: DiffOptions = { target: 'claude' };
       expect(options.target).toBe('claude');
     });
+
+    it('should allow build option', () => {
+      const options: DiffOptions = { build: 'docs' };
+      expect(options.build).toBe('docs');
+    });
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -203,6 +203,7 @@ program
 program
   .command('diff')
   .description('Show diff for compiled output')
+  .option('-b, --build <name>', 'Named build profile from config.builds')
   .option('-t, --target <target>', 'Specific target')
   .option('--format <format>', 'Output format (text, json)', 'text')
   .option('-a, --all', 'Show diff for all targets at once')

--- a/packages/cli/src/commands/__tests__/compile.spec.ts
+++ b/packages/cli/src/commands/__tests__/compile.spec.ts
@@ -1163,6 +1163,18 @@ describe('compile command - createCliLogger warn path', () => {
       );
     });
 
+    it('should reject a scalar target list without a TypeError', async () => {
+      mockLoadConfig.mockResolvedValue({
+        targets: 'claude',
+      });
+
+      await compileCommand({}, mockServices);
+
+      expect(mockCompile).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(mockError).toHaveBeenCalledWith('Compilation targets must be an array');
+    });
+
     it('should report top-level targets that are all disabled', async () => {
       mockLoadConfig.mockResolvedValue({
         targets: [{ claude: { enabled: false } }],
@@ -1541,6 +1553,19 @@ describe('compile command - createCliLogger warn path', () => {
 
     expect(mockCompile).not.toHaveBeenCalled();
     expect(mockWarning).toHaveBeenCalledWith('No named build profiles found in config.builds');
+  });
+
+  it('should reject malformed build collections with --all-builds', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: ['claude'],
+      builds: 'invalid',
+    });
+
+    await compileCommand({ allBuilds: true, cwd: '/repo/promptscript' }, mockServices);
+
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith('config.builds must be an object');
+    expect(process.exitCode).toBe(1);
   });
 
   it('should resolve all builds without cwd or config options', async () => {

--- a/packages/cli/src/commands/__tests__/diff.spec.ts
+++ b/packages/cli/src/commands/__tests__/diff.spec.ts
@@ -257,6 +257,27 @@ describe('diffCommand', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it.each([
+    [
+      'profile targets',
+      { builds: { docs: { targets: [] } }, validation: {} },
+      'config.builds.docs.targets',
+    ],
+    ['inherited targets', { targets: [], builds: { docs: {} }, validation: {} }, 'config.targets'],
+  ])('should identify empty %s for a selected build', async (_case, config, expectedLocation) => {
+    mockLoadConfig.mockResolvedValue(config);
+
+    await diffCommand({ build: 'docs', noPager: true });
+
+    expect(mockFail).toHaveBeenCalledWith('No compilation targets');
+    expect(ConsoleOutput.error).toHaveBeenCalledWith(
+      `No compilation targets configured for build profile "docs". Add an enabled target to ${expectedLocation}.`
+    );
+    expect(mockResolveRegistryPath).not.toHaveBeenCalled();
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
   it('should apply a named build profile entry, output, and targets', async () => {
     mockLoadConfig.mockResolvedValue({
       builds: {

--- a/packages/cli/src/commands/__tests__/diff.spec.ts
+++ b/packages/cli/src/commands/__tests__/diff.spec.ts
@@ -221,6 +221,21 @@ describe('diffCommand', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('should reject a scalar target list without a TypeError', async () => {
+    mockLoadConfig.mockResolvedValue({
+      targets: 'claude',
+      validation: {},
+    });
+
+    await diffCommand({ noPager: true });
+
+    expect(mockFail).toHaveBeenCalledWith('Error');
+    expect(ConsoleOutput.error).toHaveBeenCalledWith('Compilation targets must be an array');
+    expect(mockResolveRegistryPath).not.toHaveBeenCalled();
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
   it('should fail cleanly when only named build profiles define targets', async () => {
     mockLoadConfig.mockResolvedValue({
       builds: { docs: { targets: ['claude'] } },
@@ -236,8 +251,93 @@ describe('diffCommand', () => {
 
     expect(mockFail).toHaveBeenCalledWith('No compilation targets');
     expect(ConsoleOutput.error).toHaveBeenCalledWith(
-      'No compilation targets configured in config.targets. prs diff reads only top-level targets - pass --target <name> or add targets to promptscript.yaml (build profiles found: docs).'
+      'No compilation targets configured in config.targets. Run prs diff --build <name> (available: docs) or add targets to promptscript.yaml.'
     );
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should apply a named build profile entry, output, and targets', async () => {
+    mockLoadConfig.mockResolvedValue({
+      builds: {
+        docs: {
+          entry: '.promptscript/docs.prs',
+          output: 'build/docs',
+          targets: [{ claude: { version: 'full' } }],
+        },
+      },
+      validation: {},
+      includePromptScriptSkill: false,
+    });
+    mockResolveRegistryPath.mockResolvedValue({
+      path: './registry',
+      isRemote: false,
+      source: 'local',
+    });
+    mockExistsSync.mockImplementation((path: string) =>
+      String(path).endsWith('/.promptscript/docs.prs')
+    );
+    mockCompile.mockResolvedValue({
+      success: true,
+      errors: [],
+      warnings: [],
+      outputs: new Map([['CLAUDE.md', { path: 'CLAUDE.md', content: 'profile output' }]]),
+    });
+
+    await diffCommand({ build: 'docs', noPager: true });
+
+    expect(mockCompilerOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formatters: [{ name: 'claude', config: { version: 'full' } }],
+      })
+    );
+    expect(mockCompile).toHaveBeenCalledWith(resolve(process.cwd(), '.promptscript/docs.prs'));
+    expect(mockExistsSync).toHaveBeenCalledWith(resolve(process.cwd(), 'build/docs/CLAUDE.md'));
+  });
+
+  it('should reject an unknown build profile', async () => {
+    mockLoadConfig.mockResolvedValue({
+      builds: { docs: { targets: ['claude'] } },
+      validation: {},
+    });
+
+    await diffCommand({ build: 'missing', noPager: true });
+
+    expect(mockFail).toHaveBeenCalledWith('Error');
+    expect(ConsoleOutput.error).toHaveBeenCalledWith(
+      'Unknown build profile: missing. Available build profiles: docs.'
+    );
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should reject inherited object properties as build profiles', async () => {
+    mockLoadConfig.mockResolvedValue({
+      builds: { docs: { targets: ['claude'] } },
+      validation: {},
+    });
+
+    await diffCommand({ build: 'constructor', noPager: true });
+
+    expect(mockFail).toHaveBeenCalledWith('Error');
+    expect(ConsoleOutput.error).toHaveBeenCalledWith(
+      'Unknown build profile: constructor. Available build profiles: docs.'
+    );
+    expect(mockCompile).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it.each([null, 'invalid', []])('should reject malformed build profile %j', async (profile) => {
+    mockLoadConfig.mockResolvedValue({
+      builds: { docs: profile },
+      targets: ['claude'],
+      validation: {},
+    });
+
+    await diffCommand({ build: 'docs', noPager: true });
+
+    expect(mockFail).toHaveBeenCalledWith('Error');
+    expect(ConsoleOutput.error).toHaveBeenCalledWith('Build profile "docs" must be an object');
     expect(mockCompile).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
   });

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -12,7 +12,9 @@ import {
 import type { CheckOptions } from '../types.js';
 import { findConfigFile, loadEffectiveConfig, CONFIG_FILES } from '../config/loader.js';
 import { createSpinner, ConsoleOutput, isVerbose } from '../output/console.js';
+import { getEffectiveEntryPaths } from '../utils/build-profile.js';
 import { resolveRegistryPath } from '../utils/registry-resolver.js';
+import { isTargetConfig } from '../utils/target-config.js';
 
 /**
  * Check result for a single item.
@@ -23,11 +25,65 @@ interface CheckResult {
   message?: string;
 }
 
+interface TargetEntryAnalysis {
+  names: string[];
+  errors: string[];
+}
+
+function isTargetDisabled(config: unknown): boolean {
+  return (
+    config !== null &&
+    typeof config === 'object' &&
+    !Array.isArray(config) &&
+    (config as { enabled?: unknown }).enabled === false
+  );
+}
+
+function analyzeTargetEntries(entries: readonly unknown[]): TargetEntryAnalysis {
+  const names = new Set<string>();
+  const errors: string[] = [];
+
+  for (const entry of entries) {
+    if (typeof entry === 'string') {
+      if (isKnownTarget(entry)) {
+        names.add(entry);
+      } else {
+        errors.push(`unknown target "${entry}"`);
+      }
+      continue;
+    }
+
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push('target entries must be names or configuration objects');
+      continue;
+    }
+
+    const configuredTargets = Object.entries(entry);
+    if (configuredTargets.length === 0) {
+      errors.push('target entries must not be empty');
+      continue;
+    }
+
+    for (const [name, targetConfig] of configuredTargets) {
+      if (!isKnownTarget(name)) {
+        errors.push(`unknown target "${name}"`);
+      }
+      if (!isTargetConfig(targetConfig)) {
+        errors.push(`target "${name}" configuration must be an object`);
+      } else if (isKnownTarget(name) && !isTargetDisabled(targetConfig)) {
+        names.add(name);
+      }
+    }
+  }
+
+  return { names: [...names], errors };
+}
+
 /**
  * Check configuration and dependencies health.
  * Verifies:
  * - Config file exists and is valid
- * - Entry file exists
+ * - Effective entry files exist
  * - Registry and lockfile are usable
  * - PromptScript syntax, imports, and inheritance resolve
  */
@@ -135,21 +191,73 @@ export async function checkCommand(_options: CheckOptions): Promise<void> {
       });
     }
 
-    // Check 5: Entry file exists
-    const entryPath = resolve(config.input?.entry ?? '.promptscript/project.prs');
-    if (existsSync(entryPath)) {
+    // Check 5: Effective entry files exist
+    const entryIssues: string[] = [];
+    const inputValue: unknown = config.input;
+    if (
+      inputValue !== undefined &&
+      (inputValue === null || typeof inputValue !== 'object' || Array.isArray(inputValue))
+    ) {
+      entryIssues.push('config.input must be an object');
+    } else if (inputValue && typeof inputValue === 'object') {
+      const configuredEntry = (inputValue as { entry?: unknown }).entry;
+      if (
+        configuredEntry !== undefined &&
+        (typeof configuredEntry !== 'string' || configuredEntry.trim().length === 0)
+      ) {
+        entryIssues.push('config.input.entry must be a non-empty string');
+      }
+    }
+
+    const entryBuildsValue: unknown = config.builds;
+    if (
+      entryBuildsValue &&
+      typeof entryBuildsValue === 'object' &&
+      !Array.isArray(entryBuildsValue)
+    ) {
+      for (const [buildName, profile] of Object.entries(
+        entryBuildsValue as Record<string, unknown>
+      )) {
+        if (!profile || typeof profile !== 'object' || Array.isArray(profile)) continue;
+        const configuredEntry = (profile as { entry?: unknown }).entry;
+        if (
+          configuredEntry !== undefined &&
+          (typeof configuredEntry !== 'string' || configuredEntry.trim().length === 0)
+        ) {
+          entryIssues.push(`config.builds.${buildName}.entry must be a non-empty string`);
+        }
+      }
+    }
+    if (entryIssues.length > 0) {
       results.push({
-        name: 'Entry file',
-        status: 'ok',
-        message: config.input?.entry ?? '.promptscript/project.prs',
-      });
-    } else {
-      results.push({
-        name: 'Entry file',
+        name: 'Entry configuration',
         status: 'error',
-        message: `Entry file not found: ${entryPath}`,
+        message: entryIssues.join('; '),
       });
       hasErrors = true;
+    }
+
+    const effectiveEntries = getEffectiveEntryPaths(config);
+    for (const entry of effectiveEntries) {
+      const entryPath = resolve(entry);
+      const name =
+        entry === (config.input?.entry ?? '.promptscript/project.prs')
+          ? 'Entry file'
+          : `Entry file (${entry})`;
+      if (existsSync(entryPath)) {
+        results.push({
+          name,
+          status: 'ok',
+          message: entry,
+        });
+      } else {
+        results.push({
+          name,
+          status: 'error',
+          message: `Entry file not found: ${entryPath}`,
+        });
+        hasErrors = true;
+      }
     }
 
     // Check 6: Local registry path (if configured)
@@ -179,13 +287,76 @@ export async function checkCommand(_options: CheckOptions): Promise<void> {
     }
 
     // Check 7: Targets configured
-    // Builds-only projects keep every target inside config.builds, so the
-    // top-level list being empty is not by itself a misconfiguration.
-    const buildTargets = Object.values(config.builds ?? {}).flatMap(
-      (profile) => profile.targets ?? []
-    );
-    const rootTargets = config.targets ?? [];
-    if (rootTargets.length === 0 && buildTargets.length === 0) {
+    const targetIssues: string[] = [];
+    const targetNames = new Set<string>();
+    const rootTargetValue: unknown = config.targets;
+    const rootTargets: readonly unknown[] = Array.isArray(rootTargetValue) ? rootTargetValue : [];
+    const buildsValue: unknown = config.builds;
+    const builds =
+      buildsValue !== undefined &&
+      buildsValue !== null &&
+      typeof buildsValue === 'object' &&
+      !Array.isArray(buildsValue)
+        ? Object.entries(buildsValue as Record<string, unknown>)
+        : [];
+
+    const appendTargetAnalysis = (location: string, entries: readonly unknown[]): void => {
+      const analysis = analyzeTargetEntries(entries);
+      for (const name of analysis.names) {
+        targetNames.add(name);
+      }
+      targetIssues.push(...analysis.errors.map((error) => `${location}: ${error}`));
+      if (entries.length > 0 && analysis.names.length === 0 && analysis.errors.length === 0) {
+        targetIssues.push(`${location}: no enabled targets`);
+      }
+    };
+
+    if (rootTargetValue !== undefined && !Array.isArray(rootTargetValue)) {
+      targetIssues.push('config.targets must be an array');
+    } else if (rootTargets.length > 0) {
+      appendTargetAnalysis('config.targets', rootTargets);
+    }
+    if (
+      buildsValue !== undefined &&
+      (buildsValue === null || typeof buildsValue !== 'object' || Array.isArray(buildsValue))
+    ) {
+      targetIssues.push('config.builds must be an object');
+    }
+
+    for (const [buildName, profile] of builds) {
+      if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+        targetIssues.push(`config.builds.${buildName} must be an object`);
+        continue;
+      }
+
+      const profileTargetValue: unknown = (profile as { targets?: unknown }).targets;
+      if (profileTargetValue === undefined) {
+        if (rootTargets.length === 0) {
+          targetIssues.push(
+            `config.builds.${buildName}.targets is missing and config.targets is empty`
+          );
+        }
+        continue;
+      }
+      if (!Array.isArray(profileTargetValue)) {
+        targetIssues.push(`config.builds.${buildName}.targets must be an array`);
+        continue;
+      }
+      if (profileTargetValue.length === 0) {
+        targetIssues.push(`config.builds.${buildName}.targets is empty`);
+        continue;
+      }
+      appendTargetAnalysis(`config.builds.${buildName}.targets`, profileTargetValue);
+    }
+
+    if (targetIssues.length > 0) {
+      results.push({
+        name: 'Targets',
+        status: 'error',
+        message: targetIssues.join('; '),
+      });
+      hasErrors = true;
+    } else if (rootTargets.length === 0 && builds.length === 0) {
       results.push({
         name: 'Targets',
         status: 'warning',
@@ -193,42 +364,19 @@ export async function checkCommand(_options: CheckOptions): Promise<void> {
       });
       hasWarnings = true;
     } else {
-      const targetNames = [
-        ...new Set(
-          [...rootTargets, ...buildTargets].flatMap((target) => {
-            if (typeof target === 'string') return [target];
-            if (typeof target !== 'object' || target === null || Array.isArray(target)) {
-              return ['<invalid>'];
-            }
-            return Object.keys(target);
-          })
-        ),
-      ];
-      const invalidTargets = targetNames.filter((target) => !isKnownTarget(target));
-      if (invalidTargets.length > 0 || targetNames.length === 0) {
-        results.push({
-          name: 'Targets',
-          status: 'error',
-          message:
-            invalidTargets.length > 0
-              ? `Unknown target(s): ${invalidTargets.join(', ')}`
-              : 'Target entries must not be empty',
-        });
-        hasErrors = true;
-      } else {
-        results.push({
-          name: 'Targets',
-          status: 'ok',
-          message:
-            rootTargets.length === 0
-              ? `${targetNames.length} target(s) configured in build profiles`
-              : `${targetNames.length} target(s) configured`,
-        });
-      }
+      results.push({
+        name: 'Targets',
+        status: 'ok',
+        message:
+          rootTargets.length === 0
+            ? `${targetNames.size} target(s) configured in build profiles`
+            : `${targetNames.size} target(s) configured`,
+      });
     }
 
     // Check 8: Lockfile, registry, imports, inheritance, and validation
-    if (existsSync(entryPath)) {
+    const existingEntries = effectiveEntries.filter((entry) => existsSync(resolve(entry)));
+    if (existingEntries.length > 0) {
       try {
         const lockfilePath = resolve('promptscript.lock');
         let lockfile: Lockfile | undefined;
@@ -267,28 +415,44 @@ export async function checkCommand(_options: CheckOptions): Promise<void> {
           },
           formatters: [],
         });
-        const result = await compiler.compile(entryPath);
 
-        if (result.errors.length > 0) {
-          results.push({
-            name: 'Project resolution',
-            status: 'error',
-            message: result.errors.map((error) => error.message).join('; '),
-          });
-          hasErrors = true;
-        } else if (result.warnings.length > 0) {
-          results.push({
-            name: 'Project resolution',
-            status: 'warning',
-            message: `${result.warnings.length} validation warning(s)`,
-          });
-          hasWarnings = true;
-        } else {
-          results.push({
-            name: 'Project resolution',
-            status: 'ok',
-            message: 'Syntax, imports, and inheritance are valid',
-          });
+        for (const entry of existingEntries) {
+          const name =
+            entry === (config.input?.entry ?? '.promptscript/project.prs')
+              ? 'Project resolution'
+              : `Project resolution (${entry})`;
+          try {
+            const result = await compiler.compile(resolve(entry));
+
+            if (result.errors.length > 0) {
+              results.push({
+                name,
+                status: 'error',
+                message: result.errors.map((error) => error.message).join('; '),
+              });
+              hasErrors = true;
+            } else if (result.warnings.length > 0) {
+              results.push({
+                name,
+                status: 'warning',
+                message: `${result.warnings.length} validation warning(s)`,
+              });
+              hasWarnings = true;
+            } else {
+              results.push({
+                name,
+                status: 'ok',
+                message: 'Syntax, imports, and inheritance are valid',
+              });
+            }
+          } catch (error) {
+            results.push({
+              name,
+              status: 'error',
+              message: error instanceof Error ? error.message : 'Unknown resolution error',
+            });
+            hasErrors = true;
+          }
         }
       } catch (error) {
         results.push({

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -9,7 +9,6 @@ import type {
   PromptScriptConfig,
   TargetEntry,
   TargetConfig,
-  BuildProfileConfig,
   Lockfile,
 } from '@promptscript/core';
 import { ErrorCode, isValidLockfile, PSError } from '@promptscript/core';
@@ -48,6 +47,8 @@ import {
 import { loadBundledSkillContent } from '../utils/bundled-skill.js';
 import { isPromptScriptOwnedOutput } from '../utils/output-ownership.js';
 import { finalizeOutputPlan } from '../utils/output-plan.js';
+import { getBuildProfile, getBuildProfiles } from '../utils/build-profile.js';
+import { parseTargetEntries } from '../utils/target-config.js';
 
 async function loadCompileLockfile(
   projectRoot: string,
@@ -104,29 +105,6 @@ function createCliLogger(): Logger {
   };
 }
 
-/**
- * Parse target entries into compiler format.
- * Filters out targets with enabled: false.
- */
-function parseTargets(
-  targets: TargetEntry[] | undefined
-): { name: string; config?: TargetConfig }[] {
-  return (targets ?? [])
-    .map((entry) => {
-      if (typeof entry === 'string') {
-        return { name: entry };
-      }
-      // Object format: { github: { convention: 'xml' } }
-      const entries = Object.entries(entry);
-      if (entries.length === 0) {
-        throw new Error('Empty target configuration');
-      }
-      const [name, config] = entries[0] as [string, TargetConfig | undefined];
-      return { name, config };
-    })
-    .filter((target) => target.config?.enabled !== false);
-}
-
 interface EmptyTargetsContext {
   /** Profile passed via --build, also set for each profile of --all-builds */
   buildName: string | undefined;
@@ -164,23 +142,6 @@ function describeEmptyTargets(context: EmptyTargetsContext): string {
   }
 
   return 'No compilation targets configured. Add a "targets" list to promptscript.yaml or run: prs init';
-}
-
-function getBuildProfile(
-  config: PromptScriptConfig,
-  buildName: string | undefined
-): BuildProfileConfig | undefined {
-  if (!buildName) return undefined;
-
-  const profile = config.builds?.[buildName];
-  if (!profile) {
-    const available = Object.keys(config.builds ?? {});
-    const suffix =
-      available.length > 0 ? ` Available build profiles: ${available.join(', ')}.` : '';
-    throw new Error(`Unknown build profile: ${buildName}.${suffix}`);
-  }
-
-  return profile;
 }
 
 function resolveOutputBase(projectRoot: string, output: string | undefined): string {
@@ -710,7 +671,7 @@ async function compileAllBuilds(options: CompileOptions, services: CliServices):
   const configPath = resolveCompileConfigPath(projectRoot, options);
   const config = await loadEffectiveConfig(configPath);
 
-  const buildNames = Object.keys(config.builds ?? {});
+  const buildNames = Object.keys(getBuildProfiles(config));
   if (buildNames.length === 0) {
     ConsoleOutput.warning('No named build profiles found in config.builds');
     return true;
@@ -814,7 +775,7 @@ async function compileCommandWithResult(
     // --format is an alias for --target
     const selectedTarget = options.target ?? options.format;
     const targetEntries = buildProfile?.targets ?? config.targets;
-    const parsedTargets = parseTargets(targetEntries);
+    const parsedTargets = parseTargetEntries(targetEntries);
     let targets: { name: string; config?: TargetConfig }[];
     if (selectedTarget) {
       // Find the matching target entry to preserve configured options

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -2,13 +2,7 @@ import { resolve } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import type { DiffOptions } from '../types.js';
-import {
-  isValidLockfile,
-  type Lockfile,
-  type Logger,
-  type TargetEntry,
-  type TargetConfig,
-} from '@promptscript/core';
+import { isValidLockfile, type Lockfile, type Logger } from '@promptscript/core';
 import type { FormatterOutput } from '@promptscript/compiler';
 import { loadConfig } from '../config/loader.js';
 import { createSpinner, ConsoleOutput, isVerbose, isDebug } from '../output/console.js';
@@ -25,6 +19,8 @@ import {
 import { loadBundledSkillContent } from '../utils/bundled-skill.js';
 import { prepareLegacyFactoryMigration } from '../utils/legacy-factory-hooks.js';
 import { finalizeOutputPlan } from '../utils/output-plan.js';
+import { getBuildProfile } from '../utils/build-profile.js';
+import { parseTargetEntries } from '../utils/target-config.js';
 import chalk from 'chalk';
 import { parse as parseYaml } from 'yaml';
 
@@ -70,28 +66,6 @@ export function createDiffLogger(machineReadable = false): Logger {
       }
     },
   };
-}
-
-/**
- * Parse target entries into compiler format.
- */
-function parseTargets(
-  targets: TargetEntry[] | undefined
-): { name: string; config?: TargetConfig }[] {
-  return (targets ?? [])
-    .map((entry) => {
-      if (typeof entry === 'string') {
-        return { name: entry };
-      }
-      // Object format: { github: { convention: 'xml' } }
-      const entries = Object.entries(entry);
-      if (entries.length === 0) {
-        throw new Error('Empty target configuration');
-      }
-      const [name, config] = entries[0] as [string, TargetConfig | undefined];
-      return { name, config };
-    })
-    .filter((target) => target.config?.enabled !== false);
 }
 
 /**
@@ -197,32 +171,30 @@ export async function diffCommand(options: DiffOptions): Promise<void> {
 
   try {
     const config = await loadConfig();
-    const lockfile = await loadDiffLockfile(projectRoot);
-    const vendorDir = resolve(projectRoot, '.promptscript/vendor');
-
-    if (!isJsonFormat) spinner.text = 'Resolving registry...';
-    const registry = await resolveRegistryPath(config, {
-      vendorDir,
-      lockfile,
-      readOnly: true,
-    });
-
-    if (!isJsonFormat) spinner.text = 'Compiling...';
+    const buildProfile = getBuildProfile(config, options.build);
 
     // --all is the default behavior when no target is specified
-    const parsedTargets = parseTargets(config.targets);
+    const targetEntries = buildProfile?.targets ?? config.targets;
+    const parsedTargets = parseTargetEntries(targetEntries);
     const targets = options.target
       ? [parsedTargets.find((target) => target.name === options.target) ?? { name: options.target }]
       : parsedTargets;
 
     if (targets.length === 0) {
-      // Named build profiles are compile-only, so a builds-only project has
-      // nothing for diff to compare unless a target is passed explicitly.
       const availableBuilds = Object.keys(config.builds ?? {});
-      const message =
-        availableBuilds.length > 0
-          ? `No compilation targets configured in config.targets. prs diff reads only top-level targets - pass --target <name> or add targets to promptscript.yaml (build profiles found: ${availableBuilds.join(', ')}).`
-          : 'No compilation targets configured. Add a "targets" list to promptscript.yaml or run: prs init';
+      let message: string;
+      if (options.build) {
+        const location =
+          buildProfile?.targets !== undefined
+            ? `config.builds.${options.build}.targets`
+            : 'config.targets';
+        message = `No compilation targets configured for build profile "${options.build}". Add an enabled target to ${location}.`;
+      } else if (availableBuilds.length > 0) {
+        message = `No compilation targets configured in config.targets. Run prs diff --build <name> (available: ${availableBuilds.join(', ')}) or add targets to promptscript.yaml.`;
+      } else {
+        message =
+          'No compilation targets configured. Add a "targets" list to promptscript.yaml or run: prs init';
+      }
       if (isJsonFormat) {
         console.log(
           JSON.stringify(
@@ -243,11 +215,24 @@ export async function diffCommand(options: DiffOptions): Promise<void> {
       process.exitCode = 1;
       return;
     }
+
+    const lockfile = await loadDiffLockfile(projectRoot);
+    const vendorDir = resolve(projectRoot, '.promptscript/vendor');
+
+    if (!isJsonFormat) spinner.text = 'Resolving registry...';
+    const registry = await resolveRegistryPath(config, {
+      vendorDir,
+      lockfile,
+      readOnly: true,
+    });
+
+    if (!isJsonFormat) spinner.text = 'Compiling...';
+
     const logger = createDiffLogger(isJsonFormat);
     const prettierOptions = await resolvePrettierOptions(config, projectRoot);
     const skillContent =
       config.includePromptScriptSkill === false ? undefined : await loadBundledSkillContent(logger);
-    const outputRoot = resolve(projectRoot, config.output?.baseDir ?? '.');
+    const outputRoot = resolve(projectRoot, buildProfile?.output ?? config.output?.baseDir ?? '.');
 
     const compiler = new Compiler({
       resolver: {
@@ -273,7 +258,10 @@ export async function diffCommand(options: DiffOptions): Promise<void> {
       skillContent,
     });
 
-    const entryPath = resolve(projectRoot, config.input?.entry ?? './.promptscript/project.prs');
+    const entryPath = resolve(
+      projectRoot,
+      buildProfile?.entry ?? config.input?.entry ?? './.promptscript/project.prs'
+    );
 
     if (!existsSync(entryPath)) {
       const message = `File not found: ${entryPath}`;
@@ -293,7 +281,9 @@ export async function diffCommand(options: DiffOptions): Promise<void> {
       } else {
         spinner.fail('Entry file not found');
         ConsoleOutput.error(message);
-        ConsoleOutput.muted('Run: prs init');
+        ConsoleOutput.muted(
+          options.build ? `Check config.builds.${options.build}.entry` : 'Run: prs init'
+        );
       }
       process.exitCode = 1;
       return;

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -25,6 +25,8 @@ import {
 } from '../utils/write-plan.js';
 import { getSkillWrites, initCommand, selectMigrationStrategy } from './init.js';
 import { CONFIG_FILES, interpolateEnvVars } from '../config/loader.js';
+import { getEffectiveEntryPaths } from '../utils/build-profile.js';
+import { isTargetConfig } from '../utils/target-config.js';
 
 export async function migrateCommand(
   options: MigrateOptions,
@@ -74,12 +76,14 @@ async function runMigrateCommand(options: MigrateOptions, services: CliServices)
     if (options.targets) {
       throw new Error('--targets can only be used when migration initializes a project');
     }
-    const targets = extractTargetNames(config.targets);
     const strategy = options.llm
       ? 'llm'
       : options.static
         ? 'static'
         : await selectMigrationStrategy(services);
+    const entryPaths = getMigrationEntryPaths(config);
+    const targets =
+      strategy === 'llm' ? extractTargetNames(getConfiguredTargetEntries(config)) : [];
 
     let selectedCandidates = candidates;
     if (strategy === 'static' && !options.static && !options.files) {
@@ -100,12 +104,8 @@ async function runMigrateCommand(options: MigrateOptions, services: CliServices)
 
     const writes =
       strategy === 'static'
-        ? await createStaticMigrationWrites(selectedCandidates, config, services)
-        : createLlmMigrationWrites(
-            selectedCandidates,
-            targets,
-            validateProjectPath(config.input?.entry ?? '.promptscript/project.prs')
-          );
+        ? await createStaticMigrationWrites(selectedCandidates, config, entryPaths, services)
+        : createLlmMigrationWrites(selectedCandidates, targets, entryPaths);
 
     if (!isGitRepo(services)) {
       ConsoleOutput.warn('Not a git repository. Changes are not version-controlled.');
@@ -138,11 +138,11 @@ async function runMigrateCommand(options: MigrateOptions, services: CliServices)
     const spinner = createSpinner(
       options.dryRun ? 'Planning migration...' : 'Applying migration...'
     ).start();
-    const entryPath = validateProjectPath(config.input?.entry ?? '.promptscript/project.prs');
+    const overwritableEntries = new Set(entryPaths);
     const result = await executeWritePlan(writes, services, {
       dryRun: options.dryRun,
       force: options.force === true || shouldBackup,
-      canOverwrite: (path) => strategy === 'static' && path === entryPath,
+      canOverwrite: (path) => strategy === 'static' && overwritableEntries.has(path),
     });
 
     if (options.dryRun) {
@@ -225,7 +225,7 @@ function selectRequestedCandidates(
 async function readProjectConfig(
   configPath: string,
   services: CliServices
-): Promise<PromptScriptConfig & { targets: TargetEntry[] }> {
+): Promise<PromptScriptConfig> {
   const content = interpolateEnvVars(await services.fs.readFile(configPath, 'utf-8'));
   const config = parseYaml(content) as PromptScriptConfig | null;
   if (
@@ -235,20 +235,113 @@ async function readProjectConfig(
     config.id.trim().length === 0 ||
     typeof config.syntax !== 'string' ||
     config.syntax.trim().length === 0 ||
-    !Array.isArray(config.targets) ||
-    config.targets.length === 0 ||
-    !config.targets.every(
-      (target) =>
-        (typeof target === 'string' && target.length > 0) ||
-        (target !== null &&
-          typeof target === 'object' &&
-          !Array.isArray(target) &&
-          Object.keys(target).length > 0)
-    )
+    !hasValidTargetSource(config)
   ) {
-    throw new Error(`${configPath} must contain id, syntax, and targets before migration`);
+    throw new Error(
+      `${configPath} must contain id, syntax, and either non-empty targets or build profiles with non-empty targets before migration`
+    );
   }
-  return config as PromptScriptConfig & { targets: TargetEntry[] };
+  return config;
+}
+
+function isValidTargetEntry(target: unknown): target is TargetEntry {
+  if (typeof target === 'string') {
+    return target.trim().length > 0;
+  }
+  if (target === null || typeof target !== 'object' || Array.isArray(target)) {
+    return false;
+  }
+
+  const entries = Object.entries(target);
+  if (entries.length === 0) {
+    return false;
+  }
+  return entries.every(
+    ([name, targetConfig]) => name.trim().length > 0 && isTargetConfig(targetConfig)
+  );
+}
+
+function isValidTargetList(targets: unknown): targets is TargetEntry[] {
+  return Array.isArray(targets) && targets.length > 0 && targets.every(isValidTargetEntry);
+}
+
+function hasValidTargetSource(config: PromptScriptConfig): boolean {
+  const rootTargets: unknown = config.targets;
+  const hasRootTargets = isValidTargetList(rootTargets);
+  if (
+    rootTargets !== undefined &&
+    (!Array.isArray(rootTargets) || (rootTargets.length > 0 && !hasRootTargets))
+  ) {
+    return false;
+  }
+
+  const builds: unknown = config.builds;
+  if (builds === undefined) {
+    return hasRootTargets;
+  }
+  if (builds === null || typeof builds !== 'object' || Array.isArray(builds)) {
+    return false;
+  }
+
+  const profiles = Object.values(builds as Record<string, unknown>);
+  let hasProfileTargets = false;
+  for (const profile of profiles) {
+    if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+      return false;
+    }
+    const targets = (profile as { targets?: unknown }).targets;
+    if (targets === undefined) {
+      if (!hasRootTargets) {
+        return false;
+      }
+      continue;
+    }
+    if (!isValidTargetList(targets)) {
+      return false;
+    }
+    hasProfileTargets = true;
+  }
+  return hasRootTargets || hasProfileTargets;
+}
+
+function getConfiguredTargetEntries(config: PromptScriptConfig): TargetEntry[] {
+  const entries: TargetEntry[] = Array.isArray(config.targets) ? [...config.targets] : [];
+  for (const profile of Object.values(config.builds ?? {})) {
+    if (profile && typeof profile === 'object' && Array.isArray(profile.targets)) {
+      entries.push(...profile.targets);
+    }
+  }
+  return entries;
+}
+
+function getMigrationEntryPaths(config: PromptScriptConfig): string[] {
+  const input: unknown = config.input;
+  if (
+    input !== undefined &&
+    (input === null || typeof input !== 'object' || Array.isArray(input))
+  ) {
+    throw new Error('config.input must be an object');
+  }
+  const configuredEntry =
+    input && typeof input === 'object' ? (input as { entry?: unknown }).entry : undefined;
+  if (
+    configuredEntry !== undefined &&
+    (typeof configuredEntry !== 'string' || configuredEntry.trim().length === 0)
+  ) {
+    throw new Error('config.input.entry must be a non-empty string');
+  }
+
+  for (const [buildName, profile] of Object.entries(config.builds ?? {})) {
+    const profileEntry: unknown = profile.entry;
+    if (
+      profileEntry !== undefined &&
+      (typeof profileEntry !== 'string' || profileEntry.trim().length === 0)
+    ) {
+      throw new Error(`config.builds.${buildName}.entry must be a non-empty string`);
+    }
+  }
+
+  return getEffectiveEntryPaths(config).map(validateProjectPath);
 }
 
 function extractTargetNames(targets: TargetEntry[]): AIToolTarget[] {
@@ -270,6 +363,7 @@ function extractTargetNames(targets: TargetEntry[]): AIToolTarget[] {
 async function createStaticMigrationWrites(
   candidates: MigrationCandidate[],
   config: PromptScriptConfig,
+  entryPaths: string[],
   services: CliServices
 ): Promise<PlannedWrite[]> {
   const result = await importMultipleFiles(
@@ -288,9 +382,8 @@ async function createStaticMigrationWrites(
     throw new Error(`Not all selected instruction files could be imported.${details}`);
   }
 
-  const entryPath = validateProjectPath(config.input?.entry ?? '.promptscript/project.prs');
-  if (entryPath.startsWith('.promptscript/migrated/')) {
-    throw new Error('Project entry cannot be inside the reserved migration output directory');
+  if (entryPaths.some((entryPath) => entryPath.startsWith('.promptscript/migrated/'))) {
+    throw new Error('Project entries cannot be inside the reserved migration output directory');
   }
   const writes: PlannedWrite[] = [];
   let importedProject: string | undefined;
@@ -315,31 +408,34 @@ async function createStaticMigrationWrites(
 
   const migratedProjectPath = '.promptscript/migrated/project.prs';
   writes.push({ path: migratedProjectPath, content: markMigrationOutput(importedProject) });
-  const useLine = `@use ${toUsePath(entryPath, migratedProjectPath)}`;
 
-  if (services.fs.existsSync(entryPath)) {
-    const existing = await services.fs.readFile(entryPath, 'utf-8');
-    const hasUseLine = existing.split(/\r?\n/).some((line) => line.trim() === useLine);
-    if (!hasUseLine) {
+  for (const entryPath of entryPaths) {
+    const useLine = `@use ${toUsePath(entryPath, migratedProjectPath)}`;
+    if (services.fs.existsSync(entryPath)) {
+      const existing = await services.fs.readFile(entryPath, 'utf-8');
+      const hasUseLine = existing.split(/\r?\n/).some((line) => line.trim() === useLine);
+      if (hasUseLine) {
+        continue;
+      }
       writes.push({
         path: entryPath,
         content: `${existing.trimEnd()}\n\n${useLine}\n`,
       });
+    } else {
+      writes.push({
+        path: entryPath,
+        content: [
+          '# promptscript-generated: migration',
+          '@meta {',
+          `  id: ${JSON.stringify(config.id)}`,
+          `  syntax: ${JSON.stringify(config.syntax)}`,
+          '}',
+          '',
+          useLine,
+          '',
+        ].join('\n'),
+      });
     }
-  } else {
-    writes.push({
-      path: entryPath,
-      content: [
-        '# promptscript-generated: migration',
-        '@meta {',
-        `  id: ${JSON.stringify(config.id)}`,
-        `  syntax: ${JSON.stringify(config.syntax)}`,
-        '}',
-        '',
-        useLine,
-        '',
-      ].join('\n'),
-    });
   }
 
   return deduplicateWrites(writes);
@@ -348,7 +444,7 @@ async function createStaticMigrationWrites(
 function createLlmMigrationWrites(
   candidates: MigrationCandidate[],
   targets: AIToolTarget[],
-  entryPath: string
+  entryPaths: string[]
 ): PlannedWrite[] {
   const prompt = generateMigrationPrompt(
     candidates.map((candidate) => ({
@@ -358,7 +454,7 @@ function createLlmMigrationWrites(
     })),
     {
       outputDirectory: '.promptscript/migrated',
-      existingEntry: entryPath,
+      existingEntries: entryPaths,
     }
   );
 
@@ -378,7 +474,7 @@ function markMigrationOutput(content: string): string {
 function toUsePath(entryPath: string, targetPath: string): string {
   const withoutExtension = targetPath.replace(/\.prs$/, '');
   const path = relative(dirname(entryPath), withoutExtension).replace(/\\/g, '/');
-  return path.startsWith('.') ? path : `./${path}`;
+  return path.startsWith('./') || path.startsWith('../') ? path : `./${path}`;
 }
 
 function validateProjectPath(path: string): string {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -128,6 +128,8 @@ export interface PullOptions {
  * Options for the diff command.
  */
 export interface DiffOptions {
+  /** Named build profile from config.builds */
+  build?: string;
   /** Specific target to diff */
   target?: string;
   /** Output format */

--- a/packages/cli/src/utils/__tests__/migration-prompt.spec.ts
+++ b/packages/cli/src/utils/__tests__/migration-prompt.spec.ts
@@ -47,11 +47,13 @@ describe('generateMigrationPrompt', () => {
   it('protects existing projects and isolates migrated output', () => {
     const prompt = generateMigrationPrompt(candidates, {
       outputDirectory: '.promptscript/migrated',
-      existingEntry: '.promptscript/project.prs',
+      existingEntries: ['.promptscript/project.prs', 'docs/project.prs'],
     });
 
     expect(prompt).toContain('Do not modify promptscript.yaml');
     expect(prompt).toContain('.promptscript/migrated/');
-    expect(prompt).toContain('Add one @use directive to .promptscript/project.prs');
+    expect(prompt).toContain('Add one @use directive to each configured entry file');
+    expect(prompt).toContain('- .promptscript/project.prs');
+    expect(prompt).toContain('- docs/project.prs');
   });
 });

--- a/packages/cli/src/utils/build-profile.ts
+++ b/packages/cli/src/utils/build-profile.ts
@@ -1,0 +1,70 @@
+import type { BuildProfileConfig, PromptScriptConfig } from '@promptscript/core';
+
+function isBuildProfile(value: unknown): value is BuildProfileConfig {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function getBuildProfiles(config: PromptScriptConfig): Record<string, BuildProfileConfig> {
+  const builds: unknown = config.builds;
+  if (builds === undefined) {
+    return {};
+  }
+  if (builds === null || typeof builds !== 'object' || Array.isArray(builds)) {
+    throw new Error('config.builds must be an object');
+  }
+
+  const profiles = Object.create(null) as Record<string, BuildProfileConfig>;
+  for (const [name, profile] of Object.entries(builds as Record<string, unknown>)) {
+    if (!isBuildProfile(profile)) {
+      throw new Error(`Build profile "${name}" must be an object`);
+    }
+    profiles[name] = profile;
+  }
+  return profiles;
+}
+
+export function getBuildProfile(
+  config: PromptScriptConfig,
+  buildName: string | undefined
+): BuildProfileConfig | undefined {
+  if (buildName === undefined) return undefined;
+
+  const builds = getBuildProfiles(config);
+  if (!Object.hasOwn(builds, buildName)) {
+    const available = Object.keys(builds);
+    const suffix =
+      available.length > 0 ? ` Available build profiles: ${available.join(', ')}.` : '';
+    throw new Error(`Unknown build profile: ${buildName}.${suffix}`);
+  }
+
+  return builds[buildName]!;
+}
+
+export function getEffectiveEntryPaths(config: PromptScriptConfig): string[] {
+  const configuredDefaultEntry = config.input?.entry;
+  const defaultEntry =
+    typeof configuredDefaultEntry === 'string' && configuredDefaultEntry.trim().length > 0
+      ? configuredDefaultEntry
+      : '.promptscript/project.prs';
+  const entries = new Set<string>();
+
+  if ((config.targets?.length ?? 0) > 0) {
+    entries.add(defaultEntry);
+  }
+
+  for (const profile of Object.values(config.builds ?? {})) {
+    if (profile && typeof profile === 'object' && !Array.isArray(profile)) {
+      if (profile.entry === undefined) {
+        entries.add(defaultEntry);
+      } else if (typeof profile.entry === 'string' && profile.entry.trim().length > 0) {
+        entries.add(profile.entry);
+      }
+    }
+  }
+
+  if (entries.size === 0) {
+    entries.add(defaultEntry);
+  }
+
+  return [...entries];
+}

--- a/packages/cli/src/utils/migration-prompt.ts
+++ b/packages/cli/src/utils/migration-prompt.ts
@@ -6,7 +6,7 @@ export interface MigrationPromptInput {
 
 export interface MigrationPromptOptions {
   outputDirectory?: string;
-  existingEntry?: string;
+  existingEntries?: string[];
 }
 
 export function generateMigrationPrompt(
@@ -15,9 +15,11 @@ export function generateMigrationPrompt(
 ): string {
   const fileList = candidates.map((c) => `- ${c.path} (${c.sizeHuman}, ${c.toolName})`).join('\n');
   const outputDirectory = options.outputDirectory ?? '.promptscript';
-  const existingProjectInstructions = options.existingEntry
-    ? `\nDo not modify promptscript.yaml or the original instruction files. Add one @use directive to ${options.existingEntry} that composes the migrated project.\n`
-    : '';
+  const existingEntries = options.existingEntries ?? [];
+  const existingProjectInstructions =
+    existingEntries.length > 0
+      ? `\nDo not modify promptscript.yaml or the original instruction files. Add one @use directive to each configured entry file that composes the migrated project:\n${existingEntries.map((entry) => `- ${entry}`).join('\n')}\n`
+      : '';
 
   return `Migrate my existing AI instructions to PromptScript.
 

--- a/packages/cli/src/utils/target-config.ts
+++ b/packages/cli/src/utils/target-config.ts
@@ -1,0 +1,42 @@
+import type { TargetConfig } from '@promptscript/core';
+
+export interface ParsedTarget {
+  name: string;
+  config?: TargetConfig;
+}
+
+export function isTargetConfig(value: unknown): value is TargetConfig {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function parseTargetEntries(targets: unknown): ParsedTarget[] {
+  if (!Array.isArray(targets)) {
+    if (targets === undefined) {
+      return [];
+    }
+    throw new Error('Compilation targets must be an array');
+  }
+
+  return targets
+    .flatMap<ParsedTarget>((entry): ParsedTarget[] => {
+      if (typeof entry === 'string' && entry.trim().length > 0) {
+        return [{ name: entry }];
+      }
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error('Target entries must be non-empty names or configuration objects');
+      }
+
+      const entries = Object.entries(entry);
+      if (entries.length === 0) {
+        throw new Error('Empty target configuration');
+      }
+
+      return entries.map(([name, config]) => {
+        if (!isTargetConfig(config)) {
+          throw new Error(`Target "${name}" configuration must be an object`);
+        }
+        return { name, config };
+      });
+    })
+    .filter((target) => target.config?.enabled !== false);
+}

--- a/schema/config.json
+++ b/schema/config.json
@@ -1035,5 +1035,54 @@
       "additionalProperties": false,
       "description": "Registry-allowlist policy: restricts which registries can provide extensions."
     }
-  }
+  },
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "required": [
+            "targets"
+          ],
+          "properties": {
+            "targets": {
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "required": [
+            "builds"
+          ],
+          "properties": {
+            "builds": {
+              "minProperties": 1,
+              "additionalProperties": {
+                "required": [
+                  "targets"
+                ],
+                "properties": {
+                  "targets": {
+                    "minItems": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "properties": {
+        "builds": {
+          "additionalProperties": {
+            "properties": {
+              "targets": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/scripts/generate-schema.mts
+++ b/scripts/generate-schema.mts
@@ -38,6 +38,41 @@ async function main(): Promise<void> {
 
   const generator = createGenerator(config);
   const schema = generator.createSchema(config.type);
+  const targetSourceConstraint = {
+    anyOf: [
+      {
+        required: ['targets'],
+        properties: {
+          targets: { minItems: 1 },
+        },
+      },
+      {
+        required: ['builds'],
+        properties: {
+          builds: {
+            minProperties: 1,
+            additionalProperties: {
+              required: ['targets'],
+              properties: {
+                targets: { minItems: 1 },
+              },
+            },
+          },
+        },
+      },
+    ],
+  };
+  const explicitProfileTargetsConstraint = {
+    properties: {
+      builds: {
+        additionalProperties: {
+          properties: {
+            targets: { minItems: 1 },
+          },
+        },
+      },
+    },
+  };
 
   // Add schema metadata
   const enrichedSchema = {
@@ -46,6 +81,7 @@ async function main(): Promise<void> {
     title: 'PromptScript Configuration',
     description: 'Configuration schema for promptscript.yaml files',
     ...schema,
+    allOf: [...(schema.allOf ?? []), targetSourceConstraint, explicitProfileTargetsConstraint],
   };
 
   // Ensure output directory exists


### PR DESCRIPTION
## Description

Follow-up fixes identified after merging #441:

- add `prs diff --build <name>` with profile entry, output, and targets
- validate every effective build-profile entry in `prs check`
- migrate every effective entry and include all profile targets in LLM migration
- reject malformed target and build shapes with actionable errors
- align generated schema with runtime target-source requirements
- share build-profile and target parsing helpers
- update documentation and regression coverage

## Related Issue

Follow-up to #440 and #441.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Local verification passed all eight required checks, including 1,797 tests.
