### PR TITLE
fix(resolver): improve skill metadata diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ temp/
 /typings
 .claude/plans
 .claude/*.local.*
+.worktrees/
 
 # Claude-mem context files (subdirectory CLAUDE.md, not root)
 **/CLAUDE.md

--- a/docs/guides/building-skills.md
+++ b/docs/guides/building-skills.md
@@ -5,6 +5,10 @@ description: Create custom skills for PromptScript - from simple instructions to
 
 # Building Skills
 
+`metadata` values must be YAML strings. Quote numeric and boolean values, for example
+`version: "16"` instead of `version: 16`. Invalid values produce a diagnostic with the
+`SKILL.md` path and line.
+
 Skills are reusable units of AI instructions. Each skill is a directory with a `SKILL.md` file and optional resource files. PromptScript compiles them to all your AI coding agents.
 
 ## Minimal Skill

--- a/packages/cli/src/commands/__tests__/skills.spec.ts
+++ b/packages/cli/src/commands/__tests__/skills.spec.ts
@@ -3877,6 +3877,38 @@ describe('skillsUpdateCommand frontmatter re-validation', () => {
     );
   });
 
+  it('reports parser diagnostics with the remote skill path', async () => {
+    arrangeLock();
+    mockValidateSkillFrontmatter.mockReturnValue({
+      valid: false,
+      issues: [
+        {
+          severity: 'error',
+          code: 'SK000',
+          message: 'invalid metadata',
+          location: {
+            file: '/tmp/prs-skill-validate-xyz/skills/foo/SKILL.md',
+            line: 5,
+            column: 12,
+          },
+        },
+      ],
+    });
+    mockFormatSkillValidationIssues.mockReturnValue('✗ SK000: invalid metadata');
+
+    await skillsUpdateCommand(undefined, {});
+
+    expect(mockFormatSkillValidationIssues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        location: {
+          file: 'github.com/org/repo/skills/foo/SKILL.md',
+          line: 5,
+          column: 12,
+        },
+      }),
+    ]);
+  });
+
   it('updates shared-repository skills atomically', async () => {
     const lockContent = JSON.stringify({
       version: 1,

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -254,6 +254,11 @@ function extractSkillFilePath(source: string): string {
   return subPath.toLowerCase().endsWith('.md') ? subPath : `${subPath}/SKILL.md`;
 }
 
+function getRemoteSkillDiagnosticPath(source: string): string {
+  const sourcePath = parseSkillSource(source).path.replace(/^https?:\/\//i, '');
+  return sourcePath.toLowerCase().endsWith('.md') ? sourcePath : `${sourcePath}/SKILL.md`;
+}
+
 /**
  * Derive the on-disk skill folder name from a source path. Skills are written
  * to `<format-dir>/skills/<name>/SKILL.md` where `<name>` is the basename of
@@ -377,7 +382,11 @@ async function fetchAndValidateRemoteSkill(
       filePath,
       existingNames: options.existingNames,
     });
-    return { content, integrity, valid: result.valid, issues: result.issues };
+    const diagnosticPath = getRemoteSkillDiagnosticPath(source);
+    const issues = result.issues.map((issue) =>
+      issue.location ? { ...issue, location: { ...issue.location, file: diagnosticPath } } : issue
+    );
+    return { content, integrity, valid: result.valid, issues };
   } finally {
     await rm(tmp, { recursive: true, force: true }).catch(() => {
       // best-effort cleanup

--- a/packages/resolver/src/__tests__/resolver.spec.ts
+++ b/packages/resolver/src/__tests__/resolver.spec.ts
@@ -454,5 +454,47 @@ describe('Resolver', () => {
         )
       ).toBe(true);
     });
+
+    it('should preserve imported skill frontmatter locations', async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'promptscript-resolver-frontmatter-'));
+      const entryPath = join(directory, 'project.prs');
+      const skillDirectory = join(directory, 'remote-skill');
+      const skillPath = join(skillDirectory, 'SKILL.md');
+      const skillContent = [
+        '---',
+        'name: remote-skill',
+        'description: Use when testing imported metadata.',
+        'metadata:',
+        '  version: 16',
+        '---',
+        'Body',
+      ].join('\n');
+      mkdirSync(skillDirectory, { recursive: true });
+      writeFileSync(entryPath, '@use ./remote-skill\n');
+      writeFileSync(skillPath, skillContent);
+
+      try {
+        const localResolver = new Resolver({
+          registryPath: directory,
+          localPath: directory,
+          cache: false,
+        });
+        const result = await localResolver.resolve(entryPath);
+
+        expect(result.errors).toContainEqual(
+          expect.objectContaining({
+            message: expect.stringContaining('Failed to resolve import'),
+            location: {
+              file: skillPath,
+              line: 5,
+              column: 12,
+              offset: skillContent.indexOf('16'),
+            },
+          })
+        );
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/resolver/src/__tests__/skill-frontmatter-yaml.spec.ts
+++ b/packages/resolver/src/__tests__/skill-frontmatter-yaml.spec.ts
@@ -462,6 +462,35 @@ describe('YAML skill frontmatter', () => {
     expect(error).toMatchObject({ message: expect.stringMatching(/Unsafe path in references/) });
   });
 
+  it('reports metadata value errors at the offending YAML scalar', () => {
+    const content = [
+      '---',
+      'name: example',
+      'description: Example skill',
+      'metadata:',
+      '  version: 16',
+      '---',
+      'Body',
+    ].join('\n');
+
+    expect(() => parseSkillMd(content, '/tmp/skills/example/SKILL.md')).toThrow(
+      /quote scalar values/
+    );
+
+    try {
+      parseSkillMd(content, '/tmp/skills/example/SKILL.md');
+    } catch (error: unknown) {
+      expect(error).toMatchObject({
+        location: {
+          file: '/tmp/skills/example/SKILL.md',
+          line: 5,
+          column: 12,
+          offset: content.indexOf('16'),
+        },
+      });
+    }
+  });
+
   it('propagates parsed metadata through native auto-discovery', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'skill-yaml-discovery-'));
     temporaryDirectories.push(directory);

--- a/packages/resolver/src/__tests__/skill-validation.spec.ts
+++ b/packages/resolver/src/__tests__/skill-validation.spec.ts
@@ -334,6 +334,33 @@ describe('validateSkillFrontmatter', () => {
       expect(result.valid).toBe(false);
     });
   });
+
+  it('preserves frontmatter parser locations in SK000 issues', () => {
+    const filePath = '/tmp/skills/example/SKILL.md';
+    const content = [
+      '---',
+      'name: example',
+      'description: Example skill',
+      'metadata:',
+      '  version: 16',
+      '---',
+      'Body',
+    ].join('\n');
+
+    const result = validateSkillFrontmatter(content, { filePath });
+
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'SK000',
+        location: {
+          file: filePath,
+          line: 5,
+          column: 12,
+          offset: content.indexOf('16'),
+        },
+      })
+    );
+  });
 });
 
 describe('formatSkillValidationIssues', () => {
@@ -351,5 +378,18 @@ describe('formatSkillValidationIssues', () => {
       { severity: 'error', code: 'SK001', message: 'no frontmatter' },
     ]);
     expect(formatted).toBe('  ✗ SK001: no frontmatter');
+  });
+
+  it('formats source locations when provided', () => {
+    const formatted = formatSkillValidationIssues([
+      {
+        severity: 'error',
+        code: 'SK000',
+        message: 'invalid metadata',
+        location: { file: 'github.com/org/repo/SKILL.md', line: 27, column: 12 },
+      },
+    ]);
+
+    expect(formatted).toContain('at github.com/org/repo/SKILL.md:27:12');
   });
 });

--- a/packages/resolver/src/resolver.ts
+++ b/packages/resolver/src/resolver.ts
@@ -1315,7 +1315,8 @@ export class Resolver {
       }
       errors.push(
         new ResolveError(
-          `Failed to resolve parent: ${err instanceof Error ? err.message : String(err)}`
+          `Failed to resolve parent: ${err instanceof Error ? err.message : String(err)}`,
+          err instanceof ResolveError ? err.location : undefined
         )
       );
     }
@@ -1447,7 +1448,8 @@ export class Resolver {
         }
         errors.push(
           new ResolveError(
-            `Failed to resolve import: ${err instanceof Error ? err.message : String(err)}`
+            `Failed to resolve import: ${err instanceof Error ? err.message : String(err)}`,
+            err instanceof ResolveError ? err.location : undefined
           )
         );
       }

--- a/packages/resolver/src/skill-validation.ts
+++ b/packages/resolver/src/skill-validation.ts
@@ -1,5 +1,7 @@
 import { basename, dirname, join } from 'path';
 import { existsSync } from 'fs';
+import { ResolveError } from '@promptscript/core';
+import type { SourceLocation } from '@promptscript/core';
 import { extractSkillFrontmatter, parseSkillMd, type ParsedSkillMd } from './skills.js';
 
 /**
@@ -19,6 +21,8 @@ export interface SkillValidationIssue {
   message: string;
   /** Frontmatter field the issue relates to (when applicable) */
   field?: string;
+  /** Source location for parser and frontmatter diagnostics, when available */
+  location?: SourceLocation;
 }
 
 /**
@@ -76,11 +80,15 @@ export function validateSkillFrontmatter(
   try {
     parsed = parseSkillMd(rawContent, options.filePath);
   } catch (error: unknown) {
-    issues.push({
+    const issue: SkillValidationIssue = {
       severity: 'error',
       code: 'SK000',
       message: error instanceof Error ? error.message : String(error),
-    });
+    };
+    if (error instanceof ResolveError && error.location) {
+      issue.location = error.location;
+    }
+    issues.push(issue);
     return { valid: false, issues };
   }
 
@@ -316,7 +324,10 @@ export function formatSkillValidationIssues(issues: readonly SkillValidationIssu
     .map((i) => {
       const tag = i.severity === 'error' ? '✗' : '⚠';
       const field = i.field ? ` [${i.field}]` : '';
-      return `  ${tag} ${i.code}${field}: ${i.message}`;
+      const location = i.location
+        ? ` (at ${i.location.file}:${i.location.line}:${i.location.column})`
+        : '';
+      return `  ${tag} ${i.code}${field}: ${i.message}${location}`;
     })
     .join('\n');
 }

--- a/packages/resolver/src/skills.ts
+++ b/packages/resolver/src/skills.ts
@@ -78,6 +78,7 @@ interface ParsedYamlFrontmatter {
   fields: Record<string, unknown>;
   fieldLocations: ReadonlyMap<string, SourceLocation>;
   fieldItemLocations: ReadonlyMap<string, readonly SourceLocation[]>;
+  fieldValueLocations: ReadonlyMap<string, ReadonlyMap<string, SourceLocation>>;
 }
 
 const MAX_FRONTMATTER_BYTES = 256 * 1024;
@@ -147,7 +148,8 @@ export function parseSkillMd(content: string, sourceFile = '<skill>'): ParsedSki
       sourceFile,
       frontmatter.location,
       yamlFrontmatter.fieldLocations,
-      yamlFrontmatter.fieldItemLocations
+      yamlFrontmatter.fieldItemLocations,
+      yamlFrontmatter.fieldValueLocations
     );
 
     const bodyContent = stripLeadingHtmlMarker(frontmatter.body).trim();
@@ -311,11 +313,11 @@ function parseYamlFrontmatter(
 
   rejectUnsafeYamlNodes(document.contents, sourceFile, frontmatter);
   enforceFrontmatterLimits(document.contents, sourceFile, frontmatter);
-  const { fields: fieldLocations, items: fieldItemLocations } = getTopLevelFieldLocations(
-    document.contents,
-    sourceFile,
-    frontmatter
-  );
+  const {
+    fields: fieldLocations,
+    items: fieldItemLocations,
+    values: fieldValueLocations,
+  } = getTopLevelFieldLocations(document.contents, sourceFile, frontmatter);
 
   let value: unknown;
   try {
@@ -330,7 +332,7 @@ function parseYamlFrontmatter(
   }
 
   if (document.contents === null) {
-    return { fields: {}, fieldLocations, fieldItemLocations };
+    return { fields: {}, fieldLocations, fieldItemLocations, fieldValueLocations };
   }
   if (!isRecord(value)) {
     throw frontmatterError(
@@ -340,7 +342,7 @@ function parseYamlFrontmatter(
     );
   }
 
-  return { fields: value, fieldLocations, fieldItemLocations };
+  return { fields: value, fieldLocations, fieldItemLocations, fieldValueLocations };
 }
 
 function getYamlLocation(
@@ -373,10 +375,14 @@ function getTopLevelFieldLocations(
 ): {
   fields: ReadonlyMap<string, SourceLocation>;
   items: ReadonlyMap<string, readonly SourceLocation[]>;
+  values: ReadonlyMap<string, ReadonlyMap<string, SourceLocation>>;
 } {
   const fieldLocations = new Map<string, SourceLocation>();
   const fieldItemLocations = new Map<string, readonly SourceLocation[]>();
-  if (!isCollection(node)) return { fields: fieldLocations, items: fieldItemLocations };
+  const fieldValueLocations = new Map<string, ReadonlyMap<string, SourceLocation>>();
+  if (!isCollection(node)) {
+    return { fields: fieldLocations, items: fieldItemLocations, values: fieldValueLocations };
+  }
 
   for (const item of node.items) {
     if (!isPair(item)) continue;
@@ -390,10 +396,21 @@ function getTopLevelFieldLocations(
         key,
         item.value.items.map((value) => getNodeLocation(value, sourceFile, frontmatter))
       );
+      const valueLocations = new Map<string, SourceLocation>();
+      for (const nestedItem of item.value.items) {
+        if (!isPair(nestedItem)) continue;
+        const nestedKey = getScalarString(nestedItem.key);
+        if (nestedKey === undefined) continue;
+        valueLocations.set(
+          nestedKey,
+          getNodeLocation(nestedItem.value ?? nestedItem.key, sourceFile, frontmatter)
+        );
+      }
+      fieldValueLocations.set(key, valueLocations);
     }
   }
 
-  return { fields: fieldLocations, items: fieldItemLocations };
+  return { fields: fieldLocations, items: fieldItemLocations, values: fieldValueLocations };
 }
 
 function getScalarString(node: unknown): string | undefined {
@@ -554,7 +571,8 @@ function parseFrontmatterFields(
   sourceFile: string,
   fallbackLocation: SourceLocation,
   fieldLocations: ReadonlyMap<string, SourceLocation>,
-  fieldItemLocations: ReadonlyMap<string, readonly SourceLocation[]>
+  fieldItemLocations: ReadonlyMap<string, readonly SourceLocation[]>,
+  fieldValueLocations: ReadonlyMap<string, ReadonlyMap<string, SourceLocation>>
 ): ParsedSkillFrontmatter {
   const name = readOptionalString(
     fields,
@@ -613,7 +631,8 @@ function parseFrontmatterFields(
   const metadata = parseMetadataField(
     fields,
     sourceFile,
-    getFieldLocation('metadata', fieldLocations, fallbackLocation)
+    getFieldLocation('metadata', fieldLocations, fallbackLocation),
+    fieldValueLocations.get('metadata')
   );
   const allowedTools = parseAllowedToolsField(
     fields,
@@ -977,7 +996,8 @@ function readOptionalStringFromRecord(
 function parseMetadataField(
   fields: Record<string, unknown>,
   sourceFile: string,
-  location: SourceLocation
+  location: SourceLocation,
+  valueLocations: ReadonlyMap<string, SourceLocation> | undefined
 ): Record<string, string> | undefined {
   if (!Object.hasOwn(fields, 'metadata')) return undefined;
   const value = fields['metadata'];
@@ -988,7 +1008,11 @@ function parseMetadataField(
   const metadata = createSafeRecord<string>();
   for (const [key, item] of Object.entries(value)) {
     if (typeof item !== 'string') {
-      throw frontmatterError(`metadata value "${key}" must be a string`, sourceFile, location);
+      throw frontmatterError(
+        `metadata value "${key}" must be a string; quote scalar values (for example, 16 as "16")`,
+        sourceFile,
+        valueLocations?.get(key) ?? location
+      );
     }
     metadata[key] = item;
   }


### PR DESCRIPTION
## Summary

- Report exact YAML scalar locations for non-string skill metadata values.
- Preserve source locations through imports and validation.
- Show canonical remote skill paths and actionable quoting remediation in skill update diagnostics.
- Document the string-only metadata contract.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm prs validate --strict`
- `pnpm schema:check`
- `pnpm skill:check`
- `pnpm grammar:check`

Closes #444


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved skill validation errors with precise file, line, and column locations, including nested metadata values.
  - Metadata type errors now identify the specific offending value and provide clearer guidance.
  - Remote skill diagnostics now reference the original skill path instead of temporary validation directories.
  - Errors from imported skills preserve their source locations when reported.

- **Documentation**
  - Clarified that `metadata` frontmatter values must be YAML strings, including guidance to quote numeric values.
  - Documented that invalid values produce diagnostics identifying the affected `SKILL.md` path and line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->